### PR TITLE
Allow a base-baseMediaDecodeTime to specified when the transmuxer is constructed

### DIFF
--- a/lib/m2ts/m2ts.js
+++ b/lib/m2ts/m2ts.js
@@ -254,7 +254,7 @@ TransportParseStream.STREAM_TYPES  = {
  * packets plus relevant metadata that has been extracted from the
  * container.
  */
-ElementaryStream = function(timelineBaseDts) {
+ElementaryStream = function() {
   var
     // PES packet fragments
     video = {
@@ -347,8 +347,6 @@ ElementaryStream = function(timelineBaseDts) {
     },
     self;
 
-  timelineBaseDts = timelineBaseDts || 0;
-
   ElementaryStream.prototype.init.call(this);
   self = this;
 
@@ -405,7 +403,7 @@ ElementaryStream = function(timelineBaseDts) {
           if (programMapTable.hasOwnProperty(k)) {
             track = {
               timelineStartInfo: {
-                baseDts: timelineBaseDts
+                baseMediaDecodeTime: 0
               }
             };
             track.id = +k;

--- a/lib/m2ts/m2ts.js
+++ b/lib/m2ts/m2ts.js
@@ -254,7 +254,7 @@ TransportParseStream.STREAM_TYPES  = {
  * packets plus relevant metadata that has been extracted from the
  * container.
  */
-ElementaryStream = function() {
+ElementaryStream = function(timelineBaseDts) {
   var
     // PES packet fragments
     video = {
@@ -347,6 +347,8 @@ ElementaryStream = function() {
     },
     self;
 
+  timelineBaseDts = timelineBaseDts || 0;
+
   ElementaryStream.prototype.init.call(this);
   self = this;
 
@@ -402,7 +404,9 @@ ElementaryStream = function() {
         for (k in programMapTable) {
           if (programMapTable.hasOwnProperty(k)) {
             track = {
-              timelineStartInfo: {}
+              timelineStartInfo: {
+                baseDts: timelineBaseDts
+              }
             };
             track.id = +k;
             if (programMapTable[k] === H264_STREAM_TYPE) {

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -298,18 +298,12 @@ collectDtsInfo = function (track, data) {
   if (typeof data.pts === 'number') {
     if (track.timelineStartInfo.pts === undefined) {
       track.timelineStartInfo.pts = data.pts;
-    } else {
-      track.timelineStartInfo.pts =
-        Math.min(track.timelineStartInfo.pts, data.pts);
     }
   }
 
   if (typeof data.dts === 'number') {
     if (track.timelineStartInfo.dts === undefined) {
       track.timelineStartInfo.dts = data.dts;
-    } else {
-      track.timelineStartInfo.dts =
-        Math.min(track.timelineStartInfo.dts, data.dts);
     }
 
     if (track.minSegmentDts === undefined) {
@@ -345,7 +339,7 @@ calculateTrackBaseMediaDecodeTime = function (track) {
     oneSecondInPTS = 90000, // 90kHz clock
     scale;
 
-  track.baseMediaDecodeTime = track.minSegmentDts - track.timelineStartInfo.dts;
+  track.baseMediaDecodeTime = track.minSegmentDts - track.timelineStartInfo.dts + track.timelineStartInfo.baseDts;
 
   if (track.type === 'audio') {
     // Audio has a different clock equal to the sampling_rate so we need to
@@ -424,6 +418,7 @@ CoalesceStream.prototype.flush = function() {
     id3,
     initSegment,
     timelineStartPts = 0,
+    timelineBaseDts = 0,
     i;
 
   // Return until we have enough tracks from the pipeline to remux
@@ -434,8 +429,10 @@ CoalesceStream.prototype.flush = function() {
 
   if (this.videoTrack) {
     timelineStartPts = this.videoTrack.timelineStartInfo.pts;
+    timelineBaseDts = this.videoTrack.timelineStartInfo.baseDts;
   } else if (this.audioTrack) {
     timelineStartPts = this.audioTrack.timelineStartInfo.pts;
+    timelineBaseDts = this.audioTrack.timelineStartInfo.baseDts;
   }
 
   if (this.pendingTracks.length === 1) {
@@ -467,9 +464,9 @@ CoalesceStream.prototype.flush = function() {
   // video timeline for the segment
   for (i = 0; i < this.pendingCaptions.length; i++) {
     caption = this.pendingCaptions[i];
-    caption.startTime = caption.startPts - timelineStartPts;
+    caption.startTime = (caption.startPts - timelineStartPts) + timelineBaseDts;
     caption.startTime /= 90e3;
-    caption.endTime = caption.endPts - timelineStartPts;
+    caption.endTime = (caption.endPts - timelineStartPts) + timelineBaseDts;
     caption.endTime /= 90e3;
     event.captions.push(caption);
   }
@@ -478,7 +475,7 @@ CoalesceStream.prototype.flush = function() {
   // video timeline for the segment
   for (i = 0; i < this.pendingMetadata.length; i++) {
     id3 = this.pendingMetadata[i];
-    id3.cueTime = id3.pts - timelineStartPts;
+    id3.cueTime = (id3.pts - timelineStartPts) + timelineBaseDts;
     id3.cueTime /= 90e3;
     event.metadata.push(id3);
   }
@@ -523,6 +520,8 @@ Transmuxer = function(options) {
   Transmuxer.prototype.init.call(this);
   options = options || {};
 
+  options.baseDts = options.baseDts || 0;
+
   // expose the metadata stream
   this.metadataStream = new muxjs.mp2t.MetadataStream();
 
@@ -531,7 +530,7 @@ Transmuxer = function(options) {
   // set up the parsing pipeline
   packetStream = new muxjs.mp2t.TransportPacketStream();
   parseStream = new muxjs.mp2t.TransportParseStream();
-  elementaryStream = new muxjs.mp2t.ElementaryStream();
+  elementaryStream = new muxjs.mp2t.ElementaryStream(options.baseDts);
   aacStream = new muxjs.codecs.AacStream();
   h264Stream = new muxjs.codecs.H264Stream();
   coalesceStream = new CoalesceStream(options);

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -339,7 +339,7 @@ calculateTrackBaseMediaDecodeTime = function (track) {
     oneSecondInPTS = 90000, // 90kHz clock
     scale;
 
-  track.baseMediaDecodeTime = track.minSegmentDts - track.timelineStartInfo.dts + track.timelineStartInfo.baseDts;
+  track.baseMediaDecodeTime = track.minSegmentDts - track.timelineStartInfo.dts + track.timelineStartInfo.baseMediaDecodeTime;
 
   if (track.type === 'audio') {
     // Audio has a different clock equal to the sampling_rate so we need to
@@ -418,7 +418,7 @@ CoalesceStream.prototype.flush = function() {
     id3,
     initSegment,
     timelineStartPts = 0,
-    timelineBaseDts = 0,
+    baseMediaDecodeTime = 0,
     i;
 
   // Return until we have enough tracks from the pipeline to remux
@@ -429,10 +429,10 @@ CoalesceStream.prototype.flush = function() {
 
   if (this.videoTrack) {
     timelineStartPts = this.videoTrack.timelineStartInfo.pts;
-    timelineBaseDts = this.videoTrack.timelineStartInfo.baseDts;
+    baseMediaDecodeTime = this.videoTrack.timelineStartInfo.baseMediaDecodeTime;
   } else if (this.audioTrack) {
     timelineStartPts = this.audioTrack.timelineStartInfo.pts;
-    timelineBaseDts = this.audioTrack.timelineStartInfo.baseDts;
+    baseMediaDecodeTime = this.audioTrack.timelineStartInfo.baseMediaDecodeTime;
   }
 
   if (this.pendingTracks.length === 1) {
@@ -464,9 +464,9 @@ CoalesceStream.prototype.flush = function() {
   // video timeline for the segment
   for (i = 0; i < this.pendingCaptions.length; i++) {
     caption = this.pendingCaptions[i];
-    caption.startTime = (caption.startPts - timelineStartPts) + timelineBaseDts;
+    caption.startTime = (caption.startPts - timelineStartPts) + baseMediaDecodeTime;
     caption.startTime /= 90e3;
-    caption.endTime = (caption.endPts - timelineStartPts) + timelineBaseDts;
+    caption.endTime = (caption.endPts - timelineStartPts) + baseMediaDecodeTime;
     caption.endTime /= 90e3;
     event.captions.push(caption);
   }
@@ -475,7 +475,7 @@ CoalesceStream.prototype.flush = function() {
   // video timeline for the segment
   for (i = 0; i < this.pendingMetadata.length; i++) {
     id3 = this.pendingMetadata[i];
-    id3.cueTime = (id3.pts - timelineStartPts) + timelineBaseDts;
+    id3.cueTime = (id3.pts - timelineStartPts) + baseMediaDecodeTime;
     id3.cueTime /= 90e3;
     event.metadata.push(id3);
   }
@@ -511,7 +511,6 @@ Transmuxer = function(options) {
     self = this,
     videoTrack,
     audioTrack,
-
     packetStream, parseStream, elementaryStream,
     aacStream, h264Stream,
     videoSegmentStream, audioSegmentStream, captionStream,
@@ -520,7 +519,7 @@ Transmuxer = function(options) {
   Transmuxer.prototype.init.call(this);
   options = options || {};
 
-  options.baseDts = options.baseDts || 0;
+  this.baseMediaDecodeTime = options.baseMediaDecodeTime || 0;
 
   // expose the metadata stream
   this.metadataStream = new muxjs.mp2t.MetadataStream();
@@ -530,7 +529,7 @@ Transmuxer = function(options) {
   // set up the parsing pipeline
   packetStream = new muxjs.mp2t.TransportPacketStream();
   parseStream = new muxjs.mp2t.TransportParseStream();
-  elementaryStream = new muxjs.mp2t.ElementaryStream(options.baseDts);
+  elementaryStream = new muxjs.mp2t.ElementaryStream();
   aacStream = new muxjs.codecs.AacStream();
   h264Stream = new muxjs.codecs.H264Stream();
   coalesceStream = new CoalesceStream(options);
@@ -559,17 +558,19 @@ Transmuxer = function(options) {
 
   // hook up the segment streams once track metadata is delivered
   elementaryStream.on('data', function(data) {
-    var i, videoTrack, audioTrack;
+    var i;
 
     if (data.type === 'metadata') {
       i = data.tracks.length;
 
       // scan the tracks listed in the metadata
       while (i--) {
-        if (data.tracks[i].type === 'video') {
+        if (!videoTrack && data.tracks[i].type === 'video') {
           videoTrack = data.tracks[i];
-        } else if (data.tracks[i].type === 'audio') {
+          videoTrack.timelineStartInfo.baseMediaDecodeTime = self.baseMediaDecodeTime;
+        } else if (!audioTrack && data.tracks[i].type === 'audio') {
           audioTrack = data.tracks[i];
+          audioTrack.timelineStartInfo.baseMediaDecodeTime = self.baseMediaDecodeTime;
         }
       }
 
@@ -611,6 +612,22 @@ Transmuxer = function(options) {
       }
     }
   });
+
+  this.setBaseMediaDecodeTime = function (baseMediaDecodeTime) {
+    this.baseMediaDecodeTime = baseMediaDecodeTime;
+    if (audioTrack) {
+      audioTrack.timelineStartInfo.dts = undefined;
+      audioTrack.timelineStartInfo.pts = undefined;
+      clearDtsInfo(audioTrack);
+      audioTrack.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
+    }
+    if (videoTrack) {
+      videoTrack.timelineStartInfo.dts = undefined;
+      videoTrack.timelineStartInfo.pts = undefined;
+      clearDtsInfo(videoTrack);
+      videoTrack.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
+    }
+  };
 
   // feed incoming data to the front of the parsing pipeline
   this.push = function(data) {

--- a/test/transmuxer-test.js
+++ b/test/transmuxer-test.js
@@ -554,14 +554,14 @@ test('parses metadata events from PSI packets', function() {
     codec: 'avc',
     type: 'video',
     timelineStartInfo: {
-      baseDts: 0
+      baseMediaDecodeTime: 0
     }
   }, {
     id: 2,
     codec: 'adts',
     type: 'audio',
     timelineStartInfo: {
-      baseDts: 0
+      baseMediaDecodeTime: 0
     }
   }], 'identified two tracks');
 });
@@ -849,32 +849,6 @@ test('drops packets with unknown stream types', function() {
   });
 
   equal(packets.length, 0, 'ignored unknown packets');
-});
-
-test('allows setting a baseDts via the constructor', function() {
-  var metadatas = [];
-  elementaryStream = new ElementaryStream(1234);
-  elementaryStream.on('data', function(data) {
-    if (data.type === 'metadata') {
-      metadatas.push(data);
-    }
-  });
-  elementaryStream.push({
-    type: 'pat'
-  });
-  elementaryStream.push({
-    type: 'pmt',
-    programMapTable: {
-      1: 0x1b,
-      2: 0x0f
-    }
-  });
-
-  equal(1, metadatas.length, 'metadata generated');
-  equal(
-    metadatas[0].tracks[0].timelineStartInfo.baseDts,
-    1234,
-    'created a timelineStartInfo object with a proper baseDts value');
 });
 
 module('H264 Stream', {
@@ -1206,7 +1180,7 @@ module('VideoSegmentStream', {
     videoSegmentStream.track.timelineStartInfo = {
       dts: 10,
       pts: 10,
-      baseDts: 0
+      baseMediaDecodeTime: 0
     };
   }
 });
@@ -1483,12 +1457,12 @@ test('calculates baseMediaDecodeTime values from the first DTS ever seen and sub
   equal(tfdt.baseMediaDecodeTime, 90, 'calculated baseMediaDecodeTime');
 });
 
-test('calculates baseMediaDecodeTime values relative to a customizable baseDts', function() {
+test('calculates baseMediaDecodeTime values relative to a customizable baseMediaDecodeTime', function() {
   var segment, boxes, tfdt;
   videoSegmentStream.track.timelineStartInfo = {
     dts: 10,
     pts: 10,
-    baseDts: 1234
+    baseMediaDecodeTime: 1234
   };
   videoSegmentStream.on('data', function(data) {
     segment = data.boxes;


### PR DESCRIPTION
Allow specifying a time (in 90khz) to consider as the `baseMediaDecodeTime` of the first segment pushed through the transmuxer. Subsequent segments will be placed relative to the first in time.