### PR TITLE
H264frame fix

### DIFF
--- a/lib/flv/transmuxer.js
+++ b/lib/flv/transmuxer.js
@@ -185,7 +185,6 @@ VideoSegmentStream = function(track) {
     nalUnits = [],
     nalUnitsLength = 0,
     config,
-    pps,
     h264Frame;
   VideoSegmentStream.prototype.init.call(this);
 
@@ -221,12 +220,6 @@ VideoSegmentStream = function(track) {
       currentNal,
       tags = [];
 
-    // return early if no video data has been observed
-    if (nalUnits.length === 0) {
-      this.trigger('done');
-      return;
-    }
-
     // Throw away nalUnits at the start of the byte stream until we find
     // the first AUD
     while (nalUnits.length) {
@@ -234,6 +227,12 @@ VideoSegmentStream = function(track) {
         break;
       }
       nalUnits.shift();
+    }
+
+    // return early if no video data has been observed
+    if (nalUnits.length === 0) {
+      this.trigger('done');
+      return;
     }
 
     while (nalUnits.length) {
@@ -252,7 +251,6 @@ VideoSegmentStream = function(track) {
         h264Frame.endNalUnit();
       } else if (currentNal.nalUnitType === 'pic_parameter_set_rbsp') {
         track.newMetadata = true;
-        pps = currentNal.data;
         track.pps = [currentNal.data];
         h264Frame.endNalUnit();
       } else if (currentNal.nalUnitType === 'access_unit_delimiter_rbsp') {

--- a/lib/flv/transmuxer.js
+++ b/lib/flv/transmuxer.js
@@ -272,6 +272,9 @@ VideoSegmentStream = function(track) {
       h264Frame.startNalUnit();
       h264Frame.writeBytes(currentNal.data);
     }
+    if (h264Frame) {
+      this.finishFrame(tags, h264Frame);
+    }
 
     this.trigger('data', {track: track, tags: tags});
 

--- a/lib/flv/transmuxer.js
+++ b/lib/flv/transmuxer.js
@@ -227,26 +227,35 @@ VideoSegmentStream = function(track) {
       return;
     }
 
+    // Throw away nalUnits at the start of the byte stream until we find
+    // the first AUD
+    while (nalUnits.length) {
+      if (nalUnits[0].nalUnitType === 'access_unit_delimiter_rbsp') {
+        break;
+      }
+      nalUnits.shift();
+    }
+
     while (nalUnits.length) {
       currentNal = nalUnits.shift();
 
-    // record the track config
-    if (currentNal.nalUnitType === 'seq_parameter_set_rbsp') {
-      track.newMetadata = true;
-      config = currentNal.config;
-      track.width = config.width;
-      track.height = config.height;
-      track.sps = [currentNal.data];
-      track.profileIdc = config.profileIdc;
-      track.levelIdc = config.levelIdc;
-      track.profileCompatibility = config.profileCompatibility;
-      h264Frame.endNalUnit();
-    } else if (currentNal.nalUnitType === 'pic_parameter_set_rbsp') {
-      track.newMetadata = true;
-      pps = currentNal.data;
-      track.pps = [currentNal.data];
-      h264Frame.endNalUnit();
-    } else if (currentNal.nalUnitType === 'access_unit_delimiter_rbsp') {
+      // record the track config
+      if (currentNal.nalUnitType === 'seq_parameter_set_rbsp') {
+        track.newMetadata = true;
+        config = currentNal.config;
+        track.width = config.width;
+        track.height = config.height;
+        track.sps = [currentNal.data];
+        track.profileIdc = config.profileIdc;
+        track.levelIdc = config.levelIdc;
+        track.profileCompatibility = config.profileCompatibility;
+        h264Frame.endNalUnit();
+      } else if (currentNal.nalUnitType === 'pic_parameter_set_rbsp') {
+        track.newMetadata = true;
+        pps = currentNal.data;
+        track.pps = [currentNal.data];
+        h264Frame.endNalUnit();
+      } else if (currentNal.nalUnitType === 'access_unit_delimiter_rbsp') {
         if (h264Frame) {
           this.finishFrame(tags, h264Frame);
         }

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -165,6 +165,15 @@ VideoSegmentStream = function(track) {
   this.flush = function() {
     var startUnit, currentNal, moof, mdat, boxes, i, data, view, sample, duration;
 
+    // Throw away nalUnits at the start of the byte stream until we find
+    // the first AUD
+    while (nalUnits.length) {
+      if (nalUnits[0].nalUnitType === 'access_unit_delimiter_rbsp') {
+        break;
+      }
+      nalUnits.shift();
+    }
+
     // return early if no video data has been observed
     if (nalUnitsLength === 0) {
       this.trigger('done');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mux.js",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A collection of lightweight utilities for inspecting and manipulating video container formats.",
   "repository": {
     "type": "git",

--- a/test/index.html
+++ b/test/index.html
@@ -20,6 +20,8 @@
   <script src="../lib/m2ts/caption-stream.js"></script>
   <script src="../lib/m2ts/metadata-stream.js"></script>
   <script src="../lib/mp4/transmuxer.js"></script>
+  <script src="../lib/flv/flv-tag.js"></script>
+  <script src="../lib/flv/transmuxer.js"></script>
 
   <!-- test helpers -->
   <script src="test-segment.js"></script>

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -25,6 +25,8 @@ module.exports = function(config) {
       '../lib/m2ts/caption-stream.js',
       '../lib/m2ts/metadata-stream.js',
       '../lib/mp4/transmuxer.js',
+      '../lib/flv/flv-tag.js',
+      '../lib/flv/transmuxer.js',
 
       'sintel-captions.js',
       'test-segment.js',

--- a/test/transmuxer-test.js
+++ b/test/transmuxer-test.js
@@ -1186,6 +1186,10 @@ test('concatenates NAL units into AVC elementary streams', function() {
     segment = data.boxes;
   });
   videoSegmentStream.push({
+    nalUnitType: 'access_unit_delimiter_rbsp',
+    data: new Uint8Array([0x09, 0x01])
+  });
+  videoSegmentStream.push({
     data: new Uint8Array([
       0x08,
       0x01, 0x02, 0x03
@@ -1202,9 +1206,11 @@ test('concatenates NAL units into AVC elementary streams', function() {
   ok(segment, 'generated a data event');
   boxes = muxjs.tools.inspectMp4(segment);
   equal(boxes[1].byteLength,
-        (4 + 4) + (4 + 6),
+        (2 + 4) + (4 + 4) + (4 + 6),
         'wrote the correct number of bytes');
   deepEqual(new Uint8Array(segment.subarray(boxes[0].size + 8)), new Uint8Array([
+    0, 0, 0, 2,
+    0x09, 0x01,
     0, 0, 0, 4,
     0x08, 0x01, 0x02, 0x03,
     0, 0, 0, 6,


### PR DESCRIPTION
There are cases when nalUnit streams may not start with an AUD and this can result in `h264Frame` being undefined as we parse more 