### PR TITLE
Fixes for non-combined output with separate audio/video fragments and sourceBuffers

### DIFF
--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -380,6 +380,7 @@ CoalesceStream = function(options) {
   this.pendingCaptions = [];
   this.pendingMetadata = [];
   this.pendingBytes = 0;
+  this.emittedTracks = 0;
 
   CoalesceStream.prototype.init.call(this);
 
@@ -442,6 +443,7 @@ CoalesceStream.prototype.flush = function() {
   } else {
     event.type = 'combined';
   }
+  this.emittedTracks += this.pendingTracks.length;
 
   initSegment = muxjs.mp4.initSegment(this.pendingTracks);
 
@@ -492,11 +494,15 @@ CoalesceStream.prototype.flush = function() {
   this.pendingBytes = 0;
   this.pendingMetadata.length = 0;
 
-  // Emit the final segment
+  // Emit the built segment
   this.trigger('data', event);
-  this.trigger('done');
-};
 
+  // Only emit `done` if all tracks have been flushed and emitted
+  if (this.emittedTracks >= this.numberOfTracks) {
+    this.trigger('done');
+    this.emittedTracks = 0;
+  }
+};
 /**
  * A Stream that expects MP2T binary data as input and produces
  * corresponding media segments, suitable for use with Media Source
@@ -627,6 +633,7 @@ Transmuxer = function(options) {
     self.trigger('done');
   });
 };
+
 Transmuxer.prototype = new muxjs.utils.Stream();
 
 // exports

--- a/test/transmuxer-test.js
+++ b/test/transmuxer-test.js
@@ -1691,12 +1691,19 @@ test('no options creates combined output', function() {
 test('can specify that we want to generate separate audio and video segments', function() {
   var
     segments = [],
+    segmentLengthOnDone,
     boxes,
     transmuxer = new Transmuxer({remux: false});
 
   transmuxer.on('data', function(segment) {
     segments.push(segment);
   });
+  transmuxer.on('done', function(segment) {
+    if (!segmentLengthOnDone) {
+      segmentLengthOnDone = segments.length;
+    }
+  });
+
   transmuxer.push(packetize(PAT));
   transmuxer.push(packetize(generatePMT({
     hasVideo: true,
@@ -1719,6 +1726,7 @@ test('can specify that we want to generate separate audio and video segments', f
   ], false)));
   transmuxer.flush();
 
+  equal(segmentLengthOnDone, 2, 'emitted both segments before triggering done');
   equal(segments.length, 2, 'generated a video and an audio segment');
   ok(segments[0].type === 'video' || segments[1].type === 'video', 'one segment is video');
   ok(segments[0].type === 'audio' || segments[1].type === 'audio', 'one segment is audio');


### PR DESCRIPTION
The only change is to how we track emittedTracks so that we can hold-off triggering 'done' until after the segment has been completely flushed in the non-combined output mode.