### PR TITLE
Fix for large PTS/DTS values resulting in negative values

### DIFF
--- a/lib/m2ts/m2ts.js
+++ b/lib/m2ts/m2ts.js
@@ -283,29 +283,30 @@ ElementaryStream = function() {
       // performs all bitwise operations on 32-bit integers but javascript
       // supports a much greater range (52-bits) of integer using standard
       // mathematical operations.
-      // We construct a 32-bit value using bitwise operators over the 32
-      // most significant bits and then multiply by 2 (equal to a left-shift
-      // of 1) before we add the final LSB of the timestamp (equal to an OR.)
+      // We construct a 31-bit value using bitwise operators over the 31
+      // most significant bits and then multiply by 4 (equal to a left-shift
+      // of 2) before we add the final 2 least significant bits of the
+      // timestamp (equal to an OR.)
       if (ptsDtsFlags & 0xC0) {
         // the PTS and DTS are not written out directly. For information
         // on how they are encoded, see
         // http://dvd.sourceforge.net/dvdinfo/pes-hdr.html
-        pes.pts = (payload[9] & 0x0E) << 28
-          | (payload[10] & 0xFF) << 21
-          | (payload[11] & 0xFE) << 13
-          | (payload[12] & 0xFF) <<  6
-          | (payload[13] & 0xFE) >>>  2;
-        pes.pts *= 2; // Left shift by 1
-        pes.pts += (payload[13] & 0x02) >>> 1; // OR by the LSB
+        pes.pts = (payload[9] & 0x0E) << 27
+          | (payload[10] & 0xFF) << 20
+          | (payload[11] & 0xFE) << 12
+          | (payload[12] & 0xFF) <<  5
+          | (payload[13] & 0xFE) >>>  3;
+        pes.pts *= 4; // Left shift by 2
+        pes.pts += (payload[13] & 0x06) >>> 1; // OR by the two LSBs
         pes.dts = pes.pts;
         if (ptsDtsFlags & 0x40) {
-          pes.dts = (payload[14] & 0x0E ) << 28
-            | (payload[15] & 0xFF ) << 21
-            | (payload[16] & 0xFE ) << 13
-            | (payload[17] & 0xFF ) << 6
-            | (payload[18] & 0xFE ) >>> 2;
-          pes.dts *= 2; // Left shift by 1
-          pes.dts += (payload[18] & 0x02) >>> 1; // OR by the LSB
+          pes.dts = (payload[14] & 0x0E ) << 27
+            | (payload[15] & 0xFF ) << 20
+            | (payload[16] & 0xFE ) << 12
+            | (payload[17] & 0xFF ) << 5
+            | (payload[18] & 0xFE ) >>> 3;
+          pes.dts *= 4; // Left shift by 2
+          pes.dts += (payload[18] & 0x06) >>> 1; // OR by the two LSBs
         }
       }
 

--- a/test/transmuxer-test.js
+++ b/test/transmuxer-test.js
@@ -636,10 +636,10 @@ test('parses an elementary stream packet with just a pts', function() {
       0x84,
       // pdf:10 ef:1 erf:0 dtmf:0 acif:0 pcf:0 pef:0
       0xc0,
-      // phdl:0000 0101 '0010' pts:000 mb:1 pts:0000 0000
-      0x05, 0x21, 0x00,
-      // pts:0000 000 mb:1 pts:0000 0000 pts:0000 001 mb:1
-      0x01, 0x00, 0x03,
+      // phdl:0000 0101 '0010' pts:111 mb:1 pts:1111 1111
+      0x05, 0xFF, 0xFF,
+      // pts:1111 111 mb:1 pts:1111 1111 pts:1111 111 mb:1
+      0xFF, 0xFF, 0xFF,
       // "data":0101
       0x11
     ])
@@ -649,7 +649,8 @@ test('parses an elementary stream packet with just a pts', function() {
   ok(packet, 'parsed a packet');
   equal(packet.data.byteLength, 1, 'parsed a single data byte');
   equal(packet.data[0], 0x11, 'parsed the data');
-  equal(packet.pts, 1, 'parsed the pts');
+  // 2^33-1 is the maximum value of a 33-bit unsigned value
+  equal(packet.pts, Math.pow(2, 33) - 1, 'parsed the pts');
 });
 
 test('parses an elementary stream packet with a pts and dts', function() {


### PR DESCRIPTION
The basic change is to construct only the first 31-bits of the 33bit pts/dts values with bitwise ops since bitwise operations always work on *signed* 32bit integers. The remaining two bits are then added via math-wise operations.