### PR TITLE
Display roll-up caption rows as one cue to preserve ordering

### DIFF
--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -382,18 +382,20 @@ Cea608Stream.prototype = new Stream();
 // Trigger a cue point that captures the current state of the
 // display buffer
 Cea608Stream.prototype.flushDisplayed = function(pts) {
-  var row, i;
+  var content = this.displayed_
+    // remove spaces from the start and end of the string
+    .map(function(row) { return row.trim(); })
+    // remove empty rows
+    .filter(function(row) { return row.length; })
+    // combine all text rows to display in one cue
+    .join('\n');
 
-  for (i = 0; i < this.displayed_.length; i++) {
-    row = this.displayed_[i];
-    if (row.length) {
-      this.trigger('data', {
-        startPts: this.startPts_,
-        endPts: pts,
-        // remove spaces from the start and end of the string
-        text: row.trim()
-      });
-    }
+  if (content.length) {
+    this.trigger('data', {
+      startPts: this.startPts_,
+      endPts: pts,
+      text: content
+    });
   }
 };
 

--- a/test/caption-stream.test.js
+++ b/test/caption-stream.test.js
@@ -439,7 +439,7 @@ QUnit.test('roll-up display mode', function() {
     { pts: 5 * 1000, ccData: 0x142d, type:0 }
   ].forEach(cea608Stream.push, cea608Stream);
 
-  QUnit.equal(captions.length, 3, 'detected another caption');
+  QUnit.equal(captions.length, 2, 'detected another caption');
   QUnit.deepEqual(captions[0], {
     startPts: 3 * 1000,
     endPts: 4 * 1000,
@@ -448,13 +448,8 @@ QUnit.test('roll-up display mode', function() {
   QUnit.deepEqual(captions[1], {
     startPts: 4 * 1000,
     endPts: 5 * 1000,
-    text: '01'
-  }, 'kept the caption up after the new caption');
-  QUnit.deepEqual(captions[2], {
-    startPts: 4 * 1000,
-    endPts: 5 * 1000,
-    text: '23'
-  }, 'parsed the new caption');
+    text: '01\n23'
+  }, 'parsed the new caption and kept the caption up after the new caption');
 });
 
 QUnit.test('roll-up displays multiple rows simultaneously', function() {
@@ -493,7 +488,7 @@ QUnit.test('roll-up displays multiple rows simultaneously', function() {
     { pts: 3 * 1000, ccData: 0x142d, type:0 }
   ].forEach(cea608Stream.push, cea608Stream);
 
-  QUnit.equal(captions.length, 3, 'detected three captions');
+  QUnit.equal(captions.length, 2, 'detected another caption');
   QUnit.deepEqual(captions[0], {
     startPts: 1 * 1000,
     endPts: 2 * 1000,
@@ -502,13 +497,8 @@ QUnit.test('roll-up displays multiple rows simultaneously', function() {
   QUnit.deepEqual(captions[1], {
     startPts: 2 * 1000,
     endPts: 3 * 1000,
-    text: '01'
-  }, 'created the top row after the shift up');
-  QUnit.deepEqual(captions[2], {
-    startPts: 2 * 1000,
-    endPts: 3 * 1000,
-    text: '23'
-  }, 'created the bottom row for the second period');
+    text: '01\n23'
+  }, 'created the top and bottom rows after the shift up');
   captions = [];
 
   [ // '45'
@@ -521,7 +511,7 @@ QUnit.test('roll-up displays multiple rows simultaneously', function() {
     { pts: 5 * 1000, ccData: 0x142d, type:0 }
   ].forEach(cea608Stream.push, cea608Stream);
 
-  QUnit.equal(captions.length, 3, 'detected three captions');
+  QUnit.equal(captions.length, 2, 'detected two captions');
   QUnit.deepEqual(captions[0], {
     startPts: 3 * 1000,
     endPts: 4 * 1000,
@@ -530,13 +520,8 @@ QUnit.test('roll-up displays multiple rows simultaneously', function() {
   QUnit.deepEqual(captions[1], {
     startPts: 4 * 1000,
     endPts: 5 * 1000,
-    text: '23'
-  }, 'created the top row after the shift up');
-  QUnit.deepEqual(captions[2], {
-    startPts: 4 * 1000,
-    endPts: 5 * 1000,
-    text: '45'
-  }, 'created the bottom row for the third period');
+    text: '23\n45'
+  }, 'created the top and bottom rows after the shift up');
 });
 
 QUnit.test('the roll-up count can be changed on-the-fly', function() {


### PR DESCRIPTION
This PR is to fix an issue for roll-up captions where the rows would stack on top of each other.