### PR TITLE
Drop elementary streams

### DIFF
--- a/debug/index.html
+++ b/debug/index.html
@@ -69,6 +69,10 @@ mp4fragment --track audio --fragment-duration 11000 movie-audio.mp4 movie-audio.
               <div>
                 <label><input id="combined-output" type=checkbox name=combined checked value="combined">&nbsp;Remux output into a single output?
                 </label>
+                <label><input id="drop-audio" type=checkbox name=combined value="drop-audio">&nbsp;Drop audio elementary stream?
+                 </label>
+                 <label><input id="drop-video" type=checkbox name=combined value="drop-audio">&nbsp;Drop video elementary stream?
+                 </label>
               </div>
               <div>
                 Otherwise, output only:&nbsp;
@@ -284,23 +288,42 @@ mp4fragment --track audio --fragment-duration 11000 movie-audio.mp4 movie-audio.
       }
 
       reader.addEventListener('loadend', function() {
+        var
+          segment = new Uint8Array(reader.result),
+          combined = $('#combined-output').checked,
+          dropAudio = document.querySelector('#drop-audio').checked,
+          dropVideo = document.querySelector('#drop-video').checked,
+          outputType = $('input[name="output"]:checked').value,
+          remuxedSegments = [],
+          remuxedBytesLength = 0,
+          bytes,
+          i,
+          j,
+          resetTransmuxer = $('#reset-tranmsuxer').checked;
 
-        var segment = new Uint8Array(reader.result),
-            combined = document.querySelector('#combined-output').checked,
-            outputType = document.querySelector('input[name="output"]:checked').value,
-            transmuxer,
-            remuxedSegments = [],
-            remuxedBytesLength = 0,
-            bytes,
-            i, j;
-        if ((/\.aac$/i).test(original.value)) {
-          transmuxer = new muxjs.mp4.Transmuxer({remux: false, aacfile: true});
-          outputType = 'audio';
-        } else if (combined) {
-            transmuxer = new muxjs.mp4.Transmuxer();
-        } else {
-            transmuxer = new muxjs.mp4.Transmuxer({remux: false});
-        }
+        if (resetTransmuxer || !window.transmuxer){
+          if (combined) {
+              if (dropAudio) {
+
+             window.transmuxer = new muxjs.mp4.Transmuxer();
+             window.transmuxer.emitAudioStream(false);
+           } else if(dropVideo) {
+             window.transmuxer = new muxjs.mp4.Transmuxer();
+             window.transmuxer.emitVideoStream(false);
+           } else {
+              window.transmuxer = new muxjs.mp4.Transmuxer();
+           }
+          } else {
+              window.transmuxer = new muxjs.mp4.Transmuxer({remux: false});
+          }
+
+          // transmux the MPEG-TS data to BMFF segments
+          transmuxer.on('data', function(segment) {
+            if (combined || segment.type === outputType) {
+              remuxedSegments.push(segment);
+              remuxedBytesLength += segment.data.byteLength;
+            }
+          });
 
           transmuxer.on('done', function () {
             bytes = new Uint8Array(remuxedBytesLength);

--- a/lib/m2ts/m2ts.js
+++ b/lib/m2ts/m2ts.js
@@ -257,18 +257,6 @@ TransportParseStream.STREAM_TYPES  = {
 ElementaryStream = function() {
   var
     // PES packet fragments
-    video = {
-      data: [],
-      size: 0
-    },
-    audio = {
-      data: [],
-      size: 0
-    },
-    timedMetadata = {
-      data: [],
-      size: 0
-    },
     parsePes = function(payload, pes) {
       var ptsDtsFlags;
 
@@ -323,7 +311,10 @@ ElementaryStream = function() {
         },
         i = 0,
         fragment;
-
+      if (!stream.enabled) {
+        stream.data = [];
+        return;
+      }
       // do nothing if there is no buffered data
       if (!stream.data.length) {
         return;
@@ -346,6 +337,21 @@ ElementaryStream = function() {
       self.trigger('data', event);
     },
     self;
+  this.video = {
+    data: [],
+    size: 0,
+    enabled: true
+  };
+  this.audio = {
+    data: [],
+    size: 0,
+    enabled: true
+  };
+  this.timedMetadata = {
+    data: [],
+    size: 0,
+    enabled: true
+  };
 
   ElementaryStream.prototype.init.call(this);
   self = this;
@@ -362,15 +368,15 @@ ElementaryStream = function() {
         switch (data.streamType) {
         case StreamTypes.H264_STREAM_TYPE:
         case m2tsStreamTypes.H264_STREAM_TYPE:
-          stream = video;
+          stream = self.video;
           streamType = 'video';
           break;
         case StreamTypes.ADTS_STREAM_TYPE:
-          stream = audio;
+          stream = self.audio;
           streamType = 'audio';
           break;
         case StreamTypes.METADATA_STREAM_TYPE:
-          stream = timedMetadata;
+          stream = self.timedMetadata;
           streamType = 'timed-metadata';
           break;
         default:
@@ -423,6 +429,14 @@ ElementaryStream = function() {
     })[data.type]();
   };
 
+  this.excludeVideo = function() {
+    self.video.enabled = false;
+  };
+
+  this.excludeAudio = function() {
+    self.audio.enabled = false;
+  };
+
   /**
    * Flush any remaining input. Video PES packets may be of variable
    * length. Normally, the start of a new video packet can trigger the
@@ -435,9 +449,9 @@ ElementaryStream = function() {
   this.flush = function() {
     // !!THIS ORDER IS IMPORTANT!!
     // video first then audio
-    flushStream(video, 'video');
-    flushStream(audio, 'audio');
-    flushStream(timedMetadata, 'timed-metadata');
+    flushStream(self.video, 'video');
+    flushStream(self.audio, 'audio');
+    flushStream(self.timedMetadata, 'timed-metadata');
     this.trigger('done');
   };
 };

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -644,10 +644,10 @@ Transmuxer = function(options) {
 
         // scan the tracks listed in the metadata
         while (i--) {
-          if (!videoTrack && data.tracks[i].type === 'video') {
+          if (!videoTrack && data.tracks[i].type === 'video' && elementaryStream.video.enabled) {
             videoTrack = data.tracks[i];
             videoTrack.timelineStartInfo.baseMediaDecodeTime = self.baseMediaDecodeTime;
-          } else if (!audioTrack && data.tracks[i].type === 'audio') {
+          } else if (!audioTrack && data.tracks[i].type === 'audio' && elementaryStream.audio.enabled) {
             audioTrack = data.tracks[i];
             audioTrack.timelineStartInfo.baseMediaDecodeTime = self.baseMediaDecodeTime;
           }
@@ -691,8 +691,31 @@ Transmuxer = function(options) {
       }
     });
   };
+
+  this.emitAudioStream = function (emit) {
+    if (emit === undefined) {
+      return elementaryStream.audio.enabled;
+    }
+    elementaryStream.audio.enabled = emit;
+  };
+
+  this.emitVideoStream = function (emit) {
+    if (emit === undefined) {
+      return elementaryStream.video.enabled;
+    }
+    elementaryStream.video.enabled = emit;
+  };
+
+  this.emitMetadataStream = function (emit) {
+    if (emit === undefined) {
+      return elementaryStream.timedMetadata.enabled;
+    }
+    elementaryStream.timedMetadata.enabled = emit;
+  };
+
   Transmuxer.prototype.init.call(this);
   options = options || {};
+
 
   this.baseMediaDecodeTime = options.baseMediaDecodeTime || 0;
 


### PR DESCRIPTION
These enhancements allows a user to drop either the video elementary stream or the audio elementary stream. I have added functions to the transmuxer to allow this to work on the fly. Tests are in progress, but I figured somebody could start looking at this. The initialization option format for the transmuxer is:
(exclude:'audio') or (exclude:'video')