### PR TITLE
Add channel test and fix flash

### DIFF
--- a/lib/flv/transmuxer.js
+++ b/lib/flv/transmuxer.js
@@ -194,20 +194,21 @@ VideoSegmentStream = function(track) {
   VideoSegmentStream.prototype.init.call(this);
 
   this.finishFrame = function(tags, frame) {
-    if (frame) {
-      // Check if keyframe and the length of tags.
-      // This makes sure we write metadata on the first frame of a segment.
-      if (track.newMetadata &&
-          (frame.keyFrame || tags.length === 0)) {
-        // Push extra data on every IDR frame in case we did a stream change + seek
-        tags.push(metaDataTag(config, frame.pts));
-        tags.push(extraDataTag(track, frame.pts));
-        track.newMetadata = false;
-      }
-
-      frame.endNalUnit();
-      tags.push(frame);
+    if (!frame) {
+      return;
     }
+    // Check if keyframe and the length of tags.
+    // This makes sure we write metadata on the first frame of a segment.
+    if (config && track && track.newMetadata &&
+        (frame.keyFrame || tags.length === 0)) {
+      // Push extra data on every IDR frame in case we did a stream change + seek
+      tags.push(metaDataTag(config, frame.pts));
+      tags.push(extraDataTag(track, frame.pts));
+      track.newMetadata = false;
+    }
+
+    frame.endNalUnit();
+    tags.push(frame);
   };
 
   this.push = function(data) {

--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -217,7 +217,7 @@ var BASIC_CHARACTER_TRANSLATION = {
 };
 
 var getCharFromCode = function(code) {
-  if(!code) {
+  if(code === null) {
     return '';
   }
   code = BASIC_CHARACTER_TRANSLATION[code] || code;

--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -264,6 +264,10 @@ var Cea608Stream = function() {
   this.lastControlCode_ = null;
 
   this.push = function(packet) {
+    // Ignore other channels
+    if (packet['type'] !== 0) {
+      return;
+    }
     var data, swap, char0, char1;
     // remove the parity bits
     data = packet.ccData & 0x7f7f;

--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -216,6 +216,14 @@ var BASIC_CHARACTER_TRANSLATION = {
   0x7f: 0x2588
 };
 
+var getCharFromCode = function(code) {
+  if(!code) {
+    return '';
+  }
+  code = BASIC_CHARACTER_TRANSLATION[code] || code;
+  return String.fromCharCode(code);
+};
+
 // Constants for the byte codes recognized by Cea608Stream. This
 // list is not exhaustive. For a more comprehensive listing and
 // semantics see
@@ -345,7 +353,10 @@ var Cea608Stream = function() {
           char1 >= 0x40 && char1 <= 0x7F &&
           (char0 !== 0x10 || char1 < 0x60)) {
         // Follow Safari's lead and replace the PAC with a space
-        char0 = char1 = 0x20;
+        char0 = 0x20;
+        // we only want one space so make the second character null
+        // which will get become '' in getCharFromCode
+        char1 = null;
       }
 
       // ignore unsupported control codes
@@ -371,7 +382,8 @@ Cea608Stream.prototype.flushDisplayed = function(pts) {
       this.trigger('data', {
         startPts: this.startPts_,
         endPts: pts,
-        text: row
+        // remove spaces from the start and end of the string
+        text: row.trim()
       });
     }
   }
@@ -382,13 +394,11 @@ Cea608Stream.prototype.popOn = function(pts, char0, char1) {
   var baseRow = this.nonDisplayed_[BOTTOM_ROW];
 
   // buffer characters
-  char0 = BASIC_CHARACTER_TRANSLATION[char0] || char0;
-  baseRow += String.fromCharCode(char0);
-
-  char1 = BASIC_CHARACTER_TRANSLATION[char1] || char1;
-  baseRow += String.fromCharCode(char1);
+  baseRow += getCharFromCode(char0);
+  baseRow += getCharFromCode(char1);
   this.nonDisplayed_[BOTTOM_ROW] = baseRow;
 };
+
 Cea608Stream.prototype.rollUp = function(pts, char0, char1) {
   var baseRow = this.displayed_[BOTTOM_ROW];
   if (baseRow === '') {
@@ -399,11 +409,9 @@ Cea608Stream.prototype.rollUp = function(pts, char0, char1) {
     this.startPts_ = pts;
   }
 
-  char0 = BASIC_CHARACTER_TRANSLATION[char0] || char0;
-  baseRow += String.fromCharCode(char0);
+  baseRow += getCharFromCode(char0);
+  baseRow += getCharFromCode(char1);
 
-  char1 = BASIC_CHARACTER_TRANSLATION[char1] || char1;
-  baseRow += String.fromCharCode(char1);
   this.displayed_[BOTTOM_ROW] = baseRow;
 };
 Cea608Stream.prototype.shiftRowsUp_ = function() {

--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -265,7 +265,7 @@ var Cea608Stream = function() {
 
   this.push = function(packet) {
     // Ignore other channels
-    if (packet['type'] !== 0) {
+    if (packet.type !== 0) {
       return;
     }
     var data, swap, char0, char1;

--- a/test/caption-stream.test.js
+++ b/test/caption-stream.test.js
@@ -741,27 +741,17 @@ QUnit.skip('paint-on display mode', function() {
 });
 
 QUnit.test('segment with multiple caption channels, we only parse 0', function() {
-  var transmuxer = new mp4.Transmuxer(),
-      captions = [];
-
-  // Setting the BMDT to ensure that captions and id3 tags are not
-  // time-shifted by this value when they are output and instead are
-  // zero-based
-  transmuxer.setBaseMediaDecodeTime(100000);
-
-  transmuxer.on('data', function(data) {
-    if (data.captions) {
-      captions = captions.concat(data.captions);
-    }
+  var captions = [];
+  cea608Stream.on('data', function(caption) {
+    captions.push(caption);
   });
 
-  transmuxer.push(multichannelCaptions);
-  transmuxer.flush();
+  multichannelCaptions.forEach(cea608Stream.push, cea608Stream);
 
   QUnit.equal(captions.length, 3, 'parsed three captions');
   QUnit.equal(captions[0].text, 'BUT IT\'S NOT SUFFERING RIGHW.', 'parsed first caption correctly');
-  QUnit.equal(captions[1].text, 'IT\'S NOT A THREAT TO ANYBODY.', 'parsed second caption correctly');
+  // there is also bad data in the captions, so we end up with a null ascii character here
+  QUnit.equal(captions[1].text, 'IT\'S NOT A THREAT TO ANYBODY.' + String.fromCharCode(0x00), 'parsed second caption correctly');
   QUnit.equal(captions[2].text, 'WE TRY NOT TO PUT AN ANIMAL DOWN IF WE DON\'T HAVE TO.', 'parsed second caption correctly');
 });
-
 

--- a/test/caption-stream.test.js
+++ b/test/caption-stream.test.js
@@ -182,19 +182,19 @@ QUnit.test('converts non-standard character codes to ASCII', function() {
   var packets, captions;
   packets = [
     // RCL, resume caption loading
-    { ccData: 0x1420 },
+    { ccData: 0x1420, type:0 },
     // ASCII exceptions
-    { ccData: 0x2a5c },
-    { ccData: 0x5e5f },
-    { ccData: 0x607b },
-    { ccData: 0x7c7d },
-    { ccData: 0x7e7f },
+    { ccData: 0x2a5c, type:0 },
+    { ccData: 0x5e5f, type:0 },
+    { ccData: 0x607b, type:0 },
+    { ccData: 0x7c7d, type:0 },
+    { ccData: 0x7e7f, type:0 },
     // EOC, End of Caption
-    { pts: 1000, ccData: 0x142f },
+    { pts: 1000, ccData: 0x142f, type:0 },
     // Send another command so that the second EOC isn't ignored
-    { ccData: 0x1420 },
+    { ccData: 0x1420, type:0 },
     // EOC, End of Caption, clear the display
-    { pts: 10 * 1000, ccData: 0x142f }
+    { pts: 10 * 1000, ccData: 0x142f, type:0 }
   ];
   captions = [];
   cea608Stream.on('data', function(caption) {
@@ -212,15 +212,15 @@ QUnit.test('pop-on mode', function() {
   var packets, captions;
   packets = [
     // RCL, resume caption loading
-    { ccData: 0x1420 },
+    { ccData: 0x1420, type:0 },
     // 'hi'
-    { ccData: characters('hi') },
+    { ccData: characters('hi'), type:0 },
     // EOC, End of Caption. Finished transmitting, begin display
-    { pts: 1000, ccData: 0x142f },
+    { pts: 1000, ccData: 0x142f, type:0 },
     // Send another command so that the second EOC isn't ignored
-    { ccData: 0x1420 },
+    { ccData: 0x1420, type:0 },
     // EOC, End of Caption. End display
-    { pts: 10 * 1000, ccData: 0x142f }
+    { pts: 10 * 1000, ccData: 0x142f, type:0 }
   ];
   captions = [];
 
@@ -242,25 +242,25 @@ QUnit.test('recognizes the Erase Displayed Memory command', function() {
   var packets, captions;
   packets = [
     // RCL, resume caption loading
-    { ccData: 0x1420 },
+    { ccData: 0x1420, type:0 },
     // '01'
-    { ccData: characters('01') },
+    { ccData: characters('01'), type:0 },
     // EOC, End of Caption. Finished transmitting, display '01'
-    { pts: 1 * 1000, ccData: 0x142f },
+    { pts: 1 * 1000, ccData: 0x142f, type:0 },
     // EDM, Erase Displayed Memory
-    { pts: 1.5 * 1000, ccData: 0x142c },
+    { pts: 1.5 * 1000, ccData: 0x142c, type:0 },
     // '23'
-    { ccData: characters('23') },
+    { ccData: characters('23'), type:0 },
     // EOC, End of Caption. Display '23'
-    { pts: 2 * 1000, ccData: 0x142f },
+    { pts: 2 * 1000, ccData: 0x142f, type:0 },
     // '34'
-    { ccData: characters('34') },
+    { ccData: characters('34'), type:0 },
     // EOC, End of Caption. Display '34'
-    { pts: 3 * 1000, ccData: 0x142f },
+    { pts: 3 * 1000, ccData: 0x142f, type:0 },
     // Send another command so that the second EOC isn't ignored
-    { ccData: 0x1420 },
+    { ccData: 0x1420 , type:0},
     // EOC, End of Caption
-    { pts: 4 * 1000, ccData: 0x142f }
+    { pts: 4 * 1000, ccData: 0x142f, type:0 }
   ];
   captions = [];
 
@@ -296,18 +296,18 @@ QUnit.test('backspaces are applied to non-displayed memory', function() {
 
   packets = [
     // RCL, resume caption loading
-    { ccData: 0x1420 },
+    { ccData: 0x1420, type:0 },
     // '01'
-    { ccData: characters('01') },
+    { ccData: characters('01'), type:0 },
     // backspace
-    { ccData: 0x1421 },
-    { ccData: characters('23') },
+    { ccData: 0x1421, type:0 },
+    { ccData: characters('23'), type:0 },
     // EOC, End of Caption
-    { pts: 1 * 1000, ccData: 0x142f },
+    { pts: 1 * 1000, ccData: 0x142f, type:0 },
     // Send another command so that the second EOC isn't ignored
-    { ccData: 0x1420 },
+    { ccData: 0x1420, type:0 },
     // EOC, End of Caption
-    { pts: 3 * 1000, ccData: 0x142f }
+    { pts: 3 * 1000, ccData: 0x142f, type:0 }
   ];
 
   packets.forEach(cea608Stream.push, cea608Stream);
@@ -339,18 +339,18 @@ QUnit.test('recognizes the Erase Non-Displayed Memory command', function() {
   var packets, captions;
   packets = [
     // RCL, resume caption loading
-    { ccData: 0x1420 },
+    { ccData: 0x1420, type:0 },
     // '01'
-    { ccData: characters('01') },
+    { ccData: characters('01'), type:0 },
     // ENM, Erase Non-Displayed Memory
-    { ccData: 0x142e },
-    { ccData: characters('23') },
+    { ccData: 0x142e, type:0 },
+    { ccData: characters('23'), type:0 },
     // EOC, End of Caption. Finished transmitting, display '23'
-    { pts: 1 * 1000, ccData: 0x142f },
+    { pts: 1 * 1000, ccData: 0x142f, type:0 },
     // Send another command so that the second EOC isn't ignored
-    { ccData: 0x1420 },
+    { ccData: 0x1420, type:0 },
     // EOC, End of Caption
-    { pts: 2 * 1000, ccData: 0x142f }
+    { pts: 2 * 1000, ccData: 0x142f, type:0 }
   ];
   captions = [];
 
@@ -374,17 +374,17 @@ QUnit.test('ignores unrecognized commands', function() {
   var packets, captions;
   packets = [
     // RCL, resume caption loading
-    { ccData: 0x1420 },
+    { ccData: 0x1420, type:0 },
     // a row-9 indent 28 underline, which is not supported
-    { ccData: 0x1f7f },
+    { ccData: 0x1f7f, type:0 },
     // '01'
-    { ccData: characters('01') },
+    { ccData: characters('01'), type:0 },
     // EOC, End of Caption
-    { pts: 1 * 1000, ccData: 0x142f },
+    { pts: 1 * 1000, ccData: 0x142f, type:0 },
     // Send another command so that the second EOC isn't ignored
-    { ccData: 0x1420 },
+    { ccData: 0x1420, type:0 },
     // EOC, End of Caption
-    { pts: 2 * 1000, ccData: 0x142f }
+    { pts: 2 * 1000, ccData: 0x142f, type:0 }
   ];
   captions = [];
   cea608Stream.on('data', function(caption) {
@@ -407,14 +407,15 @@ QUnit.test('roll-up display mode', function() {
   });
 
   [ // RU2, roll-up captions 2 rows
-    { ccData: 0x1425 },
+    { ccData: 0x1425 , type:0},
     // '01'
     {
       pts: 1 * 1000,
-      ccData: characters('01')
+      ccData: characters('01'),
+      type:0
     },
     // CR, carriage return
-    { pts: 3 * 1000, ccData: 0x142d }
+    { pts: 3 * 1000, ccData: 0x142d, type:0 }
   ].forEach(cea608Stream.push, cea608Stream);
 
   QUnit.equal(captions.length, 1, 'detected one caption');
@@ -426,14 +427,15 @@ QUnit.test('roll-up display mode', function() {
   captions = [];
 
   [ // RU4, roll-up captions 4 rows
-    { ccdata: 0x1427 },
+    { ccdata: 0x1427, type:0 },
     // '23'
     {
       pts: 4 * 1000,
-      ccData: characters('23')
+      ccData: characters('23'),
+      type:0
     },
     // CR
-    { pts: 5 * 1000, ccData: 0x142d }
+    { pts: 5 * 1000, ccData: 0x142d, type:0 }
   ].forEach(cea608Stream.push, cea608Stream);
 
   QUnit.equal(captions.length, 3, 'detected another caption');
@@ -461,14 +463,15 @@ QUnit.test('roll-up displays multiple rows simultaneously', function() {
   });
 
   [ // RU2, roll-up captions 2 rows
-    { ccData: 0x1425 },
+    { ccData: 0x1425, type:0 },
     // '01'
     {
       pts: 0 * 1000,
-      ccData: characters('01')
+      ccData: characters('01'),
+      type:0
     },
     // CR, carriage return
-    { pts: 1 * 1000, ccData: 0x142d }
+    { pts: 1 * 1000, ccData: 0x142d, type:0 }
   ].forEach(cea608Stream.push, cea608Stream);
 
   QUnit.equal(captions.length, 1, 'detected a caption');
@@ -482,10 +485,11 @@ QUnit.test('roll-up displays multiple rows simultaneously', function() {
   [ // '23'
     {
       pts: 2 * 1000,
-      ccData: characters('23')
+      ccData: characters('23'),
+      type:0
     },
     // CR, carriage return
-    { pts: 3 * 1000, ccData: 0x142d }
+    { pts: 3 * 1000, ccData: 0x142d, type:0 }
   ].forEach(cea608Stream.push, cea608Stream);
 
   QUnit.equal(captions.length, 3, 'detected three captions');
@@ -509,10 +513,11 @@ QUnit.test('roll-up displays multiple rows simultaneously', function() {
   [ // '45'
     {
       pts: 4 * 1000,
-      ccData: characters('45')
+      ccData: characters('45'),
+      type:0
     },
     // CR, carriage return
-    { pts: 5 * 1000, ccData: 0x142d }
+    { pts: 5 * 1000, ccData: 0x142d, type:0 }
   ].forEach(cea608Stream.push, cea608Stream);
 
   QUnit.equal(captions.length, 3, 'detected three captions');
@@ -540,38 +545,39 @@ QUnit.test('the roll-up count can be changed on-the-fly', function() {
   });
 
   [ // RU2, roll-up captions 2 rows
-    { ccData: 0x1425 },
+    { ccData: 0x1425, type:0 },
     // '01'
     {
       pts: 0 * 1000,
-      ccData: characters('01')
+      ccData: characters('01'),
+      type:0
     },
     // CR, carriage return
-    { pts: 1 * 1000, ccData: 0x142d }
+    { pts: 1 * 1000, ccData: 0x142d, type:0 }
   ].forEach(cea608Stream.push, cea608Stream);
 
   captions = [];
 
   [ // RU3, roll-up captions 3 rows
-    { ccData: 0x1426 },
+    { ccData: 0x1426, type:0 },
     // CR, carriage return
-    { pts: 2 * 1000, ccData: 0x142d }
+    { pts: 2 * 1000, ccData: 0x142d, type:0 }
   ].forEach(cea608Stream.push, cea608Stream);
 
   QUnit.equal(captions.length, 1, 'still displaying a caption');
   captions = [];
 
   [ // RU4, roll-up captions 4 rows
-    { ccData: 0x1427 },
+    { ccData: 0x1427, type:0 },
     // CR, carriage return
-    { pts: 3 * 1000, ccData: 0x142d }
+    { pts: 3 * 1000, ccData: 0x142d, type:0 }
   ].forEach(cea608Stream.push, cea608Stream);
 
   QUnit.equal(captions.length, 1, 'still displaying a caption');
   captions = [];
 
   // RU3, roll-up captions 3 rows
-  cea608Stream.push({ ccdata: 0x1426 });
+  cea608Stream.push({ ccdata: 0x1426, type:0 });
   QUnit.equal(captions.length, 0, 'cleared the caption');
 });
 
@@ -582,20 +588,22 @@ QUnit.test('backspaces are reflected in the generated captions', function() {
   });
 
   [ // RU2, roll-up captions 2 rows
-    { ccData: 0x1425 },
+    { ccData: 0x1425, type:0 },
     // '01'
     {
       pts: 0 * 1000,
-      ccData: characters('01')
+      ccData: characters('01'),
+      type:0
     },
     // backspace
-    { ccData: 0x1421 },
+    { ccData: 0x1421, type:0 },
     {
       pts: 1 * 1000,
-      ccData: characters('23')
+      ccData: characters('23'),
+      type:0
     },
     // CR, carriage return
-    { pts: 1 * 1000, ccData: 0x142d }
+    { pts: 1 * 1000, ccData: 0x142d, type:0 }
   ].forEach(cea608Stream.push, cea608Stream);
 
   QUnit.equal(captions.length, 1, 'detected a caption');
@@ -609,21 +617,22 @@ QUnit.test('backspaces can remove a caption entirely', function() {
   });
 
   [ // RU2, roll-up captions 2 rows
-    { ccData: 0x1425 },
+    { ccData: 0x1425, type:0 },
     // '01'
     {
       pts: 0 * 1000,
-      ccData: characters('01')
+      ccData: characters('01'),
+      type:0
     },
     // backspace
-    { ccData: 0x1421 },
+    { ccData: 0x1421, type:0 },
     // Send another command so that the backspace isn't
     // ignored as a duplicate command
-    { ccData: 0x1425 },
+    { ccData: 0x1425, type:0 },
     // backspace
-    { ccData: 0x1421 },
+    { ccData: 0x1421, type:0 },
     // CR, carriage return
-    { pts: 1 * 1000, ccData: 0x142d }
+    { pts: 1 * 1000, ccData: 0x142d, type:0 }
   ].forEach(cea608Stream.push, cea608Stream);
 
   QUnit.equal(captions.length, 0, 'no caption emitted');
@@ -636,25 +645,27 @@ QUnit.test('a second identical control code immediately following the first is i
   });
 
   [ // RU2, roll-up captions 2 rows
-    { ccData: 0x1425 },
+    { ccData: 0x1425, type:0 },
     // '01'
     {
       pts: 0 * 1000,
-      ccData: characters('01')
+      ccData: characters('01'),
+      type:0
     },
     // '02'
     {
       pts: 1 * 1000,
-      ccData: characters('02')
+      ccData: characters('02'),
+      type:0
     },
     // backspace
-    { ccData: 0x1421 },
+    { ccData: 0x1421, type:0 },
     // backspace
-    { ccData: 0x1421 }, // duplicate is ignored
+    { ccData: 0x1421, type:0 }, // duplicate is ignored
     // backspace
-    { ccData: 0x1421 },
+    { ccData: 0x1421, type:0 },
     // CR, carriage return
-    { pts: 2 * 1000, ccData: 0x142d }
+    { pts: 2 * 1000, ccData: 0x142d, type:0 }
   ].forEach(cea608Stream.push, cea608Stream);
 
   QUnit.equal(captions.length, 1, 'caption emitted');
@@ -668,21 +679,23 @@ QUnit.test('preable address codes are converted into spaces', function() {
   });
 
   [ // RU2, roll-up captions 2 rows
-    { ccData: 0x1425 },
+    { ccData: 0x1425, type:0 },
     // '01'
     {
       pts: 0 * 1000,
-      ccData: characters('01')
+      ccData: characters('01'),
+      type:0
     },
     // PAC: row 15, indent 0
-    { ccData: 0x1470 },
+    { ccData: 0x1470, type:0 },
     // '02'
     {
       pts: 1 * 1000,
-      ccData: characters('02')
+      ccData: characters('02'),
+      type:0
     },
     // CR, carriage return
-    { pts: 2 * 1000, ccData: 0x142d }
+    { pts: 2 * 1000, ccData: 0x142d, type:0 }
   ].forEach(cea608Stream.push, cea608Stream);
 
   QUnit.equal(captions.length, 1, 'caption emitted');
@@ -696,26 +709,27 @@ QUnit.test('backspaces stop at the beginning of the line', function() {
   });
 
   [ // RU2, roll-up captions 2 rows
-    { ccData: 0x1425 },
+    { ccData: 0x1425, type:0 },
     // '01'
     {
       pts: 0 * 1000,
-      ccData: characters('01')
+      ccData: characters('01'),
+      type:0
     },
     // backspace
-    { ccData: 0x1421 },
+    { ccData: 0x1421, type:0 },
     // Send another command so that the backspace isn't
     // ignored as a duplicate command
-    { ccData: 0x1425 },
+    { ccData: 0x1425, type:0 },
     // backspace
-    { ccData: 0x1421 },
+    { ccData: 0x1421, type:0 },
     // Send another command so that the backspace isn't
     // ignored as a duplicate command
-    { ccData: 0x1425 },
+    { ccData: 0x1425, type:0 },
     // backspace
-    { ccData: 0x1421 },
+    { ccData: 0x1421, type:0 },
     // CR, carriage return
-    { pts: 1 * 1000, ccData: 0x142d }
+    { pts: 1 * 1000, ccData: 0x142d, type:0 }
   ].forEach(cea608Stream.push, cea608Stream);
 
   QUnit.equal(captions.length, 0, 'no caption emitted');


### PR DESCRIPTION
* added a getCharCode function to put the code in a central location
* only insert one space for codes that we don't support
* trim spaces before and after a row of captions before we emit
* ignore caption channels other than channel one
* updated tests to use a channel (previously non-existent)
* Added a test to decode multi channel captions (we only do the first channel)
* Verify that config and track are defined when we go to finish an FLV video frame