### PR TITLE
Don't emit empty nals

### DIFF
--- a/lib/codecs/h264.js
+++ b/lib/codecs/h264.js
@@ -61,7 +61,7 @@ NalByteStream = function() {
         }
 
         // deliver the NAL unit
-        if (buffer.subarray(syncPoint + 3, i - 2).length > 0) {
+        if (syncPoint + 3 !==  i - 2) {
           this.trigger('data', buffer.subarray(syncPoint + 3, i - 2));
         }
 

--- a/lib/codecs/h264.js
+++ b/lib/codecs/h264.js
@@ -61,7 +61,9 @@ NalByteStream = function() {
         }
 
         // deliver the NAL unit
-        this.trigger('data', buffer.subarray(syncPoint + 3, i - 2));
+        if (buffer.subarray(syncPoint + 3, i - 2).length > 0) {
+          this.trigger('data', buffer.subarray(syncPoint + 3, i - 2));
+        }
 
         // drop trailing zeroes
         do {

--- a/test/transmuxer.test.js
+++ b/test/transmuxer.test.js
@@ -2824,6 +2824,22 @@ QUnit.test('parses nal units with 3-byte start code', function(){
   QUnit.deepEqual(nalUnits[0], new Uint8Array([0x09, 0xFF]), 'has the proper payload');
 });
 
+QUnit.test('does not emit empty nal units', function() {
+  var dataTriggerCount = 0;
+  nalByteStream.on('data', function(data) {
+    dataTriggerCount++;
+  });
+
+  nalByteStream.push({
+    data: new Uint8Array([
+      0x00, 0x00, 0x01, // start code
+      0x00, 0x00, // payload
+      0x00, 0x00, 0x00
+    ])
+  });
+  QUnit.equal(dataTriggerCount, 0, 'emmited no nal units');
+});
+
 QUnit.test('parses multiple nal units', function(){
   var nalUnits = [];
   nalByteStream.on('data', function (data) {


### PR DESCRIPTION
Sometimes, due to a corrupted stream, we are emitting empty nal units, causing regression errors. This screens out empty nal events.

Example:

If we pass in a Nal unit such as:
```javascript
new Uint8Array([
    0x00, 0x00, 0x01,  // start code
    0x00, 0x00,           // empty payload
    0x00, 0x00, 0x00  // end code
]);
```
we would end up emitting it and adding an empty array to the array of nal units we feed through the pipeline. Stages of the pipeline rely on these arrays to not be empty, so it can sometimes break playback if we don't screen these out early in the pipeline. 

