### PR TITLE
Eighth note support

### DIFF
--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -213,7 +213,8 @@ var BASIC_CHARACTER_TRANSLATION = {
   0x7c: 0xf7,
   0x7d: 0xd1,
   0x7e: 0xf1,
-  0x7f: 0x2588
+  0x7f: 0x2588,
+
 };
 
 // Constants for the byte codes recognized by Cea608Stream. This
@@ -236,6 +237,7 @@ var PADDING                    = 0x0000,
     BACKSPACE                  = 0x1421,
     ERASE_DISPLAYED_MEMORY     = 0x142c,
     ERASE_NON_DISPLAYED_MEMORY = 0x142e;
+
 
 // the index of the last row in a CEA-608 display buffer
 var BOTTOM_ROW = 14;
@@ -342,6 +344,14 @@ var Cea608Stream = function() {
           (char0 !== 0x10 || char1 < 0x60)) {
         // Follow Safari's lead and replace the PAC with a space
         char0 = char1 = 0x20;
+      }
+
+      // Look for special character sets
+      if ((char0 === 0x11 || char0 === 0x19) &&
+          (char1 >= 0x30 && char1 <= 0x3F)) {
+        // Put in eigth note and space
+        char0 = 0xE299AA;
+        char1 = 0x20;
       }
 
       // ignore unsupported control codes

--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -214,7 +214,6 @@ var BASIC_CHARACTER_TRANSLATION = {
   0x7d: 0xd1,
   0x7e: 0xf1,
   0x7f: 0x2588,
-
 };
 
 // Constants for the byte codes recognized by Cea608Stream. This
@@ -237,7 +236,6 @@ var PADDING                    = 0x0000,
     BACKSPACE                  = 0x1421,
     ERASE_DISPLAYED_MEMORY     = 0x142c,
     ERASE_NON_DISPLAYED_MEMORY = 0x142e;
-
 
 // the index of the last row in a CEA-608 display buffer
 var BOTTOM_ROW = 14;

--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -213,7 +213,7 @@ var BASIC_CHARACTER_TRANSLATION = {
   0x7c: 0xf7,
   0x7d: 0xd1,
   0x7e: 0xf1,
-  0x7f: 0x2588,
+  0x7f: 0x2588
 };
 
 // Constants for the byte codes recognized by Cea608Stream. This
@@ -349,7 +349,7 @@ var Cea608Stream = function() {
           (char1 >= 0x30 && char1 <= 0x3F)) {
         // Put in eigth note and space
         char0 = 0xE299AA;
-        char1 = 0x20;
+        char1 = '';
       }
 
       // ignore unsupported control codes


### PR DESCRIPTION
This patch supports the use of the eighth note special character in basic 608 captions. 