### PR TITLE
Have the transmuxer pipeline automatically configure itself based on input

### DIFF
--- a/debug/index.html
+++ b/debug/index.html
@@ -62,7 +62,7 @@ mp4fragment --track audio --fragment-duration 11000 movie-audio.mp4 movie-audio.
               <div>
                 <input id="original-active" type=radio name=active checked value="original">
                 <label>
-                  Your original MP2T segment:
+                  Your original .TS or .AAC segment:
                   <input type="file" id="original">
                 </label>
               </div>
@@ -293,10 +293,7 @@ mp4fragment --track audio --fragment-duration 11000 movie-audio.mp4 movie-audio.
             remuxedBytesLength = 0,
             bytes,
             i, j;
-        if ((/\.aac$/i).test(original.value)) {
-          transmuxer = new muxjs.mp4.Transmuxer({remux: false, aacfile: true});
-          outputType = 'audio';
-        } else if (combined) {
+        if (combined) {
             transmuxer = new muxjs.mp4.Transmuxer();
         } else {
             transmuxer = new muxjs.mp4.Transmuxer({remux: false});

--- a/lib/aac/index.js
+++ b/lib/aac/index.js
@@ -20,7 +20,7 @@ var AacStream;
 
 AacStream = function() {
   var
-    everything,
+    everything = new Uint8Array(),
     receivedTimeStamp = false,
     timeStamp = 0;
 
@@ -65,7 +65,7 @@ AacStream = function() {
 
     // If there are bytes remaining from the last segment, prepend them to the
     // bytes that were pushed in
-    if (everything && everything.length) {
+    if (everything.length) {
       tempLength = everything.length;
       everything = new Uint8Array(bytes.byteLength + tempLength);
       everything.set(everything.subarray(0, tempLength));
@@ -134,7 +134,7 @@ AacStream = function() {
     if (bytesLeft > 0) {
       everything = everything.subarray(byteIndex);
     } else {
-      everything = null;
+      everything = new Uint8Array();
     }
   };
 };

--- a/lib/aac/index.js
+++ b/lib/aac/index.js
@@ -58,13 +58,14 @@ AacStream = function() {
     var
       frameSize = 0,
       byteIndex = 0,
+      bytesLeft,
       chunk,
       packet,
       tempLength;
 
     // If there are bytes remaining from the last segment, prepend them to the
     // bytes that were pushed in
-    if (everything !== undefined && everything.length) {
+    if (everything && everything.length) {
       tempLength = everything.length;
       everything = new Uint8Array(bytes.byteLength + tempLength);
       everything.set(everything.subarray(0, tempLength));
@@ -73,14 +74,22 @@ AacStream = function() {
       everything = bytes;
     }
 
-    while (everything.length - byteIndex >= 10) {
+    while (everything.length - byteIndex >= 3) {
       if ((everything[byteIndex] === 'I'.charCodeAt(0)) &&
           (everything[byteIndex + 1] === 'D'.charCodeAt(0)) &&
           (everything[byteIndex + 2] === '3'.charCodeAt(0))) {
 
-        //check framesize
+        // Exit early because we don't have enough to parse
+        // the ID3 tag header
+        if (everything.length - byteIndex < 10) {
+          break;
+        }
+
+        // check framesize
         frameSize = this.parseId3TagSize(everything, byteIndex);
-        //we have enough in the buffer to emit a full packet
+
+        // Exit early if we don't have enough in the buffer
+        // to emit a full packet
         if (frameSize > everything.length) {
           break;
         }
@@ -93,11 +102,21 @@ AacStream = function() {
         continue;
       } else if ((everything[byteIndex] & 0xff === 0xff) &&
                  ((everything[byteIndex + 1] & 0xf0) === 0xf0)) {
+
+        // Exit early because we don't have enough to parse
+        // the ADTS frame header
+        if (everything.length - byteIndex < 7) {
+          break;
+        }
+
         frameSize = this.parseAdtsSize(everything, byteIndex);
 
+        // Exit early if we don't have enough in the buffer
+        // to emit a full packet
         if (frameSize > everything.length) {
           break;
         }
+
         packet = {
           type: 'audio',
           data: everything.subarray(byteIndex, byteIndex + frameSize),
@@ -109,6 +128,13 @@ AacStream = function() {
         continue;
       }
       byteIndex++;
+    }
+    bytesLeft = everything.length - byteIndex;
+
+    if (bytesLeft > 0) {
+      everything = everything.subarray(byteIndex);
+    } else {
+      everything = null;
     }
   };
 };

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -939,6 +939,7 @@ CoalesceStream.prototype.flush = function(flushSource) {
 Transmuxer = function(options) {
   var
     self = this,
+    hasFlushed = true,
     videoTrack,
     audioTrack,
     packetStream, parseStream, elementaryStream,
@@ -946,7 +947,6 @@ Transmuxer = function(options) {
     videoSegmentStream, audioSegmentStream, captionStream,
     coalesceStream,
     headOfPipeline,
-    currentPipeline,
     emitData,
     emitDone;
 
@@ -954,6 +954,7 @@ Transmuxer = function(options) {
 
   options = options || {};
   this.baseMediaDecodeTime = options.baseMediaDecodeTime || 0;
+  this.currentPipeline_ = null;
 
   this.teardownAacPipeline = function() {
     aacStream.unpipe(adtsStream);
@@ -975,7 +976,7 @@ Transmuxer = function(options) {
   };
 
   this.setupAacPipeline = function() {
-    currentPipeline = 'aac';
+    this.currentPipeline_ = 'aac';
     this.metadataStream = new m2ts.MetadataStream();
     options.metadataStream = this.metadataStream;
 
@@ -1063,7 +1064,7 @@ Transmuxer = function(options) {
   };
 
   this.setupTsPipeline = function() {
-    currentPipeline = 'ts';
+    this.currentPipeline_ = 'ts';
     this.metadataStream = new m2ts.MetadataStream();
 
     options.metadataStream = this.metadataStream;
@@ -1179,25 +1180,28 @@ Transmuxer = function(options) {
 
   // feed incoming data to the front of the parsing pipeline
   this.push = function(data) {
-    var isAac = isLikelyAacData(data);
+    if (hasFlushed) {
+      var isAac = isLikelyAacData(data);
 
-    if (isAac && currentPipeline !== 'aac') {
-      if (currentPipeline) {
-        this.teardownTsPipeline();
+      if (isAac && this.currentPipeline_ !== 'aac') {
+        if (this.currentPipeline_) {
+          this.teardownTsPipeline();
+        }
+        this.setupAacPipeline();
+      } else if (!isAac && this.currentPipeline_ !== 'ts') {
+        if (this.currentPipeline_) {
+          this.teardownAacPipeline();
+        }
+        this.setupTsPipeline();
       }
-      this.setupAacPipeline();
-    } else if (!isAac && currentPipeline !== 'ts') {
-      if (currentPipeline) {
-        this.teardownAacPipeline();
-      }
-      this.setupTsPipeline();
+      hasFlushed = false;
     }
-
     headOfPipeline.push(data);
   };
 
   // flush any buffered data
   this.flush = function() {
+    hasFlushed = true;
     // Start at the top of the pipeline and flush all pending work
     headOfPipeline.flush();
   };

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -765,12 +765,12 @@ calculateTrackBaseMediaDecodeTime = function (track) {
  * into a single output segment for MSE. Also supports audio-only
  * and video-only streams.
  */
-CoalesceStream = function(options) {
+CoalesceStream = function(options, metadataStream) {
   // Number of Tracks per output segment
   // If greater than 1, we combine multiple
   // tracks into a single segment
   this.numberOfTracks = 0;
-  this.metadataStream = options.metadataStream;
+  this.metadataStream = metadataStream;
 
   if (typeof options.remux !== 'undefined') {
     this.remuxTracks = !!options.remux;
@@ -941,63 +941,39 @@ Transmuxer = function(options) {
     self = this,
     hasFlushed = true,
     videoTrack,
-    audioTrack,
-    packetStream, parseStream, elementaryStream,
-    adtsStream, h264Stream,aacStream,
-    videoSegmentStream, audioSegmentStream, captionStream,
-    coalesceStream,
-    headOfPipeline,
-    emitData,
-    emitDone;
+    audioTrack;
 
   Transmuxer.prototype.init.call(this);
 
   options = options || {};
   this.baseMediaDecodeTime = options.baseMediaDecodeTime || 0;
-  this.currentPipeline_ = null;
-
-  this.teardownAacPipeline = function() {
-    aacStream.unpipe(adtsStream);
-    aacStream
-      .unpipe(this.metadataStream)
-      .unpipe(coalesceStream);
-
-    if (audioSegmentStream) {
-      adtsStream
-        .unpipe(audioSegmentStream)
-        .unpipe(coalesceStream);
-    }
-
-    this.metadataStream = null;
-    aacStream = null;
-    adtsStream = null;
-    audioSegmentStream = null;
-    coalesceStream = null;
-  };
+  this.transmuxPipeline_ = {};
 
   this.setupAacPipeline = function() {
-    this.currentPipeline_ = 'aac';
-    this.metadataStream = new m2ts.MetadataStream();
-    options.metadataStream = this.metadataStream;
+    var pipeline = {};
+    this.transmuxPipeline_ = pipeline;
+
+    pipeline.type = 'aac';
+    pipeline.metadataStream = new m2ts.MetadataStream();
 
     // set up the parsing pipeline
-    aacStream = new AacStream();
-    adtsStream = new AdtsStream();
-    coalesceStream = new CoalesceStream(options);
-    headOfPipeline = aacStream;
+    pipeline.aacStream = new AacStream();
+    pipeline.adtsStream = new AdtsStream();
+    pipeline.coalesceStream = new CoalesceStream(options, pipeline.metadataStream);
+    pipeline.headOfPipeline = pipeline.aacStream;
 
-    aacStream.pipe(adtsStream);
-    aacStream.pipe(this.metadataStream);
-    this.metadataStream.pipe(coalesceStream);
+    pipeline.aacStream.pipe(pipeline.adtsStream);
+    pipeline.aacStream.pipe(pipeline.metadataStream);
+    pipeline.metadataStream.pipe(pipeline.coalesceStream);
 
-    this.metadataStream.on('timestamp', function(frame) {
-      aacStream.setTimestamp(frame.timeStamp);
+    pipeline.metadataStream.on('timestamp', function(frame) {
+      pipeline.aacStream.setTimestamp(frame.timeStamp);
     });
 
-    aacStream.on('data', function(data) {
+    pipeline.aacStream.on('data', function(data) {
       var i;
 
-      if (data.type === 'timed-metadata' && !audioSegmentStream) {
+      if (data.type === 'timed-metadata' && !pipeline.audioSegmentStream) {
         audioTrack = audioTrack || {
           timelineStartInfo: {
             baseMediaDecodeTime: self.baseMediaDecodeTime
@@ -1006,100 +982,59 @@ Transmuxer = function(options) {
           type: 'audio'
         };
         // hook up the audio segment stream to the first track with aac data
-        coalesceStream.numberOfTracks++;
-        audioSegmentStream = new AudioSegmentStream(audioTrack);
+        pipeline.coalesceStream.numberOfTracks++;
+        pipeline.audioSegmentStream = new AudioSegmentStream(audioTrack);
         // Set up the final part of the audio pipeline
-        adtsStream
-          .pipe(audioSegmentStream)
-          .pipe(coalesceStream);
+        pipeline.adtsStream
+          .pipe(pipeline.audioSegmentStream)
+          .pipe(pipeline.coalesceStream);
       }
     });
 
     // Re-emit any data coming from the coalesce stream to the outside world
-    coalesceStream.on('data', emitData);
+    pipeline.coalesceStream.on('data', this.trigger.bind(this, 'data'));
     // Let the consumer know we have finished flushing the entire pipeline
-    coalesceStream.on('done', emitDone);
-  };
-
-  this.teardownTsPipeline = function() {
-    packetStream
-      .unpipe(parseStream)
-      .unpipe(elementaryStream);
-
-    elementaryStream
-      .unpipe(h264Stream);
-    elementaryStream
-      .unpipe(adtsStream);
-
-    elementaryStream
-      .unpipe(this.metadataStream)
-      .unpipe(coalesceStream);
-
-    h264Stream
-      .unpipe(captionStream)
-      .unpipe(coalesceStream);
-
-    if (videoSegmentStream) {
-      h264Stream
-        .unpipe(videoSegmentStream)
-        .unpipe(coalesceStream);
-    }
-
-    if (audioSegmentStream) {
-      adtsStream
-        .unpipe(audioSegmentStream)
-        .unpipe(coalesceStream);
-    }
-
-    this.metadataStream = null;
-    packetStream = null;
-    parseStream = null;
-    elementaryStream = null;
-    adtsStream = null;
-    h264Stream = null;
-    captionStream = null;
-    videoSegmentStream = null;
-    audioSegmentStream = null;
-    coalesceStream = null;
+    pipeline.coalesceStream.on('done', this.trigger.bind(this, 'done'));
   };
 
   this.setupTsPipeline = function() {
-    this.currentPipeline_ = 'ts';
-    this.metadataStream = new m2ts.MetadataStream();
+    var pipeline = {};
+    this.transmuxPipeline_ = pipeline;
 
-    options.metadataStream = this.metadataStream;
+    pipeline.type = 'ts';
+    pipeline.metadataStream = new m2ts.MetadataStream();
 
     // set up the parsing pipeline
-    packetStream = new m2ts.TransportPacketStream();
-    parseStream = new m2ts.TransportParseStream();
-    elementaryStream = new m2ts.ElementaryStream();
-    adtsStream = new AdtsStream();
-    h264Stream = new H264Stream();
-    captionStream = new m2ts.CaptionStream();
-    coalesceStream = new CoalesceStream(options);
-    headOfPipeline = packetStream;
+    pipeline.packetStream = new m2ts.TransportPacketStream();
+    pipeline.parseStream = new m2ts.TransportParseStream();
+    pipeline.elementaryStream = new m2ts.ElementaryStream();
+    pipeline.adtsStream = new AdtsStream();
+    pipeline.h264Stream = new H264Stream();
+    pipeline.captionStream = new m2ts.CaptionStream();
+    pipeline.coalesceStream = new CoalesceStream(options, pipeline.metadataStream);
+    pipeline.headOfPipeline = pipeline.packetStream;
 
     // disassemble MPEG2-TS packets into elementary streams
-    packetStream
-      .pipe(parseStream)
-      .pipe(elementaryStream);
+    pipeline.packetStream
+      .pipe(pipeline.parseStream)
+      .pipe(pipeline.elementaryStream);
 
     // !!THIS ORDER IS IMPORTANT!!
     // demux the streams
-    elementaryStream
-      .pipe(h264Stream);
-    elementaryStream
-      .pipe(adtsStream);
+    pipeline.elementaryStream
+      .pipe(pipeline.h264Stream);
+    pipeline.elementaryStream
+      .pipe(pipeline.adtsStream);
 
-    elementaryStream
-      .pipe(this.metadataStream)
-      .pipe(coalesceStream);
+    pipeline.elementaryStream
+      .pipe(pipeline.metadataStream)
+      .pipe(pipeline.coalesceStream);
 
     // Hook up CEA-608/708 caption stream
-    h264Stream.pipe(captionStream)
-      .pipe(coalesceStream);
+    pipeline.h264Stream.pipe(pipeline.captionStream)
+      .pipe(pipeline.coalesceStream);
 
-    elementaryStream.on('data', function(data) {
+    pipeline.elementaryStream.on('data', function(data) {
       var i;
 
       if (data.type === 'metadata') {
@@ -1117,11 +1052,11 @@ Transmuxer = function(options) {
         }
 
         // hook up the video segment stream to the first track with h264 data
-        if (videoTrack && !videoSegmentStream) {
-          coalesceStream.numberOfTracks++;
-          videoSegmentStream = new VideoSegmentStream(videoTrack);
+        if (videoTrack && !pipeline.videoSegmentStream) {
+          pipeline.coalesceStream.numberOfTracks++;
+          pipeline.videoSegmentStream = new VideoSegmentStream(videoTrack);
 
-          videoSegmentStream.on('timelineStartInfo', function(timelineStartInfo){
+          pipeline.videoSegmentStream.on('timelineStartInfo', function(timelineStartInfo){
           // When video emits timelineStartInfo data after a flush, we forward that
           // info to the AudioSegmentStream, if it exists, because video timeline
           // data takes precedence.
@@ -1131,37 +1066,39 @@ Transmuxer = function(options) {
               // very earliest DTS we have seen in video because Chrome will
               // interpret any video track with a baseMediaDecodeTime that is
               // non-zero as a gap.
-              audioSegmentStream.setEarliestDts(timelineStartInfo.dts);
+              pipeline.audioSegmentStream.setEarliestDts(timelineStartInfo.dts);
             }
           });
 
           // Set up the final part of the video pipeline
-          h264Stream
-            .pipe(videoSegmentStream)
-            .pipe(coalesceStream);
+          pipeline.h264Stream
+            .pipe(pipeline.videoSegmentStream)
+            .pipe(pipeline.coalesceStream);
         }
 
-        if (audioTrack && !audioSegmentStream) {
+        if (audioTrack && !pipeline.audioSegmentStream) {
           // hook up the audio segment stream to the first track with aac data
-          coalesceStream.numberOfTracks++;
-          audioSegmentStream = new AudioSegmentStream(audioTrack);
+          pipeline.coalesceStream.numberOfTracks++;
+          pipeline.audioSegmentStream = new AudioSegmentStream(audioTrack);
 
           // Set up the final part of the audio pipeline
-          adtsStream
-            .pipe(audioSegmentStream)
-            .pipe(coalesceStream);
+          pipeline.adtsStream
+            .pipe(pipeline.audioSegmentStream)
+            .pipe(pipeline.coalesceStream);
         }
       }
     });
 
     // Re-emit any data coming from the coalesce stream to the outside world
-    coalesceStream.on('data', emitData);
+    pipeline.coalesceStream.on('data', this.trigger.bind(this, 'data'));
     // Let the consumer know we have finished flushing the entire pipeline
-    coalesceStream.on('done', emitDone);
+    pipeline.coalesceStream.on('done', this.trigger.bind(this, 'done'));
   };
 
   // hook up the segment streams once track metadata is delivered
   this.setBaseMediaDecodeTime = function (baseMediaDecodeTime) {
+    var pipeline = this.transmuxPipeline_;
+
     this.baseMediaDecodeTime = baseMediaDecodeTime;
     if (audioTrack) {
       audioTrack.timelineStartInfo.dts = undefined;
@@ -1170,7 +1107,9 @@ Transmuxer = function(options) {
       audioTrack.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
     }
     if (videoTrack) {
-      videoSegmentStream.gopCache_ = [];
+      if (pipeline.videoSegmentStream) {
+        pipeline.videoSegmentStream.gopCache_ = [];
+      }
       videoTrack.timelineStartInfo.dts = undefined;
       videoTrack.timelineStartInfo.pts = undefined;
       clearDtsInfo(videoTrack);
@@ -1183,35 +1122,21 @@ Transmuxer = function(options) {
     if (hasFlushed) {
       var isAac = isLikelyAacData(data);
 
-      if (isAac && this.currentPipeline_ !== 'aac') {
-        if (this.currentPipeline_) {
-          this.teardownTsPipeline();
-        }
+      if (isAac && this.transmuxPipeline_.type !== 'aac') {
         this.setupAacPipeline();
-      } else if (!isAac && this.currentPipeline_ !== 'ts') {
-        if (this.currentPipeline_) {
-          this.teardownAacPipeline();
-        }
+      } else if (!isAac && this.transmuxPipeline_.type !== 'ts') {
         this.setupTsPipeline();
       }
       hasFlushed = false;
     }
-    headOfPipeline.push(data);
+    this.transmuxPipeline_.headOfPipeline.push(data);
   };
 
   // flush any buffered data
   this.flush = function() {
-    hasFlushed = true;
+      hasFlushed = true;
     // Start at the top of the pipeline and flush all pending work
-    headOfPipeline.flush();
-  };
-
-  emitData = function (data) {
-    self.trigger('data', data);
-  };
-
-  emitDone = function () {
-    self.trigger('done');
+    this.transmuxPipeline_.headOfPipeline.flush();
   };
 };
 Transmuxer.prototype = new Stream();

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -23,6 +23,7 @@ var VideoSegmentStream, AudioSegmentStream, Transmuxer, CoalesceStream;
 // Helper functions
 var
   createDefaultSample,
+  isLikelyAacData,
   collectDtsInfo,
   clearDtsInfo,
   calculateTrackBaseMediaDecodeTime,
@@ -44,6 +45,15 @@ createDefaultSample = function () {
       degradationPriority: 0
     }
   };
+};
+
+isLikelyAacData = function (data) {
+  if ((data[0] === 'I'.charCodeAt(0)) &&
+      (data[1] === 'D'.charCodeAt(0)) &&
+      (data[2] === '3'.charCodeAt(0))) {
+    return true;
+  }
+  return false;
 };
 
 /**
@@ -935,14 +945,37 @@ Transmuxer = function(options) {
     adtsStream, h264Stream,aacStream,
     videoSegmentStream, audioSegmentStream, captionStream,
     coalesceStream,
-    headOfPipeline;
+    headOfPipeline,
+    currentPipeline,
+    emitData,
+    emitDone;
 
   Transmuxer.prototype.init.call(this);
 
   options = options || {};
   this.baseMediaDecodeTime = options.baseMediaDecodeTime || 0;
 
+  this.teardownAacPipeline = function() {
+    aacStream.unpipe(adtsStream);
+    aacStream
+      .unpipe(this.metadataStream)
+      .unpipe(coalesceStream);
+
+    if (audioSegmentStream) {
+      adtsStream
+        .unpipe(audioSegmentStream)
+        .unpipe(coalesceStream);
+    }
+
+    this.metadataStream = null;
+    aacStream = null;
+    adtsStream = null;
+    audioSegmentStream = null;
+    coalesceStream = null;
+  };
+
   this.setupAacPipeline = function() {
+    currentPipeline = 'aac';
     this.metadataStream = new m2ts.MetadataStream();
     options.metadataStream = this.metadataStream;
 
@@ -964,7 +997,7 @@ Transmuxer = function(options) {
       var i;
 
       if (data.type === 'timed-metadata' && !audioSegmentStream) {
-        audioTrack = {
+        audioTrack = audioTrack || {
           timelineStartInfo: {
             baseMediaDecodeTime: self.baseMediaDecodeTime
           },
@@ -980,9 +1013,57 @@ Transmuxer = function(options) {
           .pipe(coalesceStream);
       }
     });
+
+    // Re-emit any data coming from the coalesce stream to the outside world
+    coalesceStream.on('data', emitData);
+    // Let the consumer know we have finished flushing the entire pipeline
+    coalesceStream.on('done', emitDone);
+  };
+
+  this.teardownTsPipeline = function() {
+    packetStream
+      .unpipe(parseStream)
+      .unpipe(elementaryStream);
+
+    elementaryStream
+      .unpipe(h264Stream);
+    elementaryStream
+      .unpipe(adtsStream);
+
+    elementaryStream
+      .unpipe(this.metadataStream)
+      .unpipe(coalesceStream);
+
+    h264Stream
+      .unpipe(captionStream)
+      .unpipe(coalesceStream);
+
+    if (videoSegmentStream) {
+      h264Stream
+        .unpipe(videoSegmentStream)
+        .unpipe(coalesceStream);
+    }
+
+    if (audioSegmentStream) {
+      adtsStream
+        .unpipe(audioSegmentStream)
+        .unpipe(coalesceStream);
+    }
+
+    this.metadataStream = null;
+    packetStream = null;
+    parseStream = null;
+    elementaryStream = null;
+    adtsStream = null;
+    h264Stream = null;
+    captionStream = null;
+    videoSegmentStream = null;
+    audioSegmentStream = null;
+    coalesceStream = null;
   };
 
   this.setupTsPipeline = function() {
+    currentPipeline = 'ts';
     this.metadataStream = new m2ts.MetadataStream();
 
     options.metadataStream = this.metadataStream;
@@ -1071,14 +1152,12 @@ Transmuxer = function(options) {
         }
       }
     });
-  };
 
-  // expose the metadata stream
-  if (options.aacfile === undefined) {
-    this.setupTsPipeline();
-  } else {
-    this.setupAacPipeline();
-  }
+    // Re-emit any data coming from the coalesce stream to the outside world
+    coalesceStream.on('data', emitData);
+    // Let the consumer know we have finished flushing the entire pipeline
+    coalesceStream.on('done', emitDone);
+  };
 
   // hook up the segment streams once track metadata is delivered
   this.setBaseMediaDecodeTime = function (baseMediaDecodeTime) {
@@ -1100,6 +1179,20 @@ Transmuxer = function(options) {
 
   // feed incoming data to the front of the parsing pipeline
   this.push = function(data) {
+    var isAac = isLikelyAacData(data);
+
+    if (isAac && currentPipeline !== 'aac') {
+      if (currentPipeline) {
+        this.teardownTsPipeline();
+      }
+      this.setupAacPipeline();
+    } else if (!isAac && currentPipeline !== 'ts') {
+      if (currentPipeline) {
+        this.teardownAacPipeline();
+      }
+      this.setupTsPipeline();
+    }
+
     headOfPipeline.push(data);
   };
 
@@ -1109,14 +1202,13 @@ Transmuxer = function(options) {
     headOfPipeline.flush();
   };
 
-  // Re-emit any data coming from the coalesce stream to the outside world
-  coalesceStream.on('data', function (data) {
+  emitData = function (data) {
     self.trigger('data', data);
-  });
-  // Let the consumer know we have finished flushing the entire pipeline
-  coalesceStream.on('done', function () {
+  };
+
+  emitDone = function () {
     self.trigger('done');
-  });
+  };
 };
 Transmuxer.prototype = new Stream();
 

--- a/lib/utils/stream.js
+++ b/lib/utils/stream.js
@@ -12,16 +12,19 @@
 var Stream = function() {
   this.init = function() {
     var listeners = {};
+    var sentinels = {};
     /**
      * Add a listener for a specified event type.
      * @param type {string} the event name
      * @param listener {function} the callback to be invoked when an event of
      * the specified type occurs
      */
-    this.on = function(type, listener) {
+    this.on = function(type, listener, sentinel) {
       if (!listeners[type]) {
+        sentinels[type] = [];
         listeners[type] = [];
       }
+      sentinels[type].push(sentinel);
       listeners[type].push(listener);
     };
     /**
@@ -30,13 +33,20 @@ var Stream = function() {
      * @param listener {function} a function previously registered for this
      * type of event through `on`
      */
-    this.off = function(type, listener) {
+    this.off = function(type, listener, sentinel) {
       var index;
-      if (!listeners[type]) {
+
+      if (listener && listeners[type]) {
+        index = listeners[type].indexOf(listener);
+      } else if (sentinel && sentinels[type]) {
+        index = sentinels[type].indexOf(sentinel);
+      } else {
         return false;
       }
-      index = listeners[type].indexOf(listener);
+
       listeners[type].splice(index, 1);
+      sentinels[type].splice(index, 1);
+
       return index > -1;
     };
     /**
@@ -92,11 +102,18 @@ var Stream = function() {
 Stream.prototype.pipe = function(destination) {
   this.on('data', function(data) {
     destination.push(data);
-  });
+  }, destination);
 
   this.on('done', function(flushSource) {
     destination.flush(flushSource);
-  });
+  }, destination);
+
+  return destination;
+};
+
+Stream.prototype.unpipe = function(destination) {
+  this.off('data', undefined, destination);
+  this.off('done', undefined, destination);
 
   return destination;
 };

--- a/lib/utils/stream.js
+++ b/lib/utils/stream.js
@@ -12,19 +12,16 @@
 var Stream = function() {
   this.init = function() {
     var listeners = {};
-    var sentinels = {};
     /**
      * Add a listener for a specified event type.
      * @param type {string} the event name
      * @param listener {function} the callback to be invoked when an event of
      * the specified type occurs
      */
-    this.on = function(type, listener, sentinel) {
+    this.on = function(type, listener) {
       if (!listeners[type]) {
-        sentinels[type] = [];
         listeners[type] = [];
       }
-      sentinels[type].push(sentinel);
       listeners[type].push(listener);
     };
     /**
@@ -33,20 +30,13 @@ var Stream = function() {
      * @param listener {function} a function previously registered for this
      * type of event through `on`
      */
-    this.off = function(type, listener, sentinel) {
+    this.off = function(type, listener) {
       var index;
-
-      if (listener && listeners[type]) {
-        index = listeners[type].indexOf(listener);
-      } else if (sentinel && sentinels[type]) {
-        index = sentinels[type].indexOf(sentinel);
-      } else {
+      if (!listeners[type]) {
         return false;
       }
-
+      index = listeners[type].indexOf(listener);
       listeners[type].splice(index, 1);
-      sentinels[type].splice(index, 1);
-
       return index > -1;
     };
     /**
@@ -102,18 +92,11 @@ var Stream = function() {
 Stream.prototype.pipe = function(destination) {
   this.on('data', function(data) {
     destination.push(data);
-  }, destination);
+  });
 
   this.on('done', function(flushSource) {
     destination.flush(flushSource);
-  }, destination);
-
-  return destination;
-};
-
-Stream.prototype.unpipe = function(destination) {
-  this.off('data', undefined, destination);
-  this.off('done', undefined, destination);
+  });
 
   return destination;
 };

--- a/test/transmuxer.test.js
+++ b/test/transmuxer.test.js
@@ -52,6 +52,7 @@ var
   pesHeader,
   transportPacket,
   videoPes,
+  adtsFrame,
   audioPes,
   timedMetadataPes;
 
@@ -506,21 +507,31 @@ videoPes = function(data, first, pts) {
 standalonePes = videoPes([0xaf, 0x01], true);
 
 /**
- * Helper function to create audio PES packets
- * @param data {arraylike} - the payload bytes
- * @payload first {boolean} - true if this PES should be a payload
- * unit start
+ * Helper function to create audio ADTS frame header
+ * @param dataLength {number} - the payload byte count
  */
-audioPes = function(data, first, pts) {
-  var frameLength = data.length + 7;
-  return transportPacket(0x12, [
+adtsFrame = function (dataLength) {
+  var frameLength = dataLength + 7;
+  return [
     0xff, 0xf1,                            // no CRC
     0x10,                                  // AAC Main, 44.1KHz
     0xb0 | ((frameLength & 0x1800) >> 11), // 2 channels
     (frameLength & 0x7f8) >> 3,
     ((frameLength & 0x07) << 5) + 7,       // frame length in bytes
     0x00                                   // one AAC per ADTS frame
-  ].concat(data), first, pts);
+  ];
+};
+
+/**
+ * Helper function to create audio PES packets
+ * @param data {arraylike} - the payload bytes
+ * @payload first {boolean} - true if this PES should be a payload
+ * unit start
+ */
+audioPes = function(data, first, pts) {
+  return transportPacket(0x12,
+    adtsFrame(data.length).concat(data),
+    first, pts);
 };
 
 timedMetadataPes = function(data) {
@@ -2423,15 +2434,16 @@ QUnit.test('buffers video samples until flushed', function() {
 });
 
 QUnit.test('creates a metadata stream', function() {
+  transmuxer.push(packetize(PAT));
   QUnit.ok(transmuxer.metadataStream, 'created a metadata stream');
 });
 
 QUnit.test('pipes timed metadata to the metadata stream', function() {
   var metadatas = [];
+  transmuxer.push(packetize(PAT));
   transmuxer.metadataStream.on('data', function(data) {
     metadatas.push(data);
   });
-  transmuxer.push(packetize(PAT));
   transmuxer.push(packetize(PMT));
   transmuxer.push(packetize(timedMetadataPes([0x03])));
 
@@ -2439,6 +2451,79 @@ QUnit.test('pipes timed metadata to the metadata stream', function() {
   QUnit.equal(metadatas.length, 1, 'emitted timed metadata');
 });
 
+QUnit.test('pipeline dynamically configures itself based on input', function() {
+  var id3 = id3Generator;
+
+  transmuxer.push(packetize(PAT));
+  transmuxer.push(packetize(generatePMT({
+    hasAudio: true
+  })));
+  transmuxer.push(packetize(timedMetadataPes([0x03])));
+  transmuxer.flush();
+  QUnit.equal(transmuxer.currentPipeline_, 'ts', 'detected TS file data');
+
+  transmuxer.push(new Uint8Array(id3.id3Tag(id3.id3Frame('PRIV', 0x00, 0x01))));
+  transmuxer.flush();
+  QUnit.equal(transmuxer.currentPipeline_, 'aac', 'detected AAC file data');
+});
+
+QUnit.test('reuses audio track object when the pipeline reconfigures itself', function() {
+  var boxes, segments = [],
+    id3Tag = new Uint8Array(73),
+    streamTimestamp = "com.apple.streaming.transportStreamTimestamp",
+    priv = 'PRIV',
+    i;
+
+  id3Tag[0] = 73;
+  id3Tag[1] = 68;
+  id3Tag[2] = 51;
+  id3Tag[3] = 4;
+  id3Tag[9] = 63;
+  id3Tag[17] = 53;
+  id3Tag[70] = 13;
+  id3Tag[71] = 187;
+  id3Tag[72] = 160;
+
+  for (i = 0; i < priv.length; i++) {
+    id3Tag[i+10] = priv.charCodeAt(i);
+  }
+  for (i = 0; i < streamTimestamp.length; i++) {
+    id3Tag[i + 20] = streamTimestamp.charCodeAt(i);
+  }
+
+  transmuxer.on('data', function(segment) {
+    segments.push(segment);
+  });
+
+  transmuxer.push(packetize(PAT));
+  transmuxer.push(packetize(packetize(generatePMT({
+    hasAudio: true
+  }))));
+  transmuxer.push(packetize(audioPes([0x19, 0x47], true, 10000)));
+  transmuxer.flush();
+
+  boxes = mp4.tools.inspect(segments[0].data);
+
+  QUnit.equal(boxes[2].boxes[1].boxes[1].baseMediaDecodeTime,
+    0,
+    'first segment starts at 0 pts');
+
+  var adtsPayload = new Uint8Array(adtsFrame(2).concat([0x19, 0x47]));
+
+  transmuxer.push(id3Tag);
+  transmuxer.push(adtsPayload);
+  transmuxer.flush();
+
+  boxes = mp4.tools.inspect(segments[1].data);
+
+  QUnit.equal(boxes[2].boxes[1].boxes[1].baseMediaDecodeTime,
+    // The first segment had a PTS of 10,000 and the second segment 900,000
+    // Audio PTS is specified in a clock equal to samplerate (44.1khz)
+    // So you have to take the different between the PTSs (890,000)
+    // and transform it from 90khz to 44.1khz clock
+    Math.floor((900000 - 10000) / (90000 / 44100)),
+    'second segment starts at the right time');
+});
 
 validateTrack = function(track, metadata) {
   var mdia, handlerType;

--- a/test/transmuxer.test.js
+++ b/test/transmuxer.test.js
@@ -2435,13 +2435,13 @@ QUnit.test('buffers video samples until flushed', function() {
 
 QUnit.test('creates a metadata stream', function() {
   transmuxer.push(packetize(PAT));
-  QUnit.ok(transmuxer.metadataStream, 'created a metadata stream');
+  QUnit.ok(transmuxer.transmuxPipeline_.metadataStream, 'created a metadata stream');
 });
 
 QUnit.test('pipes timed metadata to the metadata stream', function() {
   var metadatas = [];
   transmuxer.push(packetize(PAT));
-  transmuxer.metadataStream.on('data', function(data) {
+  transmuxer.transmuxPipeline_.metadataStream.on('data', function(data) {
     metadatas.push(data);
   });
   transmuxer.push(packetize(PMT));
@@ -2460,11 +2460,11 @@ QUnit.test('pipeline dynamically configures itself based on input', function() {
   })));
   transmuxer.push(packetize(timedMetadataPes([0x03])));
   transmuxer.flush();
-  QUnit.equal(transmuxer.currentPipeline_, 'ts', 'detected TS file data');
+  QUnit.equal(transmuxer.transmuxPipeline_.type, 'ts', 'detected TS file data');
 
   transmuxer.push(new Uint8Array(id3.id3Tag(id3.id3Frame('PRIV', 0x00, 0x01))));
   transmuxer.flush();
-  QUnit.equal(transmuxer.currentPipeline_, 'aac', 'detected AAC file data');
+  QUnit.equal(transmuxer.transmuxPipeline_.type, 'aac', 'detected AAC file data');
 });
 
 QUnit.test('reuses audio track object when the pipeline reconfigures itself', function() {


### PR DESCRIPTION
Experimental attempt to have the transmuxer pipeline get smarter about what to do with the data that is passed into it. 

* Added the ability to tear down the pipeline
* Added a sniffer function that checks to see if the data is likely an AAC by checking to see if it starts with an ID3 tag
* The pipeline creation now happens when the first segment or when a different type of segment is passed in
* The audio track is saved so that the `timelineStartInfo` data is preserved between pipeline changes