### PR TITLE
Remove window references in parsing functions of metadata stream

### DIFF
--- a/lib/m2ts/metadata-stream.js
+++ b/lib/m2ts/metadata-stream.js
@@ -19,12 +19,12 @@ var
   // return the string representation of the specified byte range,
   // interpreted as UTf-8.
   parseUtf8 = function(bytes, start, end) {
-    return window.decodeURIComponent(percentEncode(bytes, start, end));
+    return decodeURIComponent(percentEncode(bytes, start, end));
   },
   // return the string representation of the specified byte range,
   // interpreted as ISO-8859-1.
   parseIso88591 = function(bytes, start, end) {
-    return window.unescape(percentEncode(bytes, start, end));
+    return unescape(percentEncode(bytes, start, end)); // jshint ignore:line
   },
   parseSyncSafeInteger = function (data) {
     return (data[0] << 21) |

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "portscanner": "^1.0.0",
     "qunitjs": "^1.0.0",
     "serve-static": "^1.10.0",
-    "watchify": "^3.6.1"
+    "watchify": "^3.6.1",
+    "webworkify": "^1.0.2"
   },
   "dependencies": {
     "browserify-shim": "^3.8.12"

--- a/test/metadata-stream-test-worker.js
+++ b/test/metadata-stream-test-worker.js
@@ -1,0 +1,13 @@
+var mp2t, metadataStream;
+
+mp2t = require('../lib/m2ts');
+metadataStream = new mp2t.MetadataStream();
+
+module.exports = function(self) {
+  self.addEventListener('message', function(e) {
+    metadataStream.on('data', function(data) {
+      self.postMessage(data);
+    });
+    metadataStream.push(e.data);
+  });
+};


### PR DESCRIPTION
While the functions decodeURIComponent and unescape exist in the global scope, window is not available in all scopes (for instance, in the scope of a web worker).