### PR TITLE
BaseMediaDecodeTime & Audio Metadata fixes

### DIFF
--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -73,6 +73,7 @@ AudioSegmentStream = function(track) {
         // If this is an allowed frame, keep it and record it's Dts
         if (currentFrame.dts >= earliestAllowedDts) {
           track.minSegmentDts = Math.min(track.minSegmentDts, currentFrame.dts);
+          track.minSegmentPts = track.minSegmentDts;
           return true;
         }
         // Otherwise, discard it
@@ -112,6 +113,7 @@ AudioSegmentStream = function(track) {
     boxes.set(mdat, moof.byteLength);
 
     clearDtsInfo(track);
+
     this.trigger('data', {track: track, boxes: boxes});
     this.trigger('done');
   };
@@ -131,6 +133,7 @@ VideoSegmentStream = function(track) {
     nalUnitsLength = 0,
     config,
     pps;
+
   VideoSegmentStream.prototype.init.call(this);
 
   delete track.minPTS;
@@ -290,7 +293,7 @@ VideoSegmentStream = function(track) {
 VideoSegmentStream.prototype = new muxjs.utils.Stream();
 
 /**
- * Store information about the start and end of the tracka and the
+ * Store information about the start and end of the track and the
  * duration for each frame/sample we process in order to calculate
  * the baseMediaDecodeTime
  */
@@ -298,6 +301,18 @@ collectDtsInfo = function (track, data) {
   if (typeof data.pts === 'number') {
     if (track.timelineStartInfo.pts === undefined) {
       track.timelineStartInfo.pts = data.pts;
+    }
+
+    if (track.minSegmentPts === undefined) {
+      track.minSegmentPts = data.pts;
+    } else {
+      track.minSegmentPts = Math.min(track.minSegmentPts, data.pts);
+    }
+
+    if (track.maxSegmentPts === undefined) {
+      track.maxSegmentPts = data.pts;
+    } else {
+      track.maxSegmentPts = Math.max(track.maxSegmentPts, data.pts);
     }
   }
 
@@ -327,6 +342,8 @@ collectDtsInfo = function (track, data) {
 clearDtsInfo = function (track) {
   delete track.minSegmentDts;
   delete track.maxSegmentDts;
+  delete track.minSegmentPts;
+  delete track.maxSegmentPts;
 };
 
 /**
@@ -337,9 +354,27 @@ clearDtsInfo = function (track) {
 calculateTrackBaseMediaDecodeTime = function (track) {
   var
     oneSecondInPTS = 90000, // 90kHz clock
-    scale;
+    scale,
+    // Calculate the distance, in time, that this segment starts from the start
+    // of the timeline (earliest time seen since the transmuxer initialized)
+    timeSinceStartOfTimeline = track.minSegmentDts - track.timelineStartInfo.dts,
+    // Calculate the first sample's effective compositionTimeOffset
+    firstSampleCompositionOffset = track.minSegmentPts - track.minSegmentDts;
 
-  track.baseMediaDecodeTime = track.minSegmentDts - track.timelineStartInfo.dts + track.timelineStartInfo.baseMediaDecodeTime;
+  // track.timelineStartInfo.baseMediaDecodeTime is the location, in time, where
+  // we want the start of the first segment to be placed
+  track.baseMediaDecodeTime = track.timelineStartInfo.baseMediaDecodeTime;
+
+  // Add to that the distance this segment is from the very first
+  track.baseMediaDecodeTime += timeSinceStartOfTimeline;
+
+  // Subtract this segment's "compositionTimeOffset" so that the first frame of
+  // this segment is displayed exactly at the `baseMediaDecodeTime` or at the
+  // end of the previous segment
+  track.baseMediaDecodeTime -= firstSampleCompositionOffset;
+
+  // baseMediaDecodeTime must not become negative
+  track.baseMediaDecodeTime = Math.max(0, track.baseMediaDecodeTime);
 
   if (track.type === 'audio') {
     // Audio has a different clock equal to the sampling_rate so we need to
@@ -582,7 +617,6 @@ Transmuxer = function(options) {
           // data takes precedence.
           if (audioTrack) {
             audioTrack.timelineStartInfo = timelineStartInfo;
-
             // On the first segment we trim AAC frames that exist before the
             // very earliest DTS we have seen in video because Chrome will
             // interpret any video track with a baseMediaDecodeTime that is

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -37,7 +37,7 @@ AudioSegmentStream = function(track) {
   this.push = function(data) {
     collectDtsInfo(track, data);
 
-    if (track && track.channelcount === undefined) {
+    if (track) {
       track.audioobjecttype = data.audioobjecttype;
       track.channelcount = data.channelcount;
       track.samplerate = data.samplerate;


### PR DESCRIPTION
1. Change how we calculate the baseMediaDecodeTime to correctly place segments without introducing a gap that start with a non-zero compositionTimeOffset for the first frame
1. Allow audio track metadata to change as we parse segments
 * Previously the emitted fragment would have metadata copied from the first segment we ever received and the meta data would never change even as the incoming segments changed audio parameters