### PR TITLE
Selectable elementary streams

### DIFF
--- a/debug/index.html
+++ b/debug/index.html
@@ -280,6 +280,7 @@ mp4fragment --track audio --fragment-duration 11000 movie-audio.mp4 movie-audio.
             i, j;
 
         if (combined) {
+          //
             transmuxer = new muxjs.mp4.Transmuxer();
         } else {
             transmuxer = new muxjs.mp4.Transmuxer({remux: false});

--- a/debug/index.html
+++ b/debug/index.html
@@ -69,6 +69,10 @@ mp4fragment --track audio --fragment-duration 11000 movie-audio.mp4 movie-audio.
               <div>
                 <label><input id="combined-output" type=checkbox name=combined checked value="combined">&nbsp;Remux output into a single output?
                 </label>
+                <label><input id="drop-audio" type=checkbox name=combined value="drop-audio">&nbsp;Drop audio elementary stream?
+                </label>
+                <label><input id="drop-video" type=checkbox name=combined value="drop-audio">&nbsp;Drop video elementary stream?
+                </label>
               </div>
               <div>
                 Otherwise, output only:&nbsp;
@@ -272,6 +276,8 @@ mp4fragment --track audio --fragment-duration 11000 movie-audio.mp4 movie-audio.
       reader.addEventListener('loadend', function() {
         var segment = new Uint8Array(reader.result),
             combined = document.querySelector('#combined-output').checked,
+            dropAudio = document.querySelector('#drop-audio').checked,
+            dropVideo = document.querySelector('#drop-video').checked,
             outputType = document.querySelector('input[name="output"]:checked').value,
             transmuxer,
             remuxedSegments = [],
@@ -280,8 +286,12 @@ mp4fragment --track audio --fragment-duration 11000 movie-audio.mp4 movie-audio.
             i, j;
 
         if (combined) {
-          //
+          if (dropAudio) {
+            console.log("setup new transmuxer that excludes audio elematary streams");
+            transmuxer = new muxjs.mp4.Transmuxer({exclude:'audio'});
+          } else {
             transmuxer = new muxjs.mp4.Transmuxer();
+          }
         } else {
             transmuxer = new muxjs.mp4.Transmuxer({remux: false});
         }

--- a/lib/AACStream/aacs.js
+++ b/lib/AACStream/aacs.js
@@ -1,0 +1,123 @@
+/**
+ * mux.js
+ *
+ * Copyright (c) 2016 Brightcove
+ * All rights reserved.
+ *
+ * A stream-based aac to mp4 converter. This utility can be used to
+ * deliver mp4s to a SourceBuffer on platforms that support native
+ * Media Source Extensions.
+ */
+'use strict';
+var Stream = require('../utils/stream.js');
+
+// object types
+var AacStream;
+
+var
+
+/**
+ * Splits an incoming stream of binary data into ADTS and ID3 Frames.
+ */
+
+ AacStream = function() {
+  var
+    everything,
+    frameSize = 0,
+    receivedTimeStamp = false,
+    timeStamp = 0;
+
+  AacStream.prototype.init.call(this);
+
+  this.setTimestamp = function (frame) {
+    var d = frame.data;
+    var size = ((d[3] & 0x01)  << 30) | (d[4]  << 22) | (d[5] << 14) | (d[6] << 6) | d[7] >>> 2;
+    size *= 4;
+    size += d[7] & 0x03;
+    timeStamp = size;
+  };
+
+
+  this.push = function(bytes) {
+    var canParseMore = true;
+
+    // If there are bytes remaining from the last segment, prepend them to the
+    // bytes that were pushed in
+    if (everything !== undefined && everything.length) {
+      var tempLength = everything.length;
+      everything = new Uint8Array(bytes.byteLength + tempLength);
+      everything.set(everything.subarray(0, tempLength));
+      everything.set(bytes, tempLength);
+    } else {
+      everything = bytes;
+    }
+
+    while(canParseMore) {
+      if (everything.length >= 10) {
+        if ((everything[0] === 'I'.charCodeAt(0)) &&
+          (everything[1] === 'D'.charCodeAt(0)) &&
+          (everything[2] === '3'.charCodeAt(0))) {
+
+          //check framesize
+          frameSize = (everything[6] << 21) | (everything[7] << 14) |
+              (everything[8] << 7) | (everything[9]);
+          var flags = everything[5];
+          var footerpresent = (flags & 16) >> 4;
+          if (footerpresent) {
+            frameSize = frameSize + 20;
+          } else {
+            frameSize = frameSize + 10;
+          }
+
+          //we have enough in the buffer to emit a full packet
+          if(everything.length >= frameSize) {
+            var chunk = {
+              type: 'timed-metadata',
+              data: everything.subarray(0, frameSize)
+            };
+            this.trigger('data', chunk);
+            everything = everything.subarray(frameSize);
+            continue;
+          } else {
+            canParseMore = false;
+          }
+        } else if ((everything[0] & 0xff == 0xff) &&
+            (((everything[1] >> 4) & 0xf) == 0xf)) {
+
+          var lowThree = (everything[5] & 0xE0) >> 5;
+          var middle = everything[4] << 3;
+          var highTwo = everything[3] & 0x3 << 11;
+          frameSize = (highTwo | middle) | lowThree;
+
+          if(everything.length >= frameSize) {
+            var packet = {
+              type: 'audio',
+              data: everything.subarray(0, frameSize),
+              pts: timeStamp,
+              dts: timeStamp,
+            };
+            this.trigger('data', packet);
+            everything = everything.subarray(frameSize);
+            continue;
+          } else {
+            canParseMore = false;
+          }
+        }
+      } else {
+        canParseMore = false;
+      }
+    }
+  };
+  this.flush = function () {
+    this.trigger('done');
+  };
+};
+
+AacStream.prototype = new Stream();
+
+var AACStream = {
+  AacStream: AacStream,
+  MetadataStream: require('./metadata-stream'),
+};
+
+module.exports = AACStream;

--- a/lib/AACStream/metadata-stream.js
+++ b/lib/AACStream/metadata-stream.js
@@ -1,0 +1,229 @@
+/**
+ * Accepts program elementary stream (PES) data events and parses out
+ * ID3 metadata from them, if present.
+ * @see http://id3.org/id3v2.3.0
+ */
+'use strict';
+var
+  Stream = require('../utils/stream'),
+  StreamTypes = require('./stream-types'),
+  // return a percent-encoded representation of the specified byte range
+  // @see http://en.wikipedia.org/wiki/Percent-encoding
+  percentEncode = function(bytes, start, end) {
+    var i, result = '';
+    for (i = start; i < end; i++) {
+      result += '%' + ('00' + bytes[i].toString(16)).slice(-2);
+    }
+    return result;
+  },
+  // return the string representation of the specified byte range,
+  // interpreted as UTf-8.
+  parseUtf8 = function(bytes, start, end) {
+    return window.decodeURIComponent(percentEncode(bytes, start, end));
+  },
+  // return the string representation of the specified byte range,
+  // interpreted as ISO-8859-1.
+  parseIso88591 = function(bytes, start, end) {
+    return window.unescape(percentEncode(bytes, start, end));
+  },
+  parseSyncSafeInteger = function (data) {
+    return (data[0] << 21) |
+            (data[1] << 14) |
+            (data[2] << 7) |
+            (data[3]);
+  },
+  tagParsers = {
+    'TXXX': function(tag) {
+      var i;
+      if (tag.data[0] !== 3) {
+        // ignore frames with unrecognized character encodings
+        return;
+      }
+
+      for (i = 1; i < tag.data.length; i++) {
+        if (tag.data[i] === 0) {
+          // parse the text fields
+          tag.description = parseUtf8(tag.data, 1, i);
+          // do not include the null terminator in the tag value
+          tag.value = parseUtf8(tag.data, i + 1, tag.data.length - 1);
+          break;
+        }
+      }
+      tag.data = tag.value;
+    },
+    'WXXX': function(tag) {
+      var i;
+      if (tag.data[0] !== 3) {
+        // ignore frames with unrecognized character encodings
+        return;
+      }
+
+      for (i = 1; i < tag.data.length; i++) {
+        if (tag.data[i] === 0) {
+          // parse the description and URL fields
+          tag.description = parseUtf8(tag.data, 1, i);
+          tag.url = parseUtf8(tag.data, i + 1, tag.data.length);
+          break;
+        }
+      }
+    },
+    'PRIV': function(tag) {
+      var i;
+
+      for (i = 0; i < tag.data.length; i++) {
+        if (tag.data[i] === 0) {
+          // parse the description and URL fields
+          tag.owner = parseIso88591(tag.data, 0, i);
+
+          break;
+        }
+      }
+
+      tag.privateData = tag.data.subarray(i + 1);
+      tag.data = tag.privateData;
+
+    }
+  },
+  MetadataStream;
+
+MetadataStream = function(options) {
+  var
+    settings = {
+      debug: !!(options && options.debug),
+
+      // the bytes of the program-level descriptor field in MP2T
+      // see ISO/IEC 13818-1:2013 (E), section 2.6 "Program and
+      // program element descriptors"
+      descriptor: options && options.descriptor
+    },
+    // the total size in bytes of the ID3 tag being parsed
+    tagSize = 0,
+    // tag data that is not complete enough to be parsed
+    buffer = [],
+    // the total number of bytes currently in the buffer
+    bufferSize = 0,
+    i;
+
+  MetadataStream.prototype.init.call(this);
+
+  // calculate the text track in-band metadata track dispatch type
+  // https://html.spec.whatwg.org/multipage/embedded-content.html#steps-to-expose-a-media-resource-specific-text-track
+  this.dispatchType = StreamTypes.METADATA_STREAM_TYPE.toString(16);
+  if (settings.descriptor) {
+    for (i = 0; i < settings.descriptor.length; i++) {
+      this.dispatchType += ('00' + settings.descriptor[i].toString(16)).slice(-2);
+    }
+  }
+
+  this.push = function(chunk) {
+
+    var tag, frameStart, frameSize, frame, i;
+
+    if (chunk.type !== 'timed-metadata') {
+      return;
+    }
+
+    // if data_alignment_indicator is set in the PES header,
+    // we must have the start of a new ID3 tag. Assume anything
+    // remaining in the buffer was malformed and throw it out
+    if (chunk.dataAlignmentIndicator) {
+      bufferSize = 0;
+      buffer.length = 0;
+    }
+
+    // ignore events that don't look like ID3 data
+    if (buffer.length === 0 &&
+        (chunk.data.length < 10 ||
+          chunk.data[0] !== 'I'.charCodeAt(0) ||
+          chunk.data[1] !== 'D'.charCodeAt(0) ||
+          chunk.data[2] !== '3'.charCodeAt(0))) {
+      if (settings.debug) {
+        console.log('Skipping unrecognized metadata packet');
+      }
+      return;
+    }
+
+    // add this chunk to the data we've collected so far
+
+    buffer.push(chunk);
+    bufferSize += chunk.data.byteLength;
+
+    // grab the size of the entire frame from the ID3 header
+    if (buffer.length === 1) {
+      // the frame size is transmitted as a 28-bit integer in the
+      // last four bytes of the ID3 header.
+      // The most significant bit of each byte is dropped and the
+      // results concatenated to recover the actual value.
+      tagSize = parseSyncSafeInteger(chunk.data.subarray(6, 10));
+
+      // ID3 reports the tag size excluding the header but it's more
+      // convenient for our comparisons to include it
+      tagSize += 10;
+    }
+
+    // if the entire frame has not arrived, wait for more data
+    if (bufferSize < tagSize) {
+      return;
+    }
+
+    // collect the entire frame so it can be parsed
+    tag = {
+      data: new Uint8Array(tagSize),
+      frames: [],
+      pts: buffer[0].pts,
+      dts: buffer[0].dts
+    };
+    for (i = 0; i < tagSize;) {
+      tag.data.set(buffer[0].data.subarray(0, tagSize - i), i);
+      i += buffer[0].data.byteLength;
+      bufferSize -= buffer[0].data.byteLength;
+      buffer.shift();
+    }
+
+    // find the start of the first frame and the end of the tag
+    frameStart = 10;
+    if (tag.data[5] & 0x40) {
+      // advance the frame start past the extended header
+      frameStart += 4; // header size field
+      frameStart += parseSyncSafeInteger(tag.data.subarray(10, 14));
+
+      // clip any padding off the end
+      tagSize -= parseSyncSafeInteger(tag.data.subarray(16, 20));
+    }
+
+    // parse one or more ID3 frames
+    // http://id3.org/id3v2.3.0#ID3v2_frame_overview
+    do {
+      // determine the number of bytes in this frame
+      frameSize = parseSyncSafeInteger(tag.data.subarray(frameStart + 4, frameStart + 8));
+      if (frameSize < 1) {
+        return console.log('Malformed ID3 frame encountered. Skipping metadata parsing.');
+      }
+      var frameHeader = String.fromCharCode(tag.data[frameStart],
+                                tag.data[frameStart + 1],
+                                tag.data[frameStart + 2],
+                                tag.data[frameStart + 3]);
+
+
+      frame = {
+        id: frameHeader,
+        data: tag.data.subarray(frameStart + 10, frameStart + frameSize + 10)
+      };
+      frame.key = frame.id;
+      if (tagParsers[frame.id]) {
+        tagParsers[frame.id](frame);
+        if (frame.owner === 'com.apple.streaming.transportStreamTimestamp'){
+            this.trigger('timestamp', frame);
+      }
+      }
+      tag.frames.push(frame);
+
+      frameStart += 10; // advance past the frame header
+      frameStart += frameSize; // advance past the frame body
+    } while (frameStart < tagSize);
+    this.trigger('data', tag);
+  };
+};
+MetadataStream.prototype = new Stream();
+
+module.exports = MetadataStream;

--- a/lib/AACStream/stream-types.js
+++ b/lib/AACStream/stream-types.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+  H264_STREAM_TYPE: 0x1B,
+  ADTS_STREAM_TYPE: 0x0F,
+  METADATA_STREAM_TYPE: 0x15
+};

--- a/lib/codecs/adts.js
+++ b/lib/codecs/adts.js
@@ -1,0 +1,132 @@
+'use strict';
+
+var Stream = require('../utils/stream.js');
+
+var AdtsStream;
+
+var
+  ADTS_SAMPLING_FREQUENCIES = [
+    96000,
+    88200,
+    64000,
+    48000,
+    44100,
+    32000,
+    24000,
+    22050,
+    16000,
+    12000,
+    11025,
+    8000,
+    7350
+  ];
+
+/*
+ * Accepts a ElementaryStream and emits data events with parsed
+ * AAC Audio Frames of the individual packets. Input audio in ADTS
+ * format is unpacked and re-emitted as AAC frames.
+ *
+ * @see http://wiki.multimedia.cx/index.php?title=ADTS
+ * @see http://wiki.multimedia.cx/?title=Understanding_AAC
+ */
+AdtsStream = function() {
+  var self, buffer;
+
+  AdtsStream.prototype.init.call(this);
+
+  self = this;
+
+  this.push = function(packet) {
+    var
+      i = 0,
+      frameNum = 0,
+      frameLength,
+      protectionSkipBytes,
+      frameEnd,
+      oldBuffer,
+      numFrames,
+      sampleCount,
+      adtsFrameDuration;
+
+    if (packet.type !== 'audio') {
+      // ignore non-audio data
+      return;
+    }
+
+    // Prepend any data in the buffer to the input data so that we can parse
+    // aac frames the cross a PES packet boundary
+    if (buffer) {
+      oldBuffer = buffer;
+      buffer = new Uint8Array(oldBuffer.byteLength + packet.data.byteLength);
+      buffer.set(oldBuffer);
+      buffer.set(packet.data, oldBuffer.byteLength);
+    } else {
+      buffer = packet.data;
+    }
+
+    // unpack any ADTS frames which have been fully received
+    // for details on the ADTS header, see http://wiki.multimedia.cx/index.php?title=ADTS
+    while (i + 5 < buffer.length) {
+
+      // Loook for the start of an ADTS header..
+      if (buffer[i] !== 0xFF || (buffer[i + 1] & 0xF6) !== 0xF0) {
+        // If a valid header was not found,  jump one forward and attempt to
+        // find a valid ADTS header starting at the next byte
+        i++;
+        continue;
+      }
+
+      // The protection skip bit tells us if we have 2 bytes of CRC data at the
+      // end of the ADTS header
+      protectionSkipBytes = (~buffer[i + 1] & 0x01) * 2;
+
+      // Frame length is a 13 bit integer starting 16 bits from the
+      // end of the sync sequence
+      frameLength = ((buffer[i + 3] & 0x03) << 11) |
+        (buffer[i + 4] << 3) |
+        ((buffer[i + 5] & 0xe0) >> 5);
+
+      sampleCount = ((buffer[i + 6] & 0x03) + 1) * 1024;
+      adtsFrameDuration = (sampleCount * 90000) /
+        ADTS_SAMPLING_FREQUENCIES[(buffer[i + 2] & 0x3c) >>> 2];
+
+      frameEnd = i + frameLength;
+
+      // If we don't have enough data to actually finish this ADTS frame, return
+      // and wait for more data
+      if (buffer.byteLength < frameEnd) {
+        return;
+      }
+
+      // Otherwise, deliver the complete AAC frame
+      this.trigger('data', {
+        pts: packet.pts + (frameNum * adtsFrameDuration),
+        dts: packet.dts + (frameNum * adtsFrameDuration),
+        sampleCount: sampleCount,
+        audioobjecttype: ((buffer[i + 2] >>> 6) & 0x03) + 1,
+        channelcount: ((buffer[i + 2] & 1) << 3) |
+          ((buffer[i + 3] & 0xc0) >>> 6),
+        samplerate: ADTS_SAMPLING_FREQUENCIES[(buffer[i + 2] & 0x3c) >>> 2],
+        samplingfrequencyindex: (buffer[i + 2] & 0x3c) >>> 2,
+        // assume ISO/IEC 14496-12 AudioSampleEntry default of 16
+        samplesize: 16,
+        data: buffer.subarray(i + 7 + protectionSkipBytes, frameEnd)
+      });
+
+      // If the buffer is empty, clear it and return
+      if (buffer.byteLength === frameEnd) {
+        buffer = undefined;
+        return;
+      }
+
+      frameNum++;
+
+      // Remove the finished frame from the buffer and start the process again
+      buffer = buffer.subarray(frameEnd);
+    }
+  };
+};
+
+AdtsStream.prototype = new Stream();
+
+module.exports = AdtsStream;

--- a/lib/codecs/index.js
+++ b/lib/codecs/index.js
@@ -1,4 +1,5 @@
 module.exports = {
   aac: require('./aac'),
   h264: require('./h264'),
+  adts: require('./adts'),
 };

--- a/lib/flv/transmuxer.js
+++ b/lib/flv/transmuxer.js
@@ -3,7 +3,7 @@
 var Stream = require('../utils/stream.js');
 var FlvTag = require('./flv-tag.js');
 var m2ts = require('../m2ts/m2ts.js');
-var AacStream = require('../codecs/aac.js');
+var AdtsStream = require('../codecs/adts.js');
 var H264Stream = require('../codecs/h264').H264Stream;
 
 var
@@ -87,8 +87,8 @@ extraDataTag = function(track, pts) {
  */
 AudioSegmentStream = function(track) {
   var
-    aacFrames = [],
-    aacFramesLength = 0,
+    adtsFrames = [],
+    adtsFramesLength = 0,
     sequenceNumber = 0,
     earliestAllowedDts = 0,
     oldExtraData;
@@ -113,63 +113,63 @@ AudioSegmentStream = function(track) {
     data.dts = Math.round(data.dts / 90);
 
     // buffer audio data until end() is called
-    aacFrames.push(data);
+    adtsFrames.push(data);
   };
 
   this.flush = function() {
-    var currentFrame, aacFrame, deltaDts,lastMetaPts, tags = [];
+    var currentFrame, adtsFrame, deltaDts,lastMetaPts, tags = [];
     // return early if no audio data has been observed
-    if (aacFrames.length === 0) {
+    if (adtsFrames.length === 0) {
       this.trigger('done');
       return;
     }
 
     lastMetaPts = -Infinity;
 
-    while (aacFrames.length) {
-      currentFrame = aacFrames.shift();
+    while (adtsFrames.length) {
+      currentFrame = adtsFrames.shift();
 
       // write out metadata tags every 1 second so that the decoder
       // is re-initialized quickly after seeking into a different
       // audio configuration
       if (track.extraData !== oldExtraData || currentFrame.pts - lastMetaPts >= 1000) {
-        aacFrame = new FlvTag(FlvTag.METADATA_TAG);
-        aacFrame.pts = currentFrame.pts;
-        aacFrame.dts = currentFrame.dts;
+       adtsFrame = new FlvTag(FlvTag.METADATA_TAG);
+        adtsFrame.pts = currentFrame.pts;
+        adtsFrame.dts = currentFrame.dts;
 
         // AAC is always 10
-        aacFrame.writeMetaDataDouble("audiocodecid", 10);
-        aacFrame.writeMetaDataBoolean("stereo", 2 === track.channelcount);
-        aacFrame.writeMetaDataDouble ("audiosamplerate", track.samplerate);
+        adtsFrame.writeMetaDataDouble("audiocodecid", 10);
+        adtsFrame.writeMetaDataBoolean("stereo", 2 === track.channelcount);
+        adtsFrame.writeMetaDataDouble ("audiosamplerate", track.samplerate);
         // Is AAC always 16 bit?
-        aacFrame.writeMetaDataDouble ("audiosamplesize", 16);
+        adtsFrame.writeMetaDataDouble ("audiosamplesize", 16);
 
-        tags.push(aacFrame);
+        tags.push(adtsFrame);
 
         oldExtraData = track.extraData;
 
-        aacFrame = new FlvTag(FlvTag.AUDIO_TAG, true);
+        adtsFrame = new FlvTag(FlvTag.AUDIO_TAG, true);
         // For audio, DTS is always the same as PTS. We want to set the DTS
         // however so we can compare with video DTS to determine approximate
         // packet order
-        aacFrame.pts = currentFrame.pts;
-        aacFrame.dts = currentFrame.dts;
+        adtsFrame.pts = currentFrame.pts;
+        adtsFrame.dts = currentFrame.dts;
 
-        aacFrame.view.setUint16(aacFrame.position, track.extraData);
-        aacFrame.position += 2;
-        aacFrame.length = Math.max(aacFrame.length, aacFrame.position);
+        adtsFrame.view.setUint16(adtsFrame.position, track.extraData);
+        adtsFrame.position += 2;
+        adtsFrame.length = Math.max(adtsFrame.length, adtsFrame.position);
 
-        tags.push(aacFrame);
+        tags.push(adtsFrame);
 
         lastMetaPts = currentFrame.pts;
       }
-      aacFrame = new FlvTag(FlvTag.AUDIO_TAG);
-      aacFrame.pts = currentFrame.pts;
-      aacFrame.dts = currentFrame.dts;
+      adtsFrame = new FlvTag(FlvTag.AUDIO_TAG);
+      adtsFrame.pts = currentFrame.pts;
+      adtsFrame.dts = currentFrame.dts;
 
-      aacFrame.writeBytes(currentFrame.data);
+      adtsFrame.writeBytes(currentFrame.data);
 
-      tags.push(aacFrame);
+      tags.push(adtsFrame);
     }
 
     oldExtraData = null;
@@ -410,7 +410,7 @@ Transmuxer = function(options) {
     audioTrack,
 
     packetStream, parseStream, elementaryStream,
-    aacStream, h264Stream,
+    adtsStream, h264Stream,
     videoSegmentStream, audioSegmentStream, captionStream,
     coalesceStream;
 
@@ -427,7 +427,7 @@ Transmuxer = function(options) {
   packetStream = new m2ts.TransportPacketStream();
   parseStream = new m2ts.TransportParseStream();
   elementaryStream = new m2ts.ElementaryStream();
-  aacStream = new AacStream();
+  adtsStream = new AdtsStream();
   h264Stream = new H264Stream();
   coalesceStream = new CoalesceStream(options);
 
@@ -441,7 +441,7 @@ Transmuxer = function(options) {
   elementaryStream
     .pipe(h264Stream);
   elementaryStream
-    .pipe(aacStream);
+    .pipe(adtsStream);
 
   elementaryStream
     .pipe(this.metadataStream)
@@ -484,7 +484,7 @@ Transmuxer = function(options) {
         audioSegmentStream = new AudioSegmentStream(audioTrack);
 
         // Set up the final part of the audio pipeline
-        aacStream
+        adtsStream
           .pipe(audioSegmentStream)
           .pipe(coalesceStream);
       }

--- a/lib/m2ts/m2ts.js
+++ b/lib/m2ts/m2ts.js
@@ -269,6 +269,8 @@ ElementaryStream = function() {
       data: [],
       size: 0
     },
+    dropAudio = false,
+    dropVideo = false,
     parsePes = function(payload, pes) {
       var ptsDtsFlags;
 
@@ -315,6 +317,14 @@ ElementaryStream = function() {
       // that follow the last byte of the field.
       pes.data = payload.subarray(9 + payload[8]);
     },
+    excludeVideo = function() {
+      dropVideo = true;
+    },
+
+    excludeAudio = function() {
+      dropAudio = true;
+    },
+
     flushStream = function(stream, type) {
       var
         packetData = new Uint8Array(stream.size),
@@ -342,7 +352,11 @@ ElementaryStream = function() {
       parsePes(packetData, event);
 
       stream.size = 0;
-
+      if (dropAudio && event.type === 'audio') {
+        return;
+      } else if (dropVideo && event.type === 'video') {
+        return;
+      }
       self.trigger('data', event);
     },
     self;

--- a/lib/m2ts/m2ts.js
+++ b/lib/m2ts/m2ts.js
@@ -317,13 +317,7 @@ ElementaryStream = function() {
       // that follow the last byte of the field.
       pes.data = payload.subarray(9 + payload[8]);
     },
-    excludeVideo = function() {
-      dropVideo = true;
-    },
 
-    excludeAudio = function() {
-      dropAudio = true;
-    },
 
     flushStream = function(stream, type) {
       var
@@ -436,6 +430,18 @@ ElementaryStream = function() {
       }
     })[data.type]();
   };
+
+  this.excludeVideo = function() {
+    console.log("Excluding Video called");
+      dropVideo = true;
+    };
+
+
+
+  this.excludeAudio = function() {
+    console.log("Excluding audio called");
+      dropAudio = true;
+    };
 
   /**
    * Flush any remaining input. Video PES packets may be of variable

--- a/lib/m2ts/m2ts.js
+++ b/lib/m2ts/m2ts.js
@@ -351,6 +351,7 @@ ElementaryStream = function() {
       } else if (dropVideo && event.type === 'video') {
         return;
       }
+
       self.trigger('data', event);
     },
     self;

--- a/lib/m2ts/m2ts.js
+++ b/lib/m2ts/m2ts.js
@@ -433,14 +433,12 @@ ElementaryStream = function() {
   };
 
   this.excludeVideo = function() {
-    console.log("Excluding Video called");
       dropVideo = true;
     };
 
 
 
   this.excludeAudio = function() {
-    console.log("Excluding audio called");
       dropAudio = true;
     };
 

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -548,10 +548,15 @@ Transmuxer = function(options) {
     packetStream, parseStream, elementaryStream,
     adtsStream, h264Stream,
     videoSegmentStream, audioSegmentStream, captionStream,
-    coalesceStream;
+    coalesceStream,
+    exclude;
 
   Transmuxer.prototype.init.call(this);
   options = options || {};
+  if(options.exclude) {
+    exclude = options.exclude;
+  }
+
 
   this.baseMediaDecodeTime = options.baseMediaDecodeTime || 0;
 
@@ -568,6 +573,16 @@ Transmuxer = function(options) {
   h264Stream = new H264Stream();
   captionStream = new m2ts.CaptionStream();
   coalesceStream = new CoalesceStream(options);
+  this.on('excludeAudio', elementaryStream.excludeAudio.bind(elementaryStream));
+  this.on('excludeVideo', elementaryStream.excludeVideo.bind(elementaryStream));
+
+  if (exclude === 'audio'){
+    //do audio exclusion setup
+    elementaryStream.excludeAudio.bind(elementaryStream);
+  } else if (exclude ==='video') {
+    //do video exclusion setup
+    elementaryStream.excludeVideo.bind(elementaryStream);
+  }
 
   // disassemble MPEG2-TS packets into elementary streams
   packetStream
@@ -660,6 +675,14 @@ Transmuxer = function(options) {
       videoTrack.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
     }
   };
+
+  this.excludeAudioStream = function() {
+    this.trigger('excludeAudio');
+  };
+
+  this.excludeVideoStream = function() {
+    this.trigger('excludeVideo');
+  }
 
   // feed incoming data to the front of the parsing pipeline
   this.push = function(data) {

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -13,7 +13,7 @@
 var Stream = require('../utils/stream.js');
 var mp4 = require('./mp4-generator.js');
 var m2ts = require('../m2ts/m2ts.js');
-var AacStream = require('../codecs/aac.js');
+var AdtsStream = require('../codecs/adts.js');
 var H264Stream = require('../codecs/h264').H264Stream;
 
 // object types
@@ -29,8 +29,8 @@ var collectDtsInfo, clearDtsInfo, calculateTrackBaseMediaDecodeTime;
  */
 AudioSegmentStream = function(track) {
   var
-    aacFrames = [],
-    aacFramesLength = 0,
+    adtsFrames = [],
+    adtsFramesLength = 0,
     sequenceNumber = 0,
     earliestAllowedDts = 0;
 
@@ -48,8 +48,8 @@ AudioSegmentStream = function(track) {
     }
 
     // buffer audio data until end() is called
-    aacFrames.push(data);
-    aacFramesLength += data.data.byteLength;
+    adtsFrames.push(data);
+    adtsFramesLength += data.data.byteLength;
   };
 
   this.setEarliestDts = function (earliestDts) {
@@ -59,7 +59,7 @@ AudioSegmentStream = function(track) {
   this.flush = function() {
     var boxes, currentFrame, data, sample, i, mdat, moof;
     // return early if no audio data has been observed
-    if (aacFramesLength === 0) {
+    if (adtsFramesLength === 0) {
       this.trigger('done');
       return;
     }
@@ -71,7 +71,7 @@ AudioSegmentStream = function(track) {
       // We will need to recalculate the earliest segment Dts
       track.minSegmentDts = Infinity;
 
-      aacFrames = aacFrames.filter(function(currentFrame) {
+      adtsFrames = adtsFrames.filter(function(currentFrame) {
         // If this is an allowed frame, keep it and record it's Dts
         if (currentFrame.dts >= earliestAllowedDts) {
           track.minSegmentDts = Math.min(track.minSegmentDts, currentFrame.dts);
@@ -79,17 +79,17 @@ AudioSegmentStream = function(track) {
           return true;
         }
         // Otherwise, discard it
-        aacFramesLength -= currentFrame.data.byteLength;
+        adtsFramesLength -= currentFrame.data.byteLength;
         return false;
       });
     }
 
     // concatenate the audio data to constuct the mdat
-    data = new Uint8Array(aacFramesLength);
+    data = new Uint8Array(adtsFramesLength);
     track.samples = [];
     i = 0;
-    while (aacFrames.length) {
-      currentFrame = aacFrames[0];
+    while (adtsFrames.length) {
+      currentFrame = adtsFrames[0];
       sample = {
         size: currentFrame.data.byteLength,
         duration: 1024 // FIXME calculate for realz
@@ -99,9 +99,9 @@ AudioSegmentStream = function(track) {
       data.set(currentFrame.data, i);
       i += currentFrame.data.byteLength;
 
-      aacFrames.shift();
+      adtsFrames.shift();
     }
-    aacFramesLength = 0;
+    adtsFramesLength = 0;
     mdat = mp4.mdat(data);
 
     calculateTrackBaseMediaDecodeTime(track);
@@ -546,7 +546,7 @@ Transmuxer = function(options) {
     videoTrack,
     audioTrack,
     packetStream, parseStream, elementaryStream,
-    aacStream, h264Stream,
+    adtsStream, h264Stream,
     videoSegmentStream, audioSegmentStream, captionStream,
     coalesceStream;
 
@@ -564,7 +564,7 @@ Transmuxer = function(options) {
   packetStream = new m2ts.TransportPacketStream();
   parseStream = new m2ts.TransportParseStream();
   elementaryStream = new m2ts.ElementaryStream();
-  aacStream = new AacStream();
+  adtsStream = new AdtsStream();
   h264Stream = new H264Stream();
   captionStream = new m2ts.CaptionStream();
   coalesceStream = new CoalesceStream(options);
@@ -579,7 +579,7 @@ Transmuxer = function(options) {
   elementaryStream
     .pipe(h264Stream);
   elementaryStream
-    .pipe(aacStream);
+    .pipe(adtsStream);
 
   elementaryStream
     .pipe(this.metadataStream)
@@ -638,7 +638,7 @@ Transmuxer = function(options) {
         audioSegmentStream = new AudioSegmentStream(audioTrack);
 
         // Set up the final part of the audio pipeline
-        aacStream
+        adtsStream
           .pipe(audioSegmentStream)
           .pipe(coalesceStream);
       }

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -573,16 +573,22 @@ Transmuxer = function(options) {
   h264Stream = new H264Stream();
   captionStream = new m2ts.CaptionStream();
   coalesceStream = new CoalesceStream(options);
-  this.on('excludeAudio', elementaryStream.excludeAudio.bind(elementaryStream));
-  this.on('excludeVideo', elementaryStream.excludeVideo.bind(elementaryStream));
 
   if (exclude === 'audio'){
     //do audio exclusion setup
-    elementaryStream.excludeAudio.bind(elementaryStream);
+    elementaryStream.excludeAudio();
   } else if (exclude ==='video') {
     //do video exclusion setup
-    elementaryStream.excludeVideo.bind(elementaryStream);
+    elementaryStream.excludeVideo();
   }
+
+  this.on('excludeVideo', function() {
+    elementaryStream.excludeVideo();
+  });
+
+   this.on('excludeAudio', function() {
+    elementaryStream.excludeAudio();
+  });
 
   // disassemble MPEG2-TS packets into elementary streams
   packetStream

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -576,6 +576,7 @@ Transmuxer = function(options) {
 
   if (exclude === 'audio'){
     //do audio exclusion setup
+
     elementaryStream.excludeAudio();
   } else if (exclude ==='video') {
     //do video exclusion setup
@@ -599,6 +600,7 @@ Transmuxer = function(options) {
   // demux the streams
   elementaryStream
     .pipe(h264Stream);
+
   elementaryStream
     .pipe(adtsStream);
 
@@ -619,10 +621,10 @@ Transmuxer = function(options) {
 
       // scan the tracks listed in the metadata
       while (i--) {
-        if (!videoTrack && data.tracks[i].type === 'video') {
+        if (!videoTrack && data.tracks[i].type === 'video' && exclude !== 'video') {
           videoTrack = data.tracks[i];
           videoTrack.timelineStartInfo.baseMediaDecodeTime = self.baseMediaDecodeTime;
-        } else if (!audioTrack && data.tracks[i].type === 'audio') {
+        } else if (!audioTrack && data.tracks[i].type === 'audio' && exclude !== 'audio') {
           audioTrack = data.tracks[i];
           audioTrack.timelineStartInfo.baseMediaDecodeTime = self.baseMediaDecodeTime;
         }
@@ -688,7 +690,7 @@ Transmuxer = function(options) {
 
   this.excludeVideoStream = function() {
     this.trigger('excludeVideo');
-  }
+  };
 
   // feed incoming data to the front of the parsing pipeline
   this.push = function(data) {

--- a/test/transmuxer.test.js
+++ b/test/transmuxer.test.js
@@ -578,6 +578,88 @@ QUnit.test('parses metadata events from PSI packets', function() {
   }], 'identified two tracks');
 });
 
+QUnit.test('Transmuxer drops elementary audio stream on the fly', function() {
+  var audioCount = 0,
+    videoCount = 0;
+
+  elementaryStream.on('data', function(data) {
+    if (data.type === 'audio') {
+      audioCount += 1;
+    } else if(data.type === 'video') {
+      videoCount += 1;
+    }
+  });
+  elementaryStream.excludeAudio();
+
+  elementaryStream.push({
+    type: 'pes',
+    payloadUnitStartIndicator: true,
+    streamType: H264_STREAM_TYPE,
+    data: new Uint8Array(1)
+  });
+  elementaryStream.push({
+    type: 'pes',
+    payloadUnitStartIndicator: true,
+    streamType: ADTS_STREAM_TYPE,
+    data: new Uint8Array(1)
+  });
+  elementaryStream.push({
+    type: 'pes',
+    streamType: H264_STREAM_TYPE,
+    data: new Uint8Array(1)
+  });
+  elementaryStream.push({
+    type: 'pes',
+    streamType: ADTS_STREAM_TYPE,
+    data: new Uint8Array(1)
+  });
+  elementaryStream.flush();
+  QUnit.equal(audioCount, 0, 'Elemetary stream drops all outgoing audio events');
+  QUnit.equal(videoCount, 1, "Elemetary stream doesn't drop outgoing video events");
+
+});
+
+QUnit.test('Transmuxer drops elementary audio stream on the fly', function() {
+  var audioCount = 0,
+    videoCount = 0;
+
+  elementaryStream.on('data', function(data) {
+    if (data.type === 'audio') {
+      audioCount += 1;
+    } else if(data.type === 'video') {
+      videoCount += 1;
+    }
+  });
+  elementaryStream.excludeVideo();
+
+  elementaryStream.push({
+    type: 'pes',
+    payloadUnitStartIndicator: true,
+    streamType: H264_STREAM_TYPE,
+    data: new Uint8Array(1)
+  });
+  elementaryStream.push({
+    type: 'pes',
+    payloadUnitStartIndicator: true,
+    streamType: ADTS_STREAM_TYPE,
+    data: new Uint8Array(1)
+  });
+  elementaryStream.push({
+    type: 'pes',
+    streamType: H264_STREAM_TYPE,
+    data: new Uint8Array(1)
+  });
+  elementaryStream.push({
+    type: 'pes',
+    streamType: ADTS_STREAM_TYPE,
+    data: new Uint8Array(1)
+  });
+  elementaryStream.flush();
+  QUnit.equal(audioCount, 1, "Elemetary stream doesn't drop outgoing audio events");
+  QUnit.equal(videoCount, 0, 'Elemetary stream drops all outgoing video events');
+
+});
+
 QUnit.test('parses standalone program stream packets', function() {
   var
     packets = [],

--- a/test/transmuxer.test.js
+++ b/test/transmuxer.test.js
@@ -24,8 +24,8 @@ var
   AudioSegmentStream = mp4.AudioSegmentStream,
   audioSegmentStream,
 
-  AacStream = codecs.aac,
-  aacStream,
+  AdtsStream = codecs.adts,
+  adtsStream,
   Transmuxer = mp4.Transmuxer,
   FlvTransmuxer = flv.Transmuxer,
   transmuxer,
@@ -1546,18 +1546,18 @@ QUnit.test('subtract the first frame\'s compositionTimeOffset from baseMediaDeco
   QUnit.equal(tfdt.baseMediaDecodeTime, 130, 'calculated baseMediaDecodeTime');
 });
 
-QUnit.module('AAC Stream', {
+QUnit.module('ADTS Stream', {
   setup: function() {
-    aacStream = new AacStream();
+    adtsStream = new AdtsStream();
   }
 });
 
 QUnit.test('generates AAC frame events from ADTS bytes', function() {
   var frames = [];
-  aacStream.on('data', function(frame) {
+  adtsStream.on('data', function(frame) {
     frames.push(frame);
   });
-  aacStream.push({
+  adtsStream.push({
     type: 'audio',
     data: new Uint8Array([
       0xff, 0xf1,       // no CRC
@@ -1584,10 +1584,10 @@ QUnit.test('generates AAC frame events from ADTS bytes', function() {
 
 QUnit.test('parses across packets', function() {
   var frames = [];
-  aacStream.on('data', function(frame) {
+  adtsStream.on('data', function(frame) {
     frames.push(frame);
   });
-  aacStream.push({
+  adtsStream.push({
     type: 'audio',
     data: new Uint8Array([
       0xff, 0xf1,       // no CRC
@@ -1597,7 +1597,7 @@ QUnit.test('parses across packets', function() {
       0x12, 0x34        // AAC payload 1
     ])
   });
-  aacStream.push({
+  adtsStream.push({
     type: 'audio',
     data: new Uint8Array([
       0xff, 0xf1,       // no CRC
@@ -1617,10 +1617,10 @@ QUnit.test('parses across packets', function() {
 
 QUnit.test('parses frames segmented across packet', function() {
   var frames = [];
-  aacStream.on('data', function(frame) {
+  adtsStream.on('data', function(frame) {
     frames.push(frame);
   });
-  aacStream.push({
+  adtsStream.push({
     type: 'audio',
     data: new Uint8Array([
       0xff, 0xf1,       // no CRC
@@ -1630,7 +1630,7 @@ QUnit.test('parses frames segmented across packet', function() {
       0x12        // incomplete AAC payload 1
     ])
   });
-  aacStream.push({
+  adtsStream.push({
     type: 'audio',
     data: new Uint8Array([
       0x34,             // remainder of the previous frame's payload
@@ -1654,11 +1654,11 @@ QUnit.test('parses frames segmented across packet', function() {
 
 QUnit.test('resyncs data in aac frames that contain garbage', function() {
   var frames = [];
-  aacStream.on('data', function(frame) {
+  adtsStream.on('data', function(frame) {
     frames.push(frame);
   });
 
-  aacStream.push({
+  adtsStream.push({
     type: 'audio',
     data: new Uint8Array([
       0x67,             // garbage
@@ -1670,7 +1670,7 @@ QUnit.test('resyncs data in aac frames that contain garbage', function() {
       0xde, 0xf0        // extra junk that should be ignored
     ])
   });
-  aacStream.push({
+  adtsStream.push({
     type: 'audio',
     data: new Uint8Array([
       0x67,             // garbage
@@ -1693,10 +1693,10 @@ QUnit.test('resyncs data in aac frames that contain garbage', function() {
 
 QUnit.test('ignores audio "MPEG version" bit in adts header', function() {
   var frames = [];
-  aacStream.on('data', function(frame) {
+  adtsStream.on('data', function(frame) {
     frames.push(frame);
   });
-  aacStream.push({
+  adtsStream.push({
     type: 'audio',
     data: new Uint8Array([
       0xff, 0xf8,       // MPEG-2 audio, CRC
@@ -1716,10 +1716,10 @@ QUnit.test('ignores audio "MPEG version" bit in adts header', function() {
 
 QUnit.test('skips CRC bytes', function() {
   var frames = [];
-  aacStream.on('data', function(frame) {
+  adtsStream.on('data', function(frame) {
     frames.push(frame);
   });
-  aacStream.push({
+  adtsStream.push({
     type: 'audio',
     data: new Uint8Array([
       0xff, 0xf0,       // with CRC


### PR DESCRIPTION
These enhancements allows a user to drop either the video elementary stream or the audio elementary stream. I have added functions to the transmuxer to allow this to work on the fly. Tests are in progress, but I figured somebody could start looking at this. The initialization option format for the transmuxer is:
`(exclude:'audio') ` or `(exclude:'video')`