### PR TITLE
If Uint8Array is undefined (IE8) don't set up MP4 generator functions

### DIFF
--- a/lib/mp4/mp4-generator.js
+++ b/lib/mp4/mp4-generator.js
@@ -55,6 +55,12 @@ var box, dinf, esds, ftyp, mdat, mfhd, minf, moof, moov, mvex, mvhd, trak,
     vmhd: []
   };
 
+  // In environments where Uint8Array is undefined (e.g., IE8), skip set up so that we
+  // don't throw an error
+  if (typeof Uint8Array === 'undefined') {
+    return;
+  }
+
   for (i in types) {
     if (types.hasOwnProperty(i)) {
       types[i] = [


### PR DESCRIPTION
Tested by ensuring that "'Uint8Array' is undefined" error is no longer being thrown in IE8, however, due to other errors, was not able to test full flow through with IE8.