### PR TITLE
Ignore the "mpeg version" bit in the ADTS header when looking for the syncword

### DIFF
--- a/lib/transmuxer.js
+++ b/lib/transmuxer.js
@@ -503,7 +503,7 @@ AacStream = function() {
     while (i + 5 < buffer.length) {
 
       // Loook for the start of an ADTS header..
-      if (buffer[i] !== 0xFF || (buffer[i + 1] & 0xFE) !== 0xF0) {
+      if (buffer[i] !== 0xFF || (buffer[i + 1] & 0xF6) !== 0xF0) {
         // If a valid header was not found,  jump one forward and attempt to
         // find a valid ADTS header starting at the next byte
         i++;


### PR DESCRIPTION
AAC is defined in both mpeg-2 and mpeg-4 specs and I don't think this distinction matters for our purposes.