### PR TITLE
Fix PES Parsing

### DIFF
--- a/lib/m2ts/m2ts.js
+++ b/lib/m2ts/m2ts.js
@@ -191,57 +191,6 @@ TransportParseStream = function() {
     }
   };
 
-  parsePes = function(payload, pes) {
-    var ptsDtsFlags;
-
-    if (!pes.payloadUnitStartIndicator) {
-      pes.data = payload;
-      return;
-    }
-
-    // find out if this packets starts a new keyframe
-    pes.dataAlignmentIndicator = (payload[6] & 0x04) !== 0;
-    // PES packets may be annotated with a PTS value, or a PTS value
-    // and a DTS value. Determine what combination of values is
-    // available to work with.
-    ptsDtsFlags = payload[7];
-
-    // PTS and DTS are normally stored as a 33-bit number.  Javascript
-    // performs all bitwise operations on 32-bit integers but javascript
-    // supports a much greater range (52-bits) of integer using standard
-    // mathematical operations.
-    // We construct a 32-bit value using bitwise operators over the 32
-    // most significant bits and then multiply by 2 (equal to a left-shift
-    // of 1) before we add the final LSB of the timestamp (equal to an OR.)
-    if (ptsDtsFlags & 0xC0) {
-      // the PTS and DTS are not written out directly. For information
-      // on how they are encoded, see
-      // http://dvd.sourceforge.net/dvdinfo/pes-hdr.html
-      pes.pts = (payload[9] & 0x0E) << 28
-        | (payload[10] & 0xFF) << 21
-        | (payload[11] & 0xFE) << 13
-        | (payload[12] & 0xFF) <<  6
-        | (payload[13] & 0xFE) >>>  2;
-      pes.pts *= 2; // Left shift by 1
-      pes.pts += (payload[13] & 0x02); // OR by the LSB
-      pes.dts = pes.pts;
-      if (ptsDtsFlags & 0x40) {
-        pes.dts = (payload[14] & 0x0E ) << 28
-          | (payload[15] & 0xFF ) << 21
-          | (payload[16] & 0xFE ) << 13
-          | (payload[17] & 0xFF ) << 6
-          | (payload[18] & 0xFE ) >>> 2;
-        pes.dts *= 2; // Left shift by 1
-        pes.dts += (payload[18] & 0x02); // OR by the LSB
-      }
-    }
-
-    // the data section starts immediately after the PES header.
-    // pes_header_data_length specifies the number of header bytes
-    // that follow the last byte of the field.
-    pes.data = payload.subarray(9 + payload[8]);
-  };
-
   /**
    * Deliver a new MP2T packet to the stream.
    */
@@ -285,7 +234,7 @@ TransportParseStream = function() {
   this.processPes_ = function (packet, offset, result) {
     result.streamType = this.programMapTable[result.pid];
     result.type = 'pes';
-    parsePes(packet.subarray(offset), result);
+    result.data = packet.subarray(offset);
 
     this.trigger('data', result);
   };
@@ -320,11 +269,56 @@ ElementaryStream = function() {
       data: [],
       size: 0
     },
+    parsePes = function(payload, pes) {
+      var ptsDtsFlags;
+
+      // find out if this packets starts a new keyframe
+      pes.dataAlignmentIndicator = (payload[6] & 0x04) !== 0;
+      // PES packets may be annotated with a PTS value, or a PTS value
+      // and a DTS value. Determine what combination of values is
+      // available to work with.
+      ptsDtsFlags = payload[7];
+
+      // PTS and DTS are normally stored as a 33-bit number.  Javascript
+      // performs all bitwise operations on 32-bit integers but javascript
+      // supports a much greater range (52-bits) of integer using standard
+      // mathematical operations.
+      // We construct a 32-bit value using bitwise operators over the 32
+      // most significant bits and then multiply by 2 (equal to a left-shift
+      // of 1) before we add the final LSB of the timestamp (equal to an OR.)
+      if (ptsDtsFlags & 0xC0) {
+        // the PTS and DTS are not written out directly. For information
+        // on how they are encoded, see
+        // http://dvd.sourceforge.net/dvdinfo/pes-hdr.html
+        pes.pts = (payload[9] & 0x0E) << 28
+          | (payload[10] & 0xFF) << 21
+          | (payload[11] & 0xFE) << 13
+          | (payload[12] & 0xFF) <<  6
+          | (payload[13] & 0xFE) >>>  2;
+        pes.pts *= 2; // Left shift by 1
+        pes.pts += (payload[13] & 0x02) >>> 1; // OR by the LSB
+        pes.dts = pes.pts;
+        if (ptsDtsFlags & 0x40) {
+          pes.dts = (payload[14] & 0x0E ) << 28
+            | (payload[15] & 0xFF ) << 21
+            | (payload[16] & 0xFE ) << 13
+            | (payload[17] & 0xFF ) << 6
+            | (payload[18] & 0xFE ) >>> 2;
+          pes.dts *= 2; // Left shift by 1
+          pes.dts += (payload[18] & 0x02) >>> 1; // OR by the LSB
+        }
+      }
+
+      // the data section starts immediately after the PES header.
+      // pes_header_data_length specifies the number of header bytes
+      // that follow the last byte of the field.
+      pes.data = payload.subarray(9 + payload[8]);
+    },
     flushStream = function(stream, type) {
       var
+        packetData = new Uint8Array(stream.size),
         event = {
-          type: type,
-          data: new Uint8Array(stream.size),
+          type: type
         },
         i = 0,
         fragment;
@@ -334,16 +328,18 @@ ElementaryStream = function() {
         return;
       }
       event.trackId = stream.data[0].pid;
-      event.pts = stream.data[0].pts;
-      event.dts = stream.data[0].dts;
 
       // reassemble the packet
       while (stream.data.length) {
         fragment = stream.data.shift();
 
-        event.data.set(fragment.data, i);
+        packetData.set(fragment.data, i);
         i += fragment.data.byteLength;
       }
+
+      // parse assembled packet's PES header
+      parsePes(packetData, event);
+
       stream.size = 0;
 
       self.trigger('data', event);

--- a/lib/m2ts/m2ts.js
+++ b/lib/m2ts/m2ts.js
@@ -52,7 +52,7 @@ TransportPacketStream = function() {
     // bytes that were pushed in
     if (bytesInBuffer) {
       everything = new Uint8Array(bytes.byteLength + bytesInBuffer);
-      everything.set(buffer);
+      everything.set(buffer.subarray(0, bytesInBuffer));
       everything.set(bytes, bytesInBuffer);
       bytesInBuffer = 0;
     } else {


### PR DESCRIPTION
* Moved parsePes to the ElementaryStream *after* the entire packet has been received
* Fixed a minor bug that resulted in PTS/DTS values potentially being off by 1
* Fixed/moved tests since a major portion of the TransportParseStream's work is now done in ElementaryStream
* Added a case which tests header reassembly across packets