### PR TITLE
Re-order accumulated captions by PTS before flushing

### DIFF
--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -200,7 +200,7 @@
   var createDisplayBuffer = function() {
     var result = [], i = BOTTOM_ROW + 1;
     while (i--) {
-      result.push('');
+      result.push({});
     }
     return result;
   };
@@ -217,11 +217,23 @@
     this.startPts_ = 0;
     this.displayed_ = createDisplayBuffer();
     this.nonDisplayed_ = createDisplayBuffer();
+    this.lastPts_ = 0;
 
     this.push = function(packet) {
       var data, swap, charCode;
       // remove the parity bits
       data = packet.ccData & 0x7f7f;
+
+      // for testing, of PTS is not defined,
+      // assume increasing value.
+      if (packet.pts === undefined) {
+        packet.pts = this.lastPts_++;
+      }
+
+      // keep track of the latest, greatest PTS value
+      if (packet.pts > this.lastPts_) {
+        this.lastPts_ = packet.pts;
+      }
 
       switch (data) {
       case PADDING:
@@ -263,9 +275,9 @@
 
       case BACKSPACE:
         if (this.mode_ === 'popOn') {
-          this.nonDisplayed_[BOTTOM_ROW] = this.nonDisplayed_[BOTTOM_ROW].slice(0, -1);
+          this.nonDisplayed_[BOTTOM_ROW] = this.backSpace(this.nonDisplayed_[BOTTOM_ROW]);
         } else {
-          this.displayed_[BOTTOM_ROW] = this.displayed_[BOTTOM_ROW].slice(0, -1);
+          this.displayed_[BOTTOM_ROW] = this.backSpace(this.displayed_[BOTTOM_ROW]);
         }
         break;
       case ERASE_DISPLAYED_MEMORY:
@@ -294,35 +306,56 @@
   // Trigger a cue point that captures the current state of the
   // display buffer
   Cea608Stream.prototype.flushDisplayed = function(pts) {
-    var row, i;
+    var row, i, j, keys;
 
     for (i = 0; i < this.displayed_.length; i++) {
       row = this.displayed_[i];
-      if (row.length) {
+      keys = Object.keys(row);
+      if (keys.length) {
+        var rowString = '';
+        keys.sort();
+        for (j = 0; j < keys.length; j++) {
+          rowString += row[keys[j]];
+        }
         this.trigger('data', {
           startPts: this.startPts_,
           endPts: pts,
-          text: row
+          text: rowString
         });
       }
     }
   };
 
+  Cea608Stream.prototype.backSpace = function(row) {
+    var keys, last_pair, last_pts;
+    keys = Object.keys(row);
+    keys.sort();
+    last_pts = keys[keys.length-1];
+    last_pair = row[keys[keys.length-1]];
+    if (last_pair && last_pair.length === 2)
+        row[last_pts] = last_pair.slice(0,-1);
+    else
+        delete row[last_pts];
+    return row;
+  }
+
   // Mode Implementations
   Cea608Stream.prototype.popOn = function(pts, char0, char1) {
     var baseRow = this.nonDisplayed_[BOTTOM_ROW];
 
+    baseRow[pts] = '';
+
     // buffer characters
     char0 = BASIC_CHARACTER_TRANSLATION[char0] || char0;
-    baseRow += String.fromCharCode(char0);
+    baseRow[pts] += String.fromCharCode(char0);
 
     char1 = BASIC_CHARACTER_TRANSLATION[char1] || char1;
-    baseRow += String.fromCharCode(char1);
+    baseRow[pts] += String.fromCharCode(char1);
     this.nonDisplayed_[BOTTOM_ROW] = baseRow;
   };
   Cea608Stream.prototype.rollUp = function(pts, char0, char1) {
     var baseRow = this.displayed_[BOTTOM_ROW];
-    if (baseRow === '') {
+    if (Object.keys(baseRow).length === 0) {
       // we're starting to buffer new display input, so flush out the
       // current display
       this.flushDisplayed(pts);
@@ -330,25 +363,28 @@
       this.startPts_ = pts;
     }
 
+    baseRow[pts] = '';
+
     char0 = BASIC_CHARACTER_TRANSLATION[char0] || char0;
-    baseRow += String.fromCharCode(char0);
+    baseRow[pts] += String.fromCharCode(char0);
 
     char1 = BASIC_CHARACTER_TRANSLATION[char1] || char1;
-    baseRow += String.fromCharCode(char1);
+    baseRow[pts] += String.fromCharCode(char1);
+
     this.displayed_[BOTTOM_ROW] = baseRow;
   };
   Cea608Stream.prototype.shiftRowsUp_ = function() {
     var i;
     // clear out inactive rows
     for (i = 0; i < this.topRow_; i++) {
-      this.displayed_[i] = '';
+      this.displayed_[i] = {};
     }
     // shift displayed rows up
     for (i = this.topRow_; i < BOTTOM_ROW; i++) {
       this.displayed_[i] = this.displayed_[i + 1];
     }
     // clear out the bottom row
-    this.displayed_[BOTTOM_ROW] = '';
+    this.displayed_[BOTTOM_ROW] = {};
   };
 
   // exports


### PR DESCRIPTION
The Cea608 caption parsing currently breaks if the caption packets arrive with out-of-order PTS values.  Not sure if this is the best remedy, but it works.