### PR TITLE
Use the correct unicode for the eighth note character

### DIFF
--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -363,7 +363,7 @@ var Cea608Stream = function() {
       if ((char0 === 0x11 || char0 === 0x19) &&
           (char1 >= 0x30 && char1 <= 0x3F)) {
         // Put in eigth note and space
-        char0 = 0xE299AA;
+        char0 = 0x266A;
         char1 = '';
       }
 


### PR DESCRIPTION
We were displaying some other glyph instead of the eighth-note when we detected a musical-note character in the CC stream. 