### PR TITLE
Reset bmdt

### DIFF
--- a/lib/stream.js
+++ b/lib/stream.js
@@ -83,13 +83,33 @@
    * destination stream should provide a method `push` to receive the data
    * events as they arrive.
    * @param destination {stream} the stream that will receive all `data` events
+   * @param autoFlush {boolean} if false, we will not call `flush` on the destination
+   *                            when the current stream emits a 'done' event
    * @see http://nodejs.org/api/stream.html#stream_readable_pipe_destination_options
    */
-  Stream.prototype.pipe = function(destination) {
+  Stream.prototype.pipe = function(destination, autoFlush) {
     this.on('data', function(data) {
       destination.push(data);
     });
+
+    if (autoFlush === undefined || autoFlush === true) {
+      this.on('done', function() {
+        destination.flush();
+      });
+    }
+
     return destination;
+  };
+
+  // Default stream functions that are expected to be overridden to perform
+  // actual work. These are provided by the prototype as a sort of no-op
+  // implementation so that we don't have to check for their existence in the
+  // `pipe` function above.
+  Stream.prototype.push = function(data) {
+    this.trigger('data', data);
+  };
+  Stream.prototype.flush = function() {
+    this.trigger('done');
   };
 
   window.muxjs = window.muxjs || {};

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -87,16 +87,14 @@
    *                            when the current stream emits a 'done' event
    * @see http://nodejs.org/api/stream.html#stream_readable_pipe_destination_options
    */
-  Stream.prototype.pipe = function(destination, autoFlush) {
+  Stream.prototype.pipe = function(destination) {
     this.on('data', function(data) {
       destination.push(data);
     });
 
-    if (autoFlush === undefined || autoFlush === true) {
-      this.on('done', function() {
-        destination.flush();
-      });
-    }
+    this.on('done', function() {
+      destination.flush();
+    });
 
     return destination;
   };

--- a/lib/transmuxer.js
+++ b/lib/transmuxer.js
@@ -54,24 +54,102 @@ mp4 = muxjs.mp4;
  * Splits an incoming stream of binary data into MPEG-2 Transport
  * Stream packets.
  */
+
 TransportPacketStream = function() {
   var
     buffer = new Uint8Array(MP2T_PACKET_LENGTH),
-    end = 0;
+    bytesInBuffer = 0;
 
   TransportPacketStream.prototype.init.call(this);
 
-  /**
-   * Deliver new bytes to the stream.
-   */
-  this.push = function(bytes) {
-    var i = 0;
+   // Deliver new bytes to the stream.
 
-    // parse out all the completed packets
-    do {
+  this.push = function(bytes) {
+    var
+      bytesRemaining,
+      i = 0;
+
+    bytes = this.makePacketFromBufferedData_(bytes);
+
+    // If bytes is undefined, then we don't have enough data for one
+    // complete packet so just return and wait for more
+    if (!bytes) {
+      return;
+    }
+
+    bytesRemaining = bytes.byteLength;
+
+    // Parse out all the completed packets
+    while (i + MP2T_PACKET_LENGTH <= bytes.byteLength) {
       this.trigger('data', bytes.subarray(i, i + MP2T_PACKET_LENGTH));
       i += MP2T_PACKET_LENGTH;
-    } while (i + MP2T_PACKET_LENGTH < bytes.byteLength);
+      bytesRemaining -= MP2T_PACKET_LENGTH;
+    }
+
+    // Buffer any partial packets left over
+    if (bytesRemaining > 0) {
+      buffer.set(bytes.subarray(i));
+      bytesInBuffer = bytesRemaining;
+    }
+  };
+
+  // Attempt to complete any partial packets from data that is in the
+  // `buffer` and new data we've just recieved
+  this.makePacketFromBufferedData_ = function (bytes) {
+    var bytesNeeded, bytesLeft;
+
+    while (true) {
+      // If bytes starts with a sync-byte assume the `buffer` is junk
+      // and don't change a thing because we are starting with an
+      // entire packet in the new data
+      if (bytes[0] === 0x47) {
+        // Clear the buffer
+        bytesInBuffer = 0;
+        return bytes;
+      } else {
+        // Otherwise, try assembling a packet from any remaining data in
+        // `buffer` and the new data in bytes
+        bytesNeeded = MP2T_PACKET_LENGTH - bytesInBuffer;
+        buffer.set(bytes.subarray(0, bytesNeeded), bytesInBuffer);
+
+        // We still didn't write out a complete packet so let's wait for
+        // more data
+        if (bytes.byteLength < bytesNeeded) {
+          bytesInBuffer += bytes.byteLength;
+          return;
+        }
+
+        // At this point, `buffer` is full and *may* contain a packet
+        bytesInBuffer = MP2T_PACKET_LENGTH;
+        // Move `bytes` to start just after the last byte in `buffer`
+        bytes = bytes.subarray(bytesNeeded);
+
+        // If we do not start on a sync-byte, search for one in the packet
+        while (i < bytesInBuffer && buffer[i] !== 0x47) {
+          i++;
+        }
+
+        if (i === bytesInBuffer) {
+          // We never found a sync-byte so throw out all the data and try
+          // again
+          bytesInBuffer = 0;
+          continue;
+        } else if (i > 0) {
+          // Found a sync-byte so move the data in `buffer` so that it
+          // begins with the sync-byte
+          buffer.set(buffer.subarray(i), 0);
+
+          // Buffer is no longer full so restart the loop to assemble
+          // the final packet
+          bytesInBuffer = MP2T_PACKET_LENGTH - i;
+          continue;
+        }
+
+        // We've found a complete packet!
+        this.trigger('data', buffer);
+        return bytes;
+      }
+    }
   };
 };
 TransportPacketStream.prototype = new muxjs.Stream();
@@ -227,10 +305,6 @@ TransportParseStream = function() {
       result = {},
       offset = 4;
 
-    // make sure packet is aligned on a sync byte
-    if (packet[0] !== 0x47) {
-      return this.trigger('error', 'mis-aligned packet');
-    }
     result.payloadUnitStartIndicator = !!(packet[1] & 0x40);
 
     // pid is a 13-bit field starting at the last bit of packet[1]

--- a/lib/transmuxer.js
+++ b/lib/transmuxer.js
@@ -1112,9 +1112,6 @@ calculateTrackBaseMediaDecodeTime = function (track) {
 
   track.expectedBaseMediaDecodeTime =
     track.deltaDts + track.maxSegmentDts - track.timelineStartInfo.dts;
-
-  console.log('bmdt timelinestart', track.timelineStartInfo.dts);
-  console.log('bmdt', track.type, track.minSegmentDts, track.baseMediaDecodeTime);
 };
 
 /**

--- a/lib/transmuxer.js
+++ b/lib/transmuxer.js
@@ -65,42 +65,13 @@ TransportPacketStream = function() {
    * Deliver new bytes to the stream.
    */
   this.push = function(bytes) {
-    var remaining, i;
+    var i = 0;
 
-    // clear out any partial packets in the buffer
-    if (end > 0) {
-      remaining = MP2T_PACKET_LENGTH - end;
-      buffer.set(bytes.subarray(0, remaining), end);
-
-      // we still didn't write out a complete packet
-      if (bytes.byteLength < remaining) {
-        end += bytes.byteLength;
-        return;
-      }
-
-      bytes = bytes.subarray(remaining);
-      end = 0;
-      this.trigger('data', buffer);
-    }
-
-    // if less than a single packet is available, buffer it up for later
-    if (bytes.byteLength < MP2T_PACKET_LENGTH) {
-      buffer.set(bytes.subarray(i), end);
-      end += bytes.byteLength;
-      return;
-    }
     // parse out all the completed packets
-    i = 0;
     do {
       this.trigger('data', bytes.subarray(i, i + MP2T_PACKET_LENGTH));
       i += MP2T_PACKET_LENGTH;
-      remaining = bytes.byteLength - i;
-    } while (i < bytes.byteLength && remaining >= MP2T_PACKET_LENGTH);
-    // buffer any partial packets left over
-    if (remaining > 0) {
-      buffer.set(bytes.subarray(i));
-      end = remaining;
-    }
+    } while (i + MP2T_PACKET_LENGTH < bytes.byteLength);
   };
 };
 TransportPacketStream.prototype = new muxjs.Stream();
@@ -1266,7 +1237,18 @@ Transmuxer = function(options) {
     self = this,
     videoTrack,
     audioTrack,
+
+    // Store information about the start of the timeline in both DTS/
+    // PTS timescales. The start of a timeline is where in PTS/DTS time
+    // we were when the base media decode time was last (re)set to zero
     timelineStartInfo = {},
+
+    // Signal that we are in the process of resetting the base media
+    // decode time.
+    // One effect of this state is that we trim audio frames that start
+    // earlier than the video track so that audio always has an initial
+    // base media decode time that is equal to or greater than the video
+    // track.
     resettingBaseMediaDecodeTime = true,
 
     packetStream, parseStream, elementaryStream,

--- a/lib/transmuxer.js
+++ b/lib/transmuxer.js
@@ -467,6 +467,8 @@ ElementaryStream = function() {
    * will flush the buffered packets.
    */
   this.flush = function() {
+    // !!THIS ORDER IS IMPORTANT!!
+    // video first then audio
     flushStream(video, 'video');
     flushStream(audio, 'audio');
     flushStream(timedMetadata, 'timed-metadata');
@@ -536,7 +538,12 @@ AacStream.prototype = new muxjs.Stream();
  */
 // TODO: share common code with VideoSegmentStream
 AudioSegmentStream = function(track) {
-  var aacFrames = [], aacFramesLength = 0, sequenceNumber = 0;
+  var
+    aacFrames = [],
+    aacFramesLength = 0,
+    sequenceNumber = 0,
+    earliestAllowedDts = 0;
+
   AudioSegmentStream.prototype.init.call(this);
 
   this.push = function(data) {
@@ -555,20 +562,8 @@ AudioSegmentStream = function(track) {
     aacFramesLength += data.data.byteLength;
   };
 
-  this.removeFramesEarlierThan = function (earliestAllowedDts) {
-    // We will need to recalculate the earliest segment Dts
-    track.minSegmentDts = Infinity;
-
-    aacFrames = aacFrames.filter(function(currentFrame) {
-      // If this is an allowed frame, keep it and record it's Dts
-      if (currentFrame.dts >= earliestAllowedDts) {
-        track.minSegmentDts = Math.min(track.minSegmentDts, currentFrame.dts);
-        return true;
-      }
-      // Otherwise, discard it
-      aacFramesLength -= currentFrame.data.byteLength;
-      return false;
-    });
+  this.setEarliestDts = function (earliestDts) {
+    earliestAllowedDts = earliestDts;
   };
 
   this.flush = function() {
@@ -577,6 +572,25 @@ AudioSegmentStream = function(track) {
     if (aacFramesLength === 0) {
       this.trigger('done');
       return;
+    }
+
+    // If the audio segment extends before the earliest allowed dts
+    // value, remove AAC frames until starts at or after the earliest
+    // allowed dts
+    if (track.minSegmentDts < earliestAllowedDts) {
+      // We will need to recalculate the earliest segment Dts
+      track.minSegmentDts = Infinity;
+
+      aacFrames = aacFrames.filter(function(currentFrame) {
+        // If this is an allowed frame, keep it and record it's Dts
+        if (currentFrame.dts >= earliestAllowedDts) {
+          track.minSegmentDts = Math.min(track.minSegmentDts, currentFrame.dts);
+          return true;
+        }
+        // Otherwise, discard it
+        aacFramesLength -= currentFrame.data.byteLength;
+        return false;
+      });
     }
 
     // concatenate the audio data to constuct the mdat
@@ -1091,6 +1105,8 @@ VideoSegmentStream = function(track) {
 
     calculateTrackBaseMediaDecodeTime(track);
 
+    this.trigger('timelineStartInfo', track.timelineStartInfo);
+
     moof = mp4.moof(sequenceNumber, [track]);
 
     // it would be great to allocate this array up front instead of
@@ -1123,24 +1139,42 @@ VideoSegmentStream.prototype = new muxjs.Stream();
  * the baseMediaDecodeTime
  */
 collectDtsInfo = function (track, data) {
-  if (track.minSegmentDts === undefined) {
-    track.minSegmentDts = data.dts;
-  } else {
-    track.minSegmentDts = Math.min(track.minSegmentDts, data.dts);
+  if (typeof data.pts === 'number') {
+    if (track.timelineStartInfo.pts === undefined) {
+      track.timelineStartInfo.pts = data.pts;
+    } else {
+      track.timelineStartInfo.pts =
+        Math.min(track.timelineStartInfo.pts, data.pts);
+    }
   }
 
-  if (track.maxSegmentDts === undefined) {
-    track.maxSegmentDts = data.dts;
-  } else {
-    // In order to calculate the "duration" of samples we look for
-    // the last sample that has a duration longer than an arbitrary
-    // value of "100."
-    // The reason is that often the last sample has a tiny duration
-    // that is not indicative of the true duration of the samples
-    if (data.dts - track.maxSegmentDts > 100) {
-      track.deltaDts = data.dts - track.maxSegmentDts;
+  if (typeof data.dts === 'number') {
+    if (track.timelineStartInfo.dts === undefined) {
+      track.timelineStartInfo.dts = data.dts;
+    } else {
+      track.timelineStartInfo.dts =
+        Math.min(track.timelineStartInfo.dts, data.dts);
     }
-    track.maxSegmentDts = Math.max(track.maxSegmentDts, data.dts);
+
+    if (track.minSegmentDts === undefined) {
+      track.minSegmentDts = data.dts;
+    } else {
+      track.minSegmentDts = Math.min(track.minSegmentDts, data.dts);
+    }
+
+    if (track.maxSegmentDts === undefined) {
+      track.maxSegmentDts = data.dts;
+    } else {
+      // In order to calculate the "duration" of samples we look for
+      // the last sample that has a duration longer than an arbitrary
+      // value of "100."
+      // The reason is that often the last sample has a tiny duration
+      // that is not indicative of the true duration of the samples
+      if (data.dts - track.maxSegmentDts > 100) {
+        track.deltaDts = data.dts - track.maxSegmentDts;
+      }
+      track.maxSegmentDts = Math.max(track.maxSegmentDts, data.dts);
+    }
   }
 };
 
@@ -1302,19 +1336,6 @@ Transmuxer = function(options) {
     videoTrack,
     audioTrack,
 
-    // Store information about the start of the timeline in both DTS/
-    // PTS timescales. The start of a timeline is where in PTS/DTS time
-    // we were when the base media decode time was last (re)set to zero
-    timelineStartInfo = {},
-
-    // Signal that we are in the process of resetting the base media
-    // decode time.
-    // One effect of this state is that we trim audio frames that start
-    // earlier than the video track so that audio always has an initial
-    // base media decode time that is equal to or greater than the video
-    // track.
-    resettingBaseMediaDecodeTime = true,
-
     packetStream, parseStream, elementaryStream,
     aacStream, h264Stream,
     videoSegmentStream, audioSegmentStream, captionStream,
@@ -1334,9 +1355,15 @@ Transmuxer = function(options) {
   // expose the metadata stream
   this.metadataStream = new muxjs.mp2t.MetadataStream();
 
+  packetStream.on('error', function (error) {
+    console.error(error);
+  });
+
   // assemble MPEG2-TS packets into elementary streams
   packetStream
+    .pipe(new LogStream('TransportPacketStream'))
     .pipe(parseStream)
+    .pipe(new LogStream('TransportParseStream'))
     .pipe(elementaryStream);
 
   // remux the streams
@@ -1354,20 +1381,6 @@ Transmuxer = function(options) {
   elementaryStream.on('data', function(data) {
     var i;
 
-    if (data.type === 'video' || data.type === 'audio') {
-      if (timelineStartInfo[data.type] === undefined) {
-        timelineStartInfo[data.type] = {
-          dts: data.dts,
-          pts: data.pts
-        };
-      } else {
-        timelineStartInfo[data.type].dts =
-          Math.min(timelineStartInfo[data.type].dts, data.dts);
-        timelineStartInfo[data.type].pts =
-          Math.min(timelineStartInfo[data.type].pts, data.pts);
-      }
-    }
-
     if (data.type === 'metadata') {
       i = data.tracks.length;
 
@@ -1378,29 +1391,42 @@ Transmuxer = function(options) {
         if (data.tracks[i].type === 'video' && !videoSegmentStream) {
           coalesceStream.numberOfTracks++;
           videoTrack = data.tracks[i];
+          videoTrack.timelineStartInfo = {};
           videoSegmentStream = new VideoSegmentStream(videoTrack);
+
+          videoSegmentStream.on('timelineStartInfo', function(timelineStartInfo){
+            // When video emits timelineStartInfo data after a flush, we forward that
+            // info to the AudioSegmentStream, if it exists, because video timeline
+            // data takes precedence.
+            if (audioTrack) {
+              audioTrack.timelineStartInfo = timelineStartInfo;
+
+              // We will also trim AAC frames that exist before the very earliest DTS
+              // value we have seen. This usually means that we only trim audio that
+              // starts before the first video segment we received.
+              audioSegmentStream.setEarliestDts(timelineStartInfo.dts);
+            }
+          });
+
+          // Set up the final part of the video pipeline
           h264Stream
-            .pipe(videoSegmentStream, false) // no automatic flushing
+            .pipe(videoSegmentStream)
             .pipe(coalesceStream);
         } else if (data.tracks[i].type === 'audio' && !audioSegmentStream) {
           // hook up the audio segment stream to the first track with aac data
           coalesceStream.numberOfTracks++;
           audioTrack = data.tracks[i];
+          audioTrack.timelineStartInfo = {};
           audioSegmentStream = new AudioSegmentStream(audioTrack);
+
+          // Set up the final part of the audio pipeline
           aacStream
-            .pipe(audioSegmentStream, false) // no automatic flushing
+            .pipe(audioSegmentStream)
             .pipe(coalesceStream);
         }
       }
     }
   });
-
-  // Call when you want the calculation of the BaseMediaDecodeTime
-  // to reset to 0
-  this.resetBaseMediaDecodeTime = function () {
-    timelineStartInfo = {};
-    resettingBaseMediaDecodeTime = true;
-  };
 
   // feed incoming data to the front of the parsing pipeline
   this.push = function(data) {
@@ -1409,38 +1435,8 @@ Transmuxer = function(options) {
 
   // flush any buffered data
   this.flush = function() {
-    var videoStart;
-
     // Start at the top of the pipeline and flush all pending work
     packetStream.flush();
-
-    // The flush is automatically stopped at VideoSegmentStream and
-    // AudioSegmentStream because we need to gather data and adjust
-    // the nalUnits and/or aacFrames in those stages of the pipeline
-    // before we continue the flush and emit the final mp4 segment(s)
-    if (videoSegmentStream) {
-      videoTrack.timelineStartInfo = timelineStartInfo['video'];
-      videoStart = videoTrack.minSegmentDts;
-      videoSegmentStream.flush();
-
-      // Use the video's earliest Pts/Dts values for audio unless this
-      // is an audio-only stream
-      timelineStartInfo['audio'] = timelineStartInfo['video'];
-    }
-
-    if (audioSegmentStream) {
-      audioTrack.timelineStartInfo = timelineStartInfo['audio'];
-
-      // When we are resetting the base media decode time due to a
-      // discontinuity, we need to remove any audio frames that are
-      // earlier than the beginning of the video
-      if (resettingBaseMediaDecodeTime && videoStart !== undefined) {
-        audioSegmentStream.removeFramesEarlierThan(videoStart);
-      }
-      audioSegmentStream.flush();
-    }
-
-    resettingBaseMediaDecodeTime = false;
   };
 
   // Re-emit any data coming from the coalesce stream to the outside world

--- a/lib/transmuxer.js
+++ b/lib/transmuxer.js
@@ -57,6 +57,7 @@ mp4 = muxjs.mp4;
 
 TransportPacketStream = function() {
   var
+    SYNC_BYTE = 0x47,
     buffer = new Uint8Array(MP2T_PACKET_LENGTH),
     bytesInBuffer = 0;
 
@@ -66,89 +67,63 @@ TransportPacketStream = function() {
 
   this.push = function(bytes) {
     var
-      bytesRemaining,
-      i = 0;
+      i = 0,
+      startIndex = 0,
+      endIndex = MP2T_PACKET_LENGTH,
+      everything;
 
-    bytes = this.makePacketFromBufferedData_(bytes);
-
-    // If bytes is undefined, then we don't have enough data for one
-    // complete packet so just return and wait for more
-    if (!bytes) {
-      return;
+    // If there are bytes remaining from the last segment, prepend them to the
+    // bytes that were pushed in
+    if (bytesInBuffer) {
+      everything = new Uint8Array(bytes.byteLength + bytesInBuffer);
+      everything.set(buffer);
+      everything.set(bytes, bytesInBuffer);
+      bytesInBuffer = 0;
+    } else {
+      everything = bytes;
     }
 
-    bytesRemaining = bytes.byteLength;
+    // While we have enough data for a packet
+    while (endIndex <= everything.byteLength) {
+      // Look for a pair of start and end sync bytes in the data..
 
-    // Parse out all the completed packets
-    while (i + MP2T_PACKET_LENGTH <= bytes.byteLength) {
-      this.trigger('data', bytes.subarray(i, i + MP2T_PACKET_LENGTH));
-      i += MP2T_PACKET_LENGTH;
-      bytesRemaining -= MP2T_PACKET_LENGTH;
-    }
-
-    // Buffer any partial packets left over
-    if (bytesRemaining > 0) {
-      buffer.set(bytes.subarray(i));
-      bytesInBuffer = bytesRemaining;
-    }
-  };
-
-  // Attempt to complete any partial packets from data that is in the
-  // `buffer` and new data we've just recieved
-  this.makePacketFromBufferedData_ = function (bytes) {
-    var bytesNeeded, bytesLeft;
-
-    while (true) {
-      // If bytes starts with a sync-byte assume the `buffer` is junk
-      // and don't change a thing because we are starting with an
-      // entire packet in the new data
-      if (bytes[0] === 0x47) {
-        // Clear the buffer
-        bytesInBuffer = 0;
-        return bytes;
-      } else {
-        // Otherwise, try assembling a packet from any remaining data in
-        // `buffer` and the new data in bytes
-        bytesNeeded = MP2T_PACKET_LENGTH - bytesInBuffer;
-        buffer.set(bytes.subarray(0, bytesNeeded), bytesInBuffer);
-
-        // We still didn't write out a complete packet so let's wait for
-        // more data
-        if (bytes.byteLength < bytesNeeded) {
-          bytesInBuffer += bytes.byteLength;
-          return;
-        }
-
-        // At this point, `buffer` is full and *may* contain a packet
-        bytesInBuffer = MP2T_PACKET_LENGTH;
-        // Move `bytes` to start just after the last byte in `buffer`
-        bytes = bytes.subarray(bytesNeeded);
-
-        // If we do not start on a sync-byte, search for one in the packet
-        while (i < bytesInBuffer && buffer[i] !== 0x47) {
-          i++;
-        }
-
-        if (i === bytesInBuffer) {
-          // We never found a sync-byte so throw out all the data and try
-          // again
-          bytesInBuffer = 0;
-          continue;
-        } else if (i > 0) {
-          // Found a sync-byte so move the data in `buffer` so that it
-          // begins with the sync-byte
-          buffer.set(buffer.subarray(i), 0);
-
-          // Buffer is no longer full so restart the loop to assemble
-          // the final packet
-          bytesInBuffer = MP2T_PACKET_LENGTH - i;
-          continue;
-        }
-
-        // We've found a complete packet!
-        this.trigger('data', buffer);
-        return bytes;
+      // There is a special case we have to look out for: if we have an entire packet's
+      // worth of data at the end of the push (a segment) just emit it even though we
+      // can't verify that it is followed by a sync byte
+      if (everything[startIndex] === SYNC_BYTE &&
+          (endIndex === everything.byteLength || everything[endIndex] === SYNC_BYTE)) {
+        // We found a packet so emit it and jump one whole packet forward in
+        // the stream
+        this.trigger('data', everything.slice(startIndex, endIndex));
+        startIndex += MP2T_PACKET_LENGTH;
+        endIndex += MP2T_PACKET_LENGTH;
+        continue;
       }
+      // If we get here, we have somehow become de-synchronized and we need to step
+      // forward one byte at a time until we find a pair of sync bytes that denote
+      // a packet
+      startIndex++;
+      endIndex++;
+
+      // Attempt to re-synchronize the transport stream
+      while (endIndex < everything.byteLength) {
+        if (everything[startIndex] === SYNC_BYTE && everything[endIndex] === SYNC_BYTE) {
+          // We found a packet so emit it and break this inner loop to continue the outer
+          // loop that chops up packets from the synchronized data byte-stream
+          this.trigger('data', everything.subarray(startIndex, endIndex));
+          break;
+        }
+        startIndex++;
+        endIndex++;
+      }
+    }
+
+    // If there was some data left over at the end of the segment that couldn't
+    // possibly be a whole packet, keep it because it might be the start of a packet
+    // that continues in the next segment
+    if (startIndex < everything.byteLength) {
+      buffer.set(everything.subarray(startIndex), 0);
+      bytesInBuffer = everything.byteLength - startIndex;
     }
   };
 };

--- a/lib/transmuxer.js
+++ b/lib/transmuxer.js
@@ -94,7 +94,7 @@ TransportPacketStream = function() {
           (endIndex === everything.byteLength || everything[endIndex] === SYNC_BYTE)) {
         // We found a packet so emit it and jump one whole packet forward in
         // the stream
-        this.trigger('data', everything.slice(startIndex, endIndex));
+        this.trigger('data', everything.subarray(startIndex, endIndex));
         startIndex += MP2T_PACKET_LENGTH;
         endIndex += MP2T_PACKET_LENGTH;
         continue;

--- a/lib/transmuxer.js
+++ b/lib/transmuxer.js
@@ -84,14 +84,9 @@ TransportPacketStream = function() {
     }
 
     // While we have enough data for a packet
-    while (endIndex <= everything.byteLength) {
+    while (endIndex < everything.byteLength) {
       // Look for a pair of start and end sync bytes in the data..
-
-      // There is a special case we have to look out for: if we have an entire packet's
-      // worth of data at the end of the push (a segment) just emit it even though we
-      // can't verify that it is followed by a sync byte
-      if (everything[startIndex] === SYNC_BYTE &&
-          (endIndex === everything.byteLength || everything[endIndex] === SYNC_BYTE)) {
+      if (everything[startIndex] === SYNC_BYTE && everything[endIndex] === SYNC_BYTE) {
         // We found a packet so emit it and jump one whole packet forward in
         // the stream
         this.trigger('data', everything.subarray(startIndex, endIndex));
@@ -125,6 +120,17 @@ TransportPacketStream = function() {
       buffer.set(everything.subarray(startIndex), 0);
       bytesInBuffer = everything.byteLength - startIndex;
     }
+  };
+
+  this.flush = function () {
+    // If the buffer contains a whole packet when we are being flushed, emit it
+    // and empty the buffer. Otherwise hold onto the data because it may be
+    // important for decoding the next segment
+    if (bytesInBuffer === 188) {
+      this.trigger('data', buffer);
+      bytesInBuffer = 0;
+    }
+    this.trigger('done');
   };
 };
 TransportPacketStream.prototype = new muxjs.Stream();
@@ -464,6 +470,7 @@ ElementaryStream = function() {
     flushStream(video, 'video');
     flushStream(audio, 'audio');
     flushStream(timedMetadata, 'timed-metadata');
+    this.trigger('done');
   };
 };
 ElementaryStream.prototype = new muxjs.Stream();
@@ -568,6 +575,7 @@ AudioSegmentStream = function(track) {
     var boxes, currentFrame, data, sample, i, mdat, moof;
     // return early if no audio data has been observed
     if (aacFramesLength === 0) {
+      this.trigger('done');
       return;
     }
 
@@ -603,6 +611,7 @@ AudioSegmentStream = function(track) {
 
     clearDtsInfo(track);
     this.trigger('data', {track: track, boxes: boxes});
+    this.trigger('done');
   };
 };
 AudioSegmentStream.prototype = new muxjs.Stream();
@@ -706,6 +715,7 @@ NalByteStream = function() {
     // reset the stream state
     buffer = null;
     syncPoint = 1;
+    this.trigger('done');
   };
 };
 NalByteStream.prototype = new muxjs.Stream();
@@ -772,6 +782,9 @@ H264Stream = function() {
       break;
     }
     self.trigger('data', event);
+  });
+  nalByteStream.on('done', function() {
+    self.trigger('done');
   });
 
   this.flush = function() {
@@ -1097,6 +1110,9 @@ VideoSegmentStream = function(track) {
     // for instance, when we are rendition switching
     config = undefined;
     pps = undefined;
+
+    // Continue with the flush process now
+    this.trigger('done');
   };
 };
 VideoSegmentStream.prototype = new muxjs.Stream();
@@ -1206,12 +1222,6 @@ CoalesceStream = function(options) {
     if (output.track.type === 'video') {
       this.videoTrack = output.track;
     }
-
-    // Once we have enough tracks from the various part of the
-    // re-muxing streams we can assemble the final output
-    if (!this.remuxTracks || this.pendingTracks.length >= this.numberOfTracks) {
-      this.flush();
-    }
   };
 };
 
@@ -1225,6 +1235,13 @@ CoalesceStream.prototype.flush = function() {
     caption,
     initSegment,
     i;
+
+  // Once we have enough tracks from the various part of the
+  // re-muxing streams we can assemble the final output
+  if (this.pendingTracks.length === 0 ||
+     (this.remuxTracks && this.pendingTracks.length < this.numberOfTracks)) {
+    return;
+  }
 
   if (this.pendingTracks.length === 1) {
     event.type = this.pendingTracks[0].type;
@@ -1270,6 +1287,7 @@ CoalesceStream.prototype.flush = function() {
 
   // Emit the final segment
   this.trigger('data', event);
+  this.trigger('done');
 };
 
 /**
@@ -1362,7 +1380,7 @@ Transmuxer = function(options) {
           videoTrack = data.tracks[i];
           videoSegmentStream = new VideoSegmentStream(videoTrack);
           h264Stream
-            .pipe(videoSegmentStream)
+            .pipe(videoSegmentStream, false) // no automatic flushing
             .pipe(coalesceStream);
         } else if (data.tracks[i].type === 'audio' && !audioSegmentStream) {
           // hook up the audio segment stream to the first track with aac data
@@ -1370,7 +1388,7 @@ Transmuxer = function(options) {
           audioTrack = data.tracks[i];
           audioSegmentStream = new AudioSegmentStream(audioTrack);
           aacStream
-            .pipe(audioSegmentStream)
+            .pipe(audioSegmentStream, false) // no automatic flushing
             .pipe(coalesceStream);
         }
       }
@@ -1393,17 +1411,25 @@ Transmuxer = function(options) {
   this.flush = function() {
     var videoStart;
 
-    elementaryStream.flush();
-    h264Stream.flush();
+    // Start at the top of the pipeline and flush all pending work
+    packetStream.flush();
+
+    // The flush is automatically stopped at VideoSegmentStream and
+    // AudioSegmentStream because we need to gather data and adjust
+    // the nalUnits and/or aacFrames in those stages of the pipeline
+    // before we continue the flush and emit the final mp4 segment(s)
     if (videoSegmentStream) {
       videoTrack.timelineStartInfo = timelineStartInfo['video'];
       videoStart = videoTrack.minSegmentDts;
       videoSegmentStream.flush();
+
+      // Use the video's earliest Pts/Dts values for audio unless this
+      // is an audio-only stream
+      timelineStartInfo['audio'] = timelineStartInfo['video'];
     }
 
     if (audioSegmentStream) {
-      // Use the video's earliest Dts value unless this is an audio-only stream
-      audioTrack.timelineStartInfo = timelineStartInfo['video'] || timelineStartInfo['audio'];
+      audioTrack.timelineStartInfo = timelineStartInfo['audio'];
 
       // When we are resetting the base media decode time due to a
       // discontinuity, we need to remove any audio frames that are
@@ -1411,19 +1437,19 @@ Transmuxer = function(options) {
       if (resettingBaseMediaDecodeTime && videoStart !== undefined) {
         audioSegmentStream.removeFramesEarlierThan(videoStart);
       }
-
       audioSegmentStream.flush();
     }
 
     resettingBaseMediaDecodeTime = false;
-
-    // Let the consumer know we have finished flushing the buffers
-    this.trigger('done');
   };
 
   // Re-emit any data coming from the coalesce stream to the outside world
   coalesceStream.on('data', function (data) {
     self.trigger('data', data);
+  });
+  // Let the consumer know we have finished flushing the entire pipeline
+  coalesceStream.on('done', function () {
+    self.trigger('done');
   });
 };
 Transmuxer.prototype = new muxjs.Stream();

--- a/lib/transmuxer.js
+++ b/lib/transmuxer.js
@@ -1092,11 +1092,6 @@ collectDtsInfo = function (track, data) {
   } else {
     track.minSegmentDts = Math.min(track.minSegmentDts, data.dts);
   }
-  if (track.minSegmentPts === undefined) {
-    track.minSegmentPts = data.pts;
-  } else {
-    track.minSegmentPts = Math.min(track.minSegmentPts, data.pts);
-  }
 
   if (track.maxSegmentDts === undefined) {
     track.maxSegmentDts = data.dts;
@@ -1118,7 +1113,6 @@ collectDtsInfo = function (track, data) {
  * tracks
  */
 clearDtsInfo = function (track) {
-  delete track.minSegmentPts;
   delete track.minSegmentDts;
   delete track.maxSegmentDts;
   delete track.deltaDts;
@@ -1135,7 +1129,7 @@ calculateTrackBaseMediaDecodeTime = function (track) {
     oneSecondInPTS = 90000, // 90kHz clock
     scale;
 
-  track.baseMediaDecodeTime = track.minSegmentDts - track.timelineStartDts;
+  track.baseMediaDecodeTime = track.minSegmentDts - track.timelineStartInfo.dts;
 
   if (track.type === 'audio') {
     // Audio has a different clock equal to the sampling_rate so we need to
@@ -1146,7 +1140,10 @@ calculateTrackBaseMediaDecodeTime = function (track) {
   }
 
   track.expectedBaseMediaDecodeTime =
-    track.deltaDts + track.maxSegmentDts - track.timelineStartDts;
+    track.deltaDts + track.maxSegmentDts - track.timelineStartInfo.dts;
+
+  console.log('bmdt timelinestart', track.timelineStartInfo.dts);
+  console.log('bmdt', track.type, track.minSegmentDts, track.baseMediaDecodeTime);
 };
 
 /**
@@ -1188,6 +1185,7 @@ CoalesceStream = function(options) {
     this.pendingTracks.push(output.track);
     this.pendingBoxes.push(output.boxes);
     this.pendingBytes += output.boxes.byteLength;
+
     if (output.track.type === 'video') {
       this.videoTrack = output.track;
     }
@@ -1199,6 +1197,7 @@ CoalesceStream = function(options) {
     }
   };
 };
+
 CoalesceStream.prototype = new muxjs.Stream();
 CoalesceStream.prototype.flush = function() {
   var
@@ -1238,9 +1237,9 @@ CoalesceStream.prototype.flush = function() {
   // video timeline for the segment
   for (i = 0; i < this.pendingCaptions.length; i++) {
     caption = this.pendingCaptions[i];
-    caption.startTime = caption.startPts - this.videoTrack.minSegmentPts;
+    caption.startTime = caption.startPts - this.videoTrack.timelineStartInfo.pts;
     caption.startTime /= 90e3;
-    caption.endTime = caption.endPts - this.videoTrack.minSegmentPts;
+    caption.endTime = caption.endPts - this.videoTrack.timelineStartInfo.pts;
     caption.endTime /= 90e3;
     event.captions.push(caption);
   }
@@ -1267,8 +1266,8 @@ Transmuxer = function(options) {
     self = this,
     videoTrack,
     audioTrack,
-    timelineStartDts = {},
-    resettingBaseMediaDecodeTime = false,
+    timelineStartInfo = {},
+    resettingBaseMediaDecodeTime = true,
 
     packetStream, parseStream, elementaryStream,
     aacStream, h264Stream,
@@ -1310,10 +1309,16 @@ Transmuxer = function(options) {
     var i;
 
     if (data.type === 'video' || data.type === 'audio') {
-      if (timelineStartDts[data.type] === undefined) {
-        timelineStartDts[data.type] = data.dts;
+      if (timelineStartInfo[data.type] === undefined) {
+        timelineStartInfo[data.type] = {
+          dts: data.dts,
+          pts: data.pts
+        };
       } else {
-        timelineStartDts[data.type] = Math.min(timelineStartDts[data.type], data.dts);
+        timelineStartInfo[data.type].dts =
+          Math.min(timelineStartInfo[data.type].dts, data.dts);
+        timelineStartInfo[data.type].pts =
+          Math.min(timelineStartInfo[data.type].pts, data.pts);
       }
     }
 
@@ -1347,7 +1352,7 @@ Transmuxer = function(options) {
   // Call when you want the calculation of the BaseMediaDecodeTime
   // to reset to 0
   this.resetBaseMediaDecodeTime = function () {
-    timelineStartDts = {};
+    timelineStartInfo = {};
     resettingBaseMediaDecodeTime = true;
   };
 
@@ -1363,14 +1368,14 @@ Transmuxer = function(options) {
     elementaryStream.flush();
     h264Stream.flush();
     if (videoSegmentStream) {
-      videoTrack.timelineStartDts = timelineStartDts['video'];
+      videoTrack.timelineStartInfo = timelineStartInfo['video'];
       videoStart = videoTrack.minSegmentDts;
       videoSegmentStream.flush();
     }
 
     if (audioSegmentStream) {
       // Use the video's earliest Dts value unless this is an audio-only stream
-      audioTrack.timelineStartDts = timelineStartDts['video'] || timelineStartDts['audio'];
+      audioTrack.timelineStartInfo = timelineStartInfo['video'] || timelineStartInfo['audio'];
 
       // When we are resetting the base media decode time due to a
       // discontinuity, we need to remove any audio frames that are

--- a/lib/transmuxer.js
+++ b/lib/transmuxer.js
@@ -528,6 +528,22 @@ AudioSegmentStream = function(track) {
     aacFramesLength += data.data.byteLength;
   };
 
+  this.removeFramesEarlierThan = function (earliestAllowedDts) {
+    // We will need to recalculate the earliest segment Dts
+    track.minSegmentDts = Infinity;
+
+    aacFrames = aacFrames.filter(function(currentFrame) {
+      // If this is an allowed frame, keep it and record it's Dts
+      if (currentFrame.dts >= earliestAllowedDts) {
+        track.minSegmentDts = Math.min(track.minSegmentDts, currentFrame.dts);
+        return true;
+      }
+      // Otherwise, discard it
+      aacFramesLength -= currentFrame.data.byteLength;
+      return false;
+    });
+  };
+
   this.flush = function() {
     var boxes, currentFrame, data, sample, i, mdat, moof;
     // return early if no audio data has been observed
@@ -1102,6 +1118,7 @@ collectDtsInfo = function (track, data) {
  * tracks
  */
 clearDtsInfo = function (track) {
+  delete track.minSegmentPts;
   delete track.minSegmentDts;
   delete track.maxSegmentDts;
   delete track.deltaDts;
@@ -1250,7 +1267,8 @@ Transmuxer = function(options) {
     self = this,
     videoTrack,
     audioTrack,
-    timelineStartDts,
+    timelineStartDts = {},
+    resettingBaseMediaDecodeTime = false,
 
     packetStream, parseStream, elementaryStream,
     aacStream, h264Stream,
@@ -1291,11 +1309,11 @@ Transmuxer = function(options) {
   elementaryStream.on('data', function(data) {
     var i;
 
-    if (data.type === 'audio' || data.type === 'video') {
-      if (timelineStartDts === undefined) {
-        timelineStartDts = data.dts;
+    if (data.type === 'video' || data.type === 'audio') {
+      if (timelineStartDts[data.type] === undefined) {
+        timelineStartDts[data.type] = data.dts;
       } else {
-        timelineStartDts = Math.min(timelineStartDts, data.dts);
+        timelineStartDts[data.type] = Math.min(timelineStartDts[data.type], data.dts);
       }
     }
 
@@ -1326,6 +1344,13 @@ Transmuxer = function(options) {
     }
   });
 
+  // Call when you want the calculation of the BaseMediaDecodeTime
+  // to reset to 0
+  this.resetBaseMediaDecodeTime = function () {
+    timelineStartDts = {};
+    resettingBaseMediaDecodeTime = true;
+  };
+
   // feed incoming data to the front of the parsing pipeline
   this.push = function(data) {
     packetStream.push(data);
@@ -1333,18 +1358,31 @@ Transmuxer = function(options) {
 
   // flush any buffered data
   this.flush = function() {
+    var videoStart;
+
     elementaryStream.flush();
     h264Stream.flush();
-
     if (videoSegmentStream) {
-      videoTrack.timelineStartDts = timelineStartDts;
+      videoTrack.timelineStartDts = timelineStartDts['video'];
+      videoStart = videoTrack.minSegmentDts;
       videoSegmentStream.flush();
     }
 
     if (audioSegmentStream) {
-      audioTrack.timelineStartDts = timelineStartDts;
+      // Use the video's earliest Dts value unless this is an audio-only stream
+      audioTrack.timelineStartDts = timelineStartDts['video'] || timelineStartDts['audio'];
+
+      // When we are resetting the base media decode time due to a
+      // discontinuity, we need to remove any audio frames that are
+      // earlier than the beginning of the video
+      if (resettingBaseMediaDecodeTime && videoStart !== undefined) {
+        audioSegmentStream.removeFramesEarlierThan(videoStart);
+      }
+
       audioSegmentStream.flush();
     }
+
+    resettingBaseMediaDecodeTime = false;
 
     // Let the consumer know we have finished flushing the buffers
     this.trigger('done');

--- a/lib/transmuxer.js
+++ b/lib/transmuxer.js
@@ -21,12 +21,13 @@ var collectDtsInfo, clearDtsInfo, calculateTrackBaseMediaDecodeTime;
 
 // constants
 var MP2T_PACKET_LENGTH, H264_STREAM_TYPE, ADTS_STREAM_TYPE,
-    METADATA_STREAM_TYPE, ADTS_SAMPLING_FREQUENCIES;
+    METADATA_STREAM_TYPE, ADTS_SAMPLING_FREQUENCIES, SYNC_BYTE;
 
 // namespace
 var mp4;
 
 MP2T_PACKET_LENGTH = 188; // bytes
+SYNC_BYTE = 0x47;
 
 H264_STREAM_TYPE = 0x1b;
 ADTS_STREAM_TYPE = 0x0f;
@@ -54,10 +55,8 @@ mp4 = muxjs.mp4;
  * Splits an incoming stream of binary data into MPEG-2 Transport
  * Stream packets.
  */
-
 TransportPacketStream = function() {
   var
-    SYNC_BYTE = 0x47,
     buffer = new Uint8Array(MP2T_PACKET_LENGTH),
     bytesInBuffer = 0;
 
@@ -99,18 +98,6 @@ TransportPacketStream = function() {
       // a packet
       startIndex++;
       endIndex++;
-
-      // Attempt to re-synchronize the transport stream
-      while (endIndex < everything.byteLength) {
-        if (everything[startIndex] === SYNC_BYTE && everything[endIndex] === SYNC_BYTE) {
-          // We found a packet so emit it and break this inner loop to continue the outer
-          // loop that chops up packets from the synchronized data byte-stream
-          this.trigger('data', everything.subarray(startIndex, endIndex));
-          break;
-        }
-        startIndex++;
-        endIndex++;
-      }
     }
 
     // If there was some data left over at the end of the segment that couldn't
@@ -126,7 +113,7 @@ TransportPacketStream = function() {
     // If the buffer contains a whole packet when we are being flushed, emit it
     // and empty the buffer. Otherwise hold onto the data because it may be
     // important for decoding the next segment
-    if (bytesInBuffer === 188) {
+    if (bytesInBuffer === MP2T_PACKET_LENGTH && buffer[0] === SYNC_BYTE) {
       this.trigger('data', buffer);
       bytesInBuffer = 0;
     }
@@ -440,7 +427,9 @@ ElementaryStream = function() {
         // translate streams to tracks
         for (k in programMapTable) {
           if (programMapTable.hasOwnProperty(k)) {
-            track = {};
+            track = {
+              timelineStartInfo: {}
+            };
             track.id = +k;
             if (programMapTable[k] === H264_STREAM_TYPE) {
               track.codec = 'avc';
@@ -576,7 +565,7 @@ AudioSegmentStream = function(track) {
 
     // If the audio segment extends before the earliest allowed dts
     // value, remove AAC frames until starts at or after the earliest
-    // allowed dts
+    // allowed dts.
     if (track.minSegmentDts < earliestAllowedDts) {
       // We will need to recalculate the earliest segment Dts
       track.minSegmentDts = Infinity;
@@ -1165,14 +1154,6 @@ collectDtsInfo = function (track, data) {
     if (track.maxSegmentDts === undefined) {
       track.maxSegmentDts = data.dts;
     } else {
-      // In order to calculate the "duration" of samples we look for
-      // the last sample that has a duration longer than an arbitrary
-      // value of "100."
-      // The reason is that often the last sample has a tiny duration
-      // that is not indicative of the true duration of the samples
-      if (data.dts - track.maxSegmentDts > 100) {
-        track.deltaDts = data.dts - track.maxSegmentDts;
-      }
       track.maxSegmentDts = Math.max(track.maxSegmentDts, data.dts);
     }
   }
@@ -1185,7 +1166,6 @@ collectDtsInfo = function (track, data) {
 clearDtsInfo = function (track) {
   delete track.minSegmentDts;
   delete track.maxSegmentDts;
-  delete track.deltaDts;
 };
 
 /**
@@ -1195,7 +1175,6 @@ clearDtsInfo = function (track) {
  */
 calculateTrackBaseMediaDecodeTime = function (track) {
   var
-    expectedBaseMediaDecodeTime = track.expectedBaseMediaDecodeTime,
     oneSecondInPTS = 90000, // 90kHz clock
     scale;
 
@@ -1208,9 +1187,6 @@ calculateTrackBaseMediaDecodeTime = function (track) {
     track.baseMediaDecodeTime *= scale;
     track.baseMediaDecodeTime = Math.floor(track.baseMediaDecodeTime);
   }
-
-  track.expectedBaseMediaDecodeTime =
-    track.deltaDts + track.maxSegmentDts - track.timelineStartInfo.dts;
 };
 
 /**
@@ -1270,8 +1246,7 @@ CoalesceStream.prototype.flush = function() {
     initSegment,
     i;
 
-  // Once we have enough tracks from the various part of the
-  // re-muxing streams we can assemble the final output
+  // Return until we have enough tracks from the pipeline to remux
   if (this.pendingTracks.length === 0 ||
      (this.remuxTracks && this.pendingTracks.length < this.numberOfTracks)) {
     return;
@@ -1355,21 +1330,18 @@ Transmuxer = function(options) {
   // expose the metadata stream
   this.metadataStream = new muxjs.mp2t.MetadataStream();
 
-  packetStream.on('error', function (error) {
-    console.error(error);
-  });
-
   // assemble MPEG2-TS packets into elementary streams
   packetStream
-    .pipe(new LogStream('TransportPacketStream'))
     .pipe(parseStream)
-    .pipe(new LogStream('TransportParseStream'))
     .pipe(elementaryStream);
 
   // remux the streams
-  elementaryStream.pipe(aacStream);
-  elementaryStream.pipe(h264Stream);
-  elementaryStream.pipe(this.metadataStream);
+  elementaryStream
+    .pipe(aacStream);
+  elementaryStream
+    .pipe(h264Stream);
+  elementaryStream
+    .pipe(this.metadataStream);
   // if CEA-708 parsing is available, hook up a caption stream
   if (muxjs.mp2t.CaptionStream) {
     captionStream = new muxjs.mp2t.CaptionStream();
@@ -1391,7 +1363,6 @@ Transmuxer = function(options) {
         if (data.tracks[i].type === 'video' && !videoSegmentStream) {
           coalesceStream.numberOfTracks++;
           videoTrack = data.tracks[i];
-          videoTrack.timelineStartInfo = {};
           videoSegmentStream = new VideoSegmentStream(videoTrack);
 
           videoSegmentStream.on('timelineStartInfo', function(timelineStartInfo){
@@ -1401,9 +1372,10 @@ Transmuxer = function(options) {
             if (audioTrack) {
               audioTrack.timelineStartInfo = timelineStartInfo;
 
-              // We will also trim AAC frames that exist before the very earliest DTS
-              // value we have seen. This usually means that we only trim audio that
-              // starts before the first video segment we received.
+              // On the first segment we trim AAC frames that exist before the
+              // very earliest DTS we have seen in video because Chrome will
+              // interpret any video track with a baseMediaDecodeTime that is
+              // non-zero as a gap.
               audioSegmentStream.setEarliestDts(timelineStartInfo.dts);
             }
           });
@@ -1416,7 +1388,6 @@ Transmuxer = function(options) {
           // hook up the audio segment stream to the first track with aac data
           coalesceStream.numberOfTracks++;
           audioTrack = data.tracks[i];
-          audioTrack.timelineStartInfo = {};
           audioSegmentStream = new AudioSegmentStream(audioTrack);
 
           // Set up the final part of the audio pipeline

--- a/test/transmuxer-test.js
+++ b/test/transmuxer-test.js
@@ -56,6 +56,7 @@ test('parses a generic packet', function() {
     datas.push(event);
   });
   transportPacketStream.push(packet);
+  transportPacketStream.flush();
 
   equal(1, datas.length, 'fired one event');
   equal(datas[0].byteLength, 188, 'delivered the packet');
@@ -78,6 +79,8 @@ test('buffers partial packets', function() {
   equal(0, datas.length, 'did not fire an event');
 
   transportPacketStream.push(partialPacket2);
+  transportPacketStream.flush();
+
   equal(2, datas.length, 'fired events');
   equal(188, datas[0].byteLength, 'parsed the first packet');
   equal(188, datas[1].byteLength, 'parsed the second packet');
@@ -95,6 +98,8 @@ test('parses multiple packets delivered at once', function() {
   });
 
   transportPacketStream.push(packetStream);
+  transportPacketStream.flush();
+
   equal(3, datas.length, 'fired three events');
   equal(188, datas[0].byteLength, 'parsed the first packet');
   equal(188, datas[1].byteLength, 'parsed the second packet');
@@ -118,6 +123,8 @@ test('buffers extra after multiple packets', function() {
   equal(188, datas[1].byteLength, 'parsed the second packet');
 
   transportPacketStream.push(new Uint8Array(178));
+  transportPacketStream.flush();
+
   equal(3, datas.length, 'fired a final event');
   equal(188, datas[2].length, 'parsed the finel packet');
 });


### PR DESCRIPTION
A laundry list of fixes in the PR (in roughly top-down order):
* Rewrote transport packet parsing to be more robust when confronted with strange segmentation strategies - again!
* On a ~~BMDT reset (PTS - discontinuity)~~ the first segment, we now remove AAC frames that extend before the first PTS of the video track.
* Extended tracking previously done with `timelineStartDts` to track both audio and video tracks and both dts and pts values for each.
* Caption `startTime` and `endTime` are now relative to the last time base media decode time was set to zero.