### PR TITLE
Do not output ID3 and caption times based on baseMediaDecodeTime

### DIFF
--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -418,7 +418,6 @@ CoalesceStream.prototype.flush = function() {
     id3,
     initSegment,
     timelineStartPts = 0,
-    baseMediaDecodeTime = 0,
     i;
 
   // Return until we have enough tracks from the pipeline to remux
@@ -429,10 +428,8 @@ CoalesceStream.prototype.flush = function() {
 
   if (this.videoTrack) {
     timelineStartPts = this.videoTrack.timelineStartInfo.pts;
-    baseMediaDecodeTime = this.videoTrack.timelineStartInfo.baseMediaDecodeTime;
   } else if (this.audioTrack) {
     timelineStartPts = this.audioTrack.timelineStartInfo.pts;
-    baseMediaDecodeTime = this.audioTrack.timelineStartInfo.baseMediaDecodeTime;
   }
 
   if (this.pendingTracks.length === 1) {
@@ -464,9 +461,9 @@ CoalesceStream.prototype.flush = function() {
   // video timeline for the segment
   for (i = 0; i < this.pendingCaptions.length; i++) {
     caption = this.pendingCaptions[i];
-    caption.startTime = (caption.startPts - timelineStartPts) + baseMediaDecodeTime;
+    caption.startTime = (caption.startPts - timelineStartPts);
     caption.startTime /= 90e3;
-    caption.endTime = (caption.endPts - timelineStartPts) + baseMediaDecodeTime;
+    caption.endTime = (caption.endPts - timelineStartPts);
     caption.endTime /= 90e3;
     event.captions.push(caption);
   }
@@ -475,7 +472,7 @@ CoalesceStream.prototype.flush = function() {
   // video timeline for the segment
   for (i = 0; i < this.pendingMetadata.length; i++) {
     id3 = this.pendingMetadata[i];
-    id3.cueTime = (id3.pts - timelineStartPts) + baseMediaDecodeTime;
+    id3.cueTime = (id3.pts - timelineStartPts);
     id3.cueTime /= 90e3;
     event.metadata.push(id3);
   }

--- a/test/caption-stream-test.js
+++ b/test/caption-stream-test.js
@@ -75,6 +75,11 @@
     var transmuxer = new muxjs.mp4.Transmuxer(),
         captions = [];
 
+    // Setting the BMDT to ensure that captions and id3 tags are not
+    // time-shifted by this value when they are output and instead are
+    // zero-based
+    transmuxer.setBaseMediaDecodeTime(100000);
+
     transmuxer.on('data', function(data) {
       if (data.captions) {
         captions = captions.concat(data.captions);


### PR DESCRIPTION
Instead of outputting ID3 and captions in absolutely time, go back to placing them relative to the start of the *first* segment since we last set the `baseMediaDecodeTime`. Let `videojs-contrib-media-sources` do the translation in time based on `timestampOffset` which follows what we must do in the Flash case.