### PR TITLE
Fix AAC frame-trimming algorithm

### DIFF
--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -51,7 +51,7 @@ AudioSegmentStream = function(track) {
   };
 
   this.setEarliestDts = function (earliestDts) {
-    earliestAllowedDts = earliestDts;
+    earliestAllowedDts = earliestDts - track.timelineStartInfo.baseMediaDecodeTime;
   };
 
   this.flush = function() {


### PR DESCRIPTION
Only trim AAC frames if the current segment will end up with negative baseMediaDecodeTime calculation in the calculateTrackBaseMediaDecodeTime function. This serves to cull AAC frames that occur before the video at the beginning of a video so that all videos start at 0 but leaves intact AAC frames for any other segments.