### PR TITLE
Mux.js changes for multiple audio track support

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,3 @@
-.DS_Store
-/node_modules/
-*~
+# Intentionally left blank, so that npm does not ignore anything by default,
+# but relies on the package.json "files" array to explicitly define what ends
+# up in the package.

--- a/debug/index.html
+++ b/debug/index.html
@@ -62,9 +62,10 @@ mp4fragment --track audio --fragment-duration 11000 movie-audio.mp4 movie-audio.
               <div>
                 <input id="original-active" type=radio name=active checked value="original">
                 <label>
-                  Your original MP2T segment:
+                  Your original .TS or .AAC segment:
                   <input type="file" id="original">
                 </label>
+                <button id="save-muxed" type="button">Save Transmuxer Output</button>
               </div>
               <div>
                 <label><input id="combined-output" type=checkbox name=combined checked value="combined">&nbsp;Remux output into a single output?
@@ -138,12 +139,17 @@ mp4fragment --track audio --fragment-duration 11000 movie-audio.mp4 movie-audio.
   <!-- Include QUnit for object diffs -->
   <script src="../node_modules/qunitjs/qunit/qunit.js"></script>
   <script>
+      /*! @source http://purl.eligrey.com/github/FileSaver.js/blob/master/FileSaver.js */
+    window.saveAs=function(view){"use strict";if(typeof navigator!=="undefined"&&/MSIE [1-9]\./.test(navigator.userAgent)){return}var doc=view.document,get_URL=function(){return view.URL||view.webkitURL||view},save_link=doc.createElementNS("http://www.w3.org/1999/xhtml","a"),can_use_save_link="download"in save_link,click=function(node){var event=new MouseEvent("click");node.dispatchEvent(event)},is_safari=/Version\/[\d\.]+.*Safari/.test(navigator.userAgent),webkit_req_fs=view.webkitRequestFileSystem,req_fs=view.requestFileSystem||webkit_req_fs||view.mozRequestFileSystem,throw_outside=function(ex){(view.setImmediate||view.setTimeout)(function(){throw ex},0)},force_saveable_type="application/octet-stream",fs_min_size=0,arbitrary_revoke_timeout=500,revoke=function(file){var revoker=function(){if(typeof file==="string"){get_URL().revokeObjectURL(file)}else{file.remove()}};if(view.chrome){revoker()}else{setTimeout(revoker,arbitrary_revoke_timeout)}},dispatch=function(filesaver,event_types,event){event_types=[].concat(event_types);var i=event_types.length;while(i--){var listener=filesaver["on"+event_types[i]];if(typeof listener==="function"){try{listener.call(filesaver,event||filesaver)}catch(ex){throw_outside(ex)}}}},auto_bom=function(blob){if(/^\s*(?:text\/\S*|application\/xml|\S*\/\S*\+xml)\s*;.*charset\s*=\s*utf-8/i.test(blob.type)){return new Blob(["\ufeff",blob],{type:blob.type})}return blob},FileSaver=function(blob,name,no_auto_bom){if(!no_auto_bom){blob=auto_bom(blob)}var filesaver=this,type=blob.type,blob_changed=false,object_url,target_view,dispatch_all=function(){dispatch(filesaver,"writestart progress write writeend".split(" "))},fs_error=function(){if(target_view&&is_safari&&typeof FileReader!=="undefined"){var reader=new FileReader;reader.onloadend=function(){var base64Data=reader.result;target_view.location.href="data:attachment/file"+base64Data.slice(base64Data.search(/[,;]/));filesaver.readyState=filesaver.DONE;dispatch_all()};reader.readAsDataURL(blob);filesaver.readyState=filesaver.INIT;return}if(blob_changed||!object_url){object_url=get_URL().createObjectURL(blob)}if(target_view){target_view.location.href=object_url}else{var new_tab=view.open(object_url,"_blank");if(new_tab==undefined&&is_safari){view.location.href=object_url}}filesaver.readyState=filesaver.DONE;dispatch_all();revoke(object_url)},abortable=function(func){return function(){if(filesaver.readyState!==filesaver.DONE){return func.apply(this,arguments)}}},create_if_not_found={create:true,exclusive:false},slice;filesaver.readyState=filesaver.INIT;if(!name){name="download"}if(can_use_save_link){object_url=get_URL().createObjectURL(blob);setTimeout(function(){save_link.href=object_url;save_link.download=name;click(save_link);dispatch_all();revoke(object_url);filesaver.readyState=filesaver.DONE});return}if(view.chrome&&type&&type!==force_saveable_type){slice=blob.slice||blob.webkitSlice;blob=slice.call(blob,0,blob.size,force_saveable_type);blob_changed=true}if(webkit_req_fs&&name!=="download"){name+=".download"}if(type===force_saveable_type||webkit_req_fs){target_view=view}if(!req_fs){fs_error();return}fs_min_size+=blob.size;req_fs(view.TEMPORARY,fs_min_size,abortable(function(fs){fs.root.getDirectory("saved",create_if_not_found,abortable(function(dir){var save=function(){dir.getFile(name,create_if_not_found,abortable(function(file){file.createWriter(abortable(function(writer){writer.onwriteend=function(event){target_view.location.href=file.toURL();filesaver.readyState=filesaver.DONE;dispatch(filesaver,"writeend",event);revoke(file)};writer.onerror=function(){var error=writer.error;if(error.code!==error.ABORT_ERR){fs_error()}};"writestart progress write abort".split(" ").forEach(function(event){writer["on"+event]=filesaver["on"+event]});writer.write(blob);filesaver.abort=function(){writer.abort();filesaver.readyState=filesaver.DONE};filesaver.readyState=filesaver.WRITING}),fs_error)}),fs_error)};dir.getFile(name,{create:false},abortable(function(file){file.remove();save()}),abortable(function(ex){if(ex.code===ex.NOT_FOUND_ERR){save()}else{fs_error()}}))}),fs_error)}),fs_error)},FS_proto=FileSaver.prototype,saveAs=function(blob,name,no_auto_bom){return new FileSaver(blob,name,no_auto_bom)};if(typeof navigator!=="undefined"&&navigator.msSaveOrOpenBlob){return function(blob,name,no_auto_bom){if(!no_auto_bom){blob=auto_bom(blob)}return navigator.msSaveOrOpenBlob(blob,name||"download")}}FS_proto.abort=function(){var filesaver=this;filesaver.readyState=filesaver.DONE;dispatch(filesaver,"abort")};FS_proto.readyState=FS_proto.INIT=0;FS_proto.WRITING=1;FS_proto.DONE=2;FS_proto.error=FS_proto.onwritestart=FS_proto.onprogress=FS_proto.onwrite=FS_proto.onabort=FS_proto.onerror=FS_proto.onwriteend=null;return saveAs}(typeof self!=="undefined"&&self||typeof window!=="undefined"&&window||this.content);if(typeof module!=="undefined"&&module.exports){module.exports.saveAs=saveAs}else if(typeof define!=="undefined"&&define!==null&&define.amd!=null){define([],function(){return saveAs})}
+  </script>
+  <script>
     'use strict';
     var
       $ = document.querySelector.bind(document),
       inputs = $('#inputs'),
       original = $('#original'),
       working = $('#working'),
+      saveButton = $('#save-muxed'),
 
       vjsParsed,
       workingParsed,
@@ -152,19 +158,25 @@ mp4fragment --track audio --fragment-duration 11000 movie-audio.mp4 movie-audio.
       workingBytes,
       saveConfig,
       restoreConfig,
+      saveTA,
 
       vjsBoxes = $('.vjs-boxes'),
       workingBoxes = $('.working-boxes'),
       workingBoxes = $('.working-boxes'),
 
+      muxedData,
+      muxedName,
+      transmuxer,
       video,
       mediaSource,
       logevent,
       prepareSourceBuffer;
 
-      logevent = function(event) {
-        console.log(event.type);
-      };
+    logevent = function(event) {
+      console.log(event.type);
+    };
+
+    saveTA = function(tarr, n) { var b = new Blob([tarr], {type: 'application/octet-binary'}); return window.saveAs(b, n);}
 
     saveConfig = function () {
       var inputs = [].slice.call(document.querySelectorAll('input:not([type=file])'));
@@ -288,56 +300,61 @@ mp4fragment --track audio --fragment-duration 11000 movie-audio.mp4 movie-audio.
         var segment = new Uint8Array(reader.result),
             combined = document.querySelector('#combined-output').checked,
             outputType = document.querySelector('input[name="output"]:checked').value,
-            transmuxer,
+            resetTransmuxer = $('#reset-tranmsuxer').checked,
             remuxedSegments = [],
             remuxedBytesLength = 0,
             bytes,
             i, j;
-        if ((/\.aac$/i).test(original.value)) {
-          transmuxer = new muxjs.mp4.Transmuxer({remux: false, aacfile: true});
-          outputType = 'audio';
-        } else if (combined) {
-            transmuxer = new muxjs.mp4.Transmuxer();
-        } else {
-            transmuxer = new muxjs.mp4.Transmuxer({remux: false});
+
+        if (resetTransmuxer || !transmuxer) {
+          if (combined) {
+              outputType = 'combined';
+              transmuxer = new muxjs.mp4.Transmuxer();
+          } else {
+              transmuxer = new muxjs.mp4.Transmuxer({remux: false});
+          }
+
+          transmuxer.on('data', function(event) {
+            if (event.type === outputType) {
+              remuxedSegments.push(event);
+              remuxedBytesLength += event.data.byteLength;
+            }
+          });
+
+          transmuxer.on('done', function () {
+            bytes = new Uint8Array(remuxedBytesLength);
+
+            for (j = 0, i = 0; j < remuxedSegments.length; j++) {
+              bytes.set(remuxedSegments[j].data, i);
+              i += remuxedSegments[j].byteLength;
+            }
+            muxedData = bytes;
+            remuxedSegments = [];
+            remuxedBytesLength = 0;
+
+            vjsBytes = bytes;
+            vjsParsed = muxjs.mp4.tools.inspect(bytes);
+            console.log('transmuxed', vjsParsed);
+            diffParsed();
+
+            // clear old box info
+            vjsBoxes.innerHTML = muxjs.mp4.tools.textify(vjsParsed, null, ' ');
+
+            if ($('#original-active').checked) {
+              prepareSourceBuffer(combined, outputType, function () {
+                console.log('appending...');
+                window.vjsBuffer.appendBuffer(bytes);
+                video.play();
+              });
+            }
+          });
         }
-
-        transmuxer.on('data', function(event) {
-          remuxedSegments.push(event);
-          remuxedBytesLength += event.data.byteLength;
-        });
-
-        transmuxer.on('done', function () {
-          bytes = new Uint8Array(remuxedBytesLength);
-
-          for (j = 0, i = 0; j < remuxedSegments.length; j++) {
-            bytes.set(remuxedSegments[j].data, i);
-            i += remuxedSegments[j].byteLength;
-          }
-          remuxedSegments = [];
-          remuxedBytesLength = 0;
-
-          vjsBytes = bytes;
-          vjsParsed = muxjs.mp4.tools.inspect(bytes);
-          console.log('transmuxed', vjsParsed);
-          diffParsed();
-
-          // clear old box info
-          vjsBoxes.innerHTML = muxjs.mp4.tools.textify(vjsParsed, null, ' ');
-
-          if ($('#original-active').checked) {
-            prepareSourceBuffer(combined, outputType, function () {
-              console.log('appending...');
-              window.vjsBuffer.appendBuffer(bytes);
-              video.play();
-            });
-          }
-        });
 
         transmuxer.push(segment);
         transmuxer.flush();
       });
 
+      muxedName = this.files[0].name.replace('.ts', '.f4m');
       reader.readAsArrayBuffer(this.files[0]);
     }, false);
 
@@ -364,6 +381,14 @@ mp4fragment --track audio --fragment-duration 11000 movie-audio.mp4 movie-audio.
       });
       reader.readAsArrayBuffer(this.files[0]);
     }, false);
+
+
+    $('#save-muxed').addEventListener('click', function () {
+      if (muxedData && muxedName) {
+        return saveTA(muxedData, muxedName);
+      }
+    });
+
     $('#combined-output').addEventListener('change', function () {
         Array.prototype.slice.call(document.querySelectorAll('[name="output"'))
           .forEach(function (el) {

--- a/lib/aac/index.js
+++ b/lib/aac/index.js
@@ -20,7 +20,7 @@ var AacStream;
 
 AacStream = function() {
   var
-    everything,
+    everything = new Uint8Array(),
     receivedTimeStamp = false,
     timeStamp = 0;
 
@@ -58,13 +58,14 @@ AacStream = function() {
     var
       frameSize = 0,
       byteIndex = 0,
+      bytesLeft,
       chunk,
       packet,
       tempLength;
 
     // If there are bytes remaining from the last segment, prepend them to the
     // bytes that were pushed in
-    if (everything !== undefined && everything.length) {
+    if (everything.length) {
       tempLength = everything.length;
       everything = new Uint8Array(bytes.byteLength + tempLength);
       everything.set(everything.subarray(0, tempLength));
@@ -73,14 +74,22 @@ AacStream = function() {
       everything = bytes;
     }
 
-    while (everything.length - byteIndex >= 10) {
+    while (everything.length - byteIndex >= 3) {
       if ((everything[byteIndex] === 'I'.charCodeAt(0)) &&
           (everything[byteIndex + 1] === 'D'.charCodeAt(0)) &&
           (everything[byteIndex + 2] === '3'.charCodeAt(0))) {
 
-        //check framesize
+        // Exit early because we don't have enough to parse
+        // the ID3 tag header
+        if (everything.length - byteIndex < 10) {
+          break;
+        }
+
+        // check framesize
         frameSize = this.parseId3TagSize(everything, byteIndex);
-        //we have enough in the buffer to emit a full packet
+
+        // Exit early if we don't have enough in the buffer
+        // to emit a full packet
         if (frameSize > everything.length) {
           break;
         }
@@ -93,11 +102,21 @@ AacStream = function() {
         continue;
       } else if ((everything[byteIndex] & 0xff === 0xff) &&
                  ((everything[byteIndex + 1] & 0xf0) === 0xf0)) {
+
+        // Exit early because we don't have enough to parse
+        // the ADTS frame header
+        if (everything.length - byteIndex < 7) {
+          break;
+        }
+
         frameSize = this.parseAdtsSize(everything, byteIndex);
 
+        // Exit early if we don't have enough in the buffer
+        // to emit a full packet
         if (frameSize > everything.length) {
           break;
         }
+
         packet = {
           type: 'audio',
           data: everything.subarray(byteIndex, byteIndex + frameSize),
@@ -109,6 +128,13 @@ AacStream = function() {
         continue;
       }
       byteIndex++;
+    }
+    bytesLeft = everything.length - byteIndex;
+
+    if (bytesLeft > 0) {
+      everything = everything.subarray(byteIndex);
+    } else {
+      everything = new Uint8Array();
     }
   };
 };

--- a/lib/codecs/h264.js
+++ b/lib/codecs/h264.js
@@ -60,8 +60,10 @@ NalByteStream = function() {
           break;
         }
 
-        // deliver the NAL unit
-        this.trigger('data', buffer.subarray(syncPoint + 3, i - 2));
+        // deliver the NAL unit if it isn't empty
+        if (syncPoint + 3 !==  i - 2) {
+          this.trigger('data', buffer.subarray(syncPoint + 3, i - 2));
+        }
 
         // drop trailing zeroes
         do {
@@ -271,12 +273,15 @@ H264Stream = function() {
       frameCropRightOffset = 0,
       frameCropTopOffset = 0,
       frameCropBottomOffset = 0,
+      sarScale = 1,
       expGolombDecoder, profileIdc, levelIdc, profileCompatibility,
       chromaFormatIdc, picOrderCntType,
       numRefFramesInPicOrderCntCycle, picWidthInMbsMinus1,
       picHeightInMapUnitsMinus1,
       frameMbsOnlyFlag,
       scalingListCount,
+      sarRatio,
+      aspectRatioIdc,
       i;
 
     expGolombDecoder = new ExpGolomb(data);
@@ -352,12 +357,46 @@ H264Stream = function() {
       frameCropTopOffset = expGolombDecoder.readUnsignedExpGolomb();
       frameCropBottomOffset = expGolombDecoder.readUnsignedExpGolomb();
     }
-
+    if (expGolombDecoder.readBoolean()) {
+      // vui_parameters_present_flag
+      if (expGolombDecoder.readBoolean()) {
+        // aspect_ratio_info_present_flag
+        aspectRatioIdc = expGolombDecoder.readUnsignedByte();
+        switch (aspectRatioIdc) {
+          case 1: sarRatio = [1,1]; break;
+          case 2: sarRatio = [12,11]; break;
+          case 3: sarRatio = [10,11]; break;
+          case 4: sarRatio = [16,11]; break;
+          case 5: sarRatio = [40,33]; break;
+          case 6: sarRatio = [24,11]; break;
+          case 7: sarRatio = [20,11]; break;
+          case 8: sarRatio = [32,11]; break;
+          case 9: sarRatio = [80,33]; break;
+          case 10: sarRatio = [18,11]; break;
+          case 11: sarRatio = [15,11]; break;
+          case 12: sarRatio = [64,33]; break;
+          case 13: sarRatio = [160,99]; break;
+          case 14: sarRatio = [4,3]; break;
+          case 15: sarRatio = [3,2]; break;
+          case 16: sarRatio = [2,1]; break;
+          case 255: {
+            sarRatio = [expGolombDecoder.readUnsignedByte() << 8 |
+                        expGolombDecoder.readUnsignedByte(),
+                        expGolombDecoder.readUnsignedByte() << 8 |
+                        expGolombDecoder.readUnsignedByte() ];
+            break;
+          }
+        }
+        if (sarRatio) {
+          sarScale = sarRatio[0] / sarRatio[1];
+        }
+      }
+    }
     return {
       profileIdc: profileIdc,
       levelIdc: levelIdc,
       profileCompatibility: profileCompatibility,
-      width: ((picWidthInMbsMinus1 + 1) * 16) - frameCropLeftOffset * 2 - frameCropRightOffset * 2,
+      width: Math.ceil((((picWidthInMbsMinus1 + 1) * 16) - frameCropLeftOffset * 2 - frameCropRightOffset * 2) * sarScale),
       height: ((2 - frameMbsOnlyFlag) * (picHeightInMapUnitsMinus1 + 1) * 16) - (frameCropTopOffset * 2) - (frameCropBottomOffset * 2)
     };
   };

--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -363,7 +363,7 @@ var Cea608Stream = function() {
       if ((char0 === 0x11 || char0 === 0x19) &&
           (char1 >= 0x30 && char1 <= 0x3F)) {
         // Put in eigth note and space
-        char0 = 0xE299AA;
+        char0 = 0x266A;
         char1 = '';
       }
 
@@ -382,18 +382,20 @@ Cea608Stream.prototype = new Stream();
 // Trigger a cue point that captures the current state of the
 // display buffer
 Cea608Stream.prototype.flushDisplayed = function(pts) {
-  var row, i;
+  var content = this.displayed_
+    // remove spaces from the start and end of the string
+    .map(function(row) { return row.trim(); })
+    // remove empty rows
+    .filter(function(row) { return row.length; })
+    // combine all text rows to display in one cue
+    .join('\n');
 
-  for (i = 0; i < this.displayed_.length; i++) {
-    row = this.displayed_[i];
-    if (row.length) {
-      this.trigger('data', {
-        startPts: this.startPts_,
-        endPts: pts,
-        // remove spaces from the start and end of the string
-        text: row.trim()
-      });
-    }
+  if (content.length) {
+    this.trigger('data', {
+      startPts: this.startPts_,
+      endPts: pts,
+      text: content
+    });
   }
 };
 

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -17,12 +17,30 @@ var AdtsStream = require('../codecs/adts.js');
 var H264Stream = require('../codecs/h264').H264Stream;
 var AacStream = require('../aac');
 
+// constants
+var AUDIO_PROPERTIES = [
+  'audioobjecttype',
+  'channelcount',
+  'samplerate',
+  'samplingfrequencyindex',
+  'samplesize'
+];
+
+var VIDEO_PROPERTIES = [
+  'width',
+  'height',
+  'profileIdc',
+  'levelIdc',
+  'profileCompatibility',
+];
+
 // object types
 var VideoSegmentStream, AudioSegmentStream, Transmuxer, CoalesceStream;
 
 // Helper functions
 var
   createDefaultSample,
+  isLikelyAacData,
   collectDtsInfo,
   clearDtsInfo,
   calculateTrackBaseMediaDecodeTime,
@@ -44,6 +62,15 @@ createDefaultSample = function () {
       degradationPriority: 0
     }
   };
+};
+
+isLikelyAacData = function (data) {
+  if ((data[0] === 'I'.charCodeAt(0)) &&
+      (data[1] === 'D'.charCodeAt(0)) &&
+      (data[2] === '3'.charCodeAt(0))) {
+    return true;
+  }
+  return false;
 };
 
 /**
@@ -102,11 +129,9 @@ AudioSegmentStream = function(track) {
     collectDtsInfo(track, data);
 
     if (track) {
-      track.audioobjecttype = data.audioobjecttype;
-      track.channelcount = data.channelcount;
-      track.samplerate = data.samplerate;
-      track.samplingfrequencyindex = data.samplingfrequencyindex;
-      track.samplesize = data.samplesize;
+      AUDIO_PROPERTIES.forEach(function(prop) {
+        track[prop] = data[prop];
+      });
     }
 
     // buffer audio data until end() is called
@@ -126,7 +151,7 @@ AudioSegmentStream = function(track) {
 
     // return early if no audio data has been observed
     if (adtsFrames.length === 0) {
-      this.trigger('done');
+      this.trigger('done', 'AudioSegmentStream');
       return;
     }
 
@@ -154,7 +179,7 @@ AudioSegmentStream = function(track) {
     clearDtsInfo(track);
 
     this.trigger('data', {track: track, boxes: boxes});
-    this.trigger('done');
+    this.trigger('done', 'AudioSegmentStream');
   };
 
   // If the audio segment extends before the earliest allowed dts
@@ -241,16 +266,13 @@ VideoSegmentStream = function(track) {
     collectDtsInfo(track, nalUnit);
 
     // record the track config
-    if (nalUnit.nalUnitType === 'seq_parameter_set_rbsp' &&
-        !config) {
+    if (nalUnit.nalUnitType === 'seq_parameter_set_rbsp' && !config) {
       config = nalUnit.config;
-
-      track.width = config.width;
-      track.height = config.height;
       track.sps = [nalUnit.data];
-      track.profileIdc = config.profileIdc;
-      track.levelIdc = config.levelIdc;
-      track.profileCompatibility = config.profileCompatibility;
+
+      VIDEO_PROPERTIES.forEach(function(prop) {
+        track[prop] = config[prop];
+      }, this);
     }
 
     if (nalUnit.nalUnitType === 'pic_parameter_set_rbsp' &&
@@ -284,7 +306,7 @@ VideoSegmentStream = function(track) {
     // Return early if no video data has been observed
     if (nalUnits.length === 0) {
       this.resetStream_();
-      this.trigger('done');
+      this.trigger('done', 'VideoSegmentStream');
       return;
     }
 
@@ -373,7 +395,7 @@ VideoSegmentStream = function(track) {
     this.resetStream_();
 
     // Continue with the flush process now
-    this.trigger('done');
+    this.trigger('done', 'VideoSegmentStream');
   };
 
   this.resetStream_ = function() {
@@ -506,8 +528,8 @@ VideoSegmentStream = function(track) {
     // For the last frame, use the duration of the previous frame if we
     // have nothing better to go on
     if (frames.length &&
-        !currentFrame.duration ||
-        currentFrame.duration <= 0) {
+        (!currentFrame.duration ||
+         currentFrame.duration <= 0)) {
       currentFrame.duration = frames[frames.length - 1].duration;
     }
 
@@ -755,12 +777,12 @@ calculateTrackBaseMediaDecodeTime = function (track) {
  * into a single output segment for MSE. Also supports audio-only
  * and video-only streams.
  */
-CoalesceStream = function(options) {
+CoalesceStream = function(options, metadataStream) {
   // Number of Tracks per output segment
   // If greater than 1, we combine multiple
   // tracks into a single segment
   this.numberOfTracks = 0;
-  this.metadataStream = options.metadataStream;
+  this.metadataStream = metadataStream;
 
   if (typeof options.remux !== 'undefined') {
     this.remuxTracks = !!options.remux;
@@ -807,12 +829,13 @@ CoalesceStream = function(options) {
 };
 
 CoalesceStream.prototype = new Stream();
-CoalesceStream.prototype.flush = function() {
+CoalesceStream.prototype.flush = function(flushSource) {
   var
     offset = 0,
     event = {
       captions: [],
-      metadata: []
+      metadata: [],
+      info: {}
     },
     caption,
     id3,
@@ -820,16 +843,44 @@ CoalesceStream.prototype.flush = function() {
     timelineStartPts = 0,
     i;
 
-  // Return until we have enough tracks from the pipeline to remux
-  if (this.pendingTracks.length === 0 ||
-     (this.remuxTracks && this.pendingTracks.length < this.numberOfTracks)) {
-    return;
+  if (this.pendingTracks.length < this.numberOfTracks) {
+    if (flushSource !== 'VideoSegmentStream' &&
+        flushSource !== 'AudioSegmentStream') {
+      // Return because we haven't received a flush from a data-generating
+      // portion of the segment (meaning that we have only recieved meta-data
+      // or captions.)
+      return;
+    } else if (this.remuxTracks) {
+      // Return until we have enough tracks from the pipeline to remux (if we
+      // are remuxing audio and video into a single MP4)
+      return;
+    } else if (this.pendingTracks.length === 0) {
+      // In the case where we receive a flush without any data having been
+      // received we consider it an emitted track for the purposes of coalescing
+      // `done` events.
+      // We do this for the case where there is an audio and video track in the
+      // segment but no audio data. (seen in several playlists with alternate
+      // audio tracks and no audio present in the main TS segments.)
+      this.emittedTracks++;
+
+      if (this.emittedTracks >= this.numberOfTracks) {
+        this.trigger('done');
+        this.emittedTracks = 0;
+      }
+      return;
+    }
   }
 
   if (this.videoTrack) {
     timelineStartPts = this.videoTrack.timelineStartInfo.pts;
+    VIDEO_PROPERTIES.forEach(function(prop) {
+      event.info[prop] = this.videoTrack[prop];
+    }, this);
   } else if (this.audioTrack) {
     timelineStartPts = this.audioTrack.timelineStartInfo.pts;
+    AUDIO_PROPERTIES.forEach(function(prop) {
+      event.info[prop] = this.audioTrack[prop];
+    }, this);
   }
 
   if (this.pendingTracks.length === 1) {
@@ -837,6 +888,7 @@ CoalesceStream.prototype.flush = function() {
   } else {
     event.type = 'combined';
   }
+
   this.emittedTracks += this.pendingTracks.length;
 
   initSegment = mp4.initSegment(this.pendingTracks);
@@ -906,99 +958,102 @@ CoalesceStream.prototype.flush = function() {
 Transmuxer = function(options) {
   var
     self = this,
+    hasFlushed = true,
     videoTrack,
-    audioTrack,
-    packetStream, parseStream, elementaryStream,
-    adtsStream, h264Stream,aacStream,
-    videoSegmentStream, audioSegmentStream, captionStream,
-    coalesceStream,
-    headOfPipeline;
+    audioTrack;
+
+  Transmuxer.prototype.init.call(this);
+
+  options = options || {};
+  this.baseMediaDecodeTime = options.baseMediaDecodeTime || 0;
+  this.transmuxPipeline_ = {};
 
   this.setupAacPipeline = function() {
-    this.metadataStream = new m2ts.MetadataStream();
-    options.metadataStream = this.metadataStream;
+    var pipeline = {};
+    this.transmuxPipeline_ = pipeline;
+
+    pipeline.type = 'aac';
+    pipeline.metadataStream = new m2ts.MetadataStream();
 
     // set up the parsing pipeline
-    aacStream = new AacStream();
-    adtsStream = new AdtsStream();
-    coalesceStream = new CoalesceStream(options);
-    headOfPipeline = aacStream;
+    pipeline.aacStream = new AacStream();
+    pipeline.adtsStream = new AdtsStream();
+    pipeline.coalesceStream = new CoalesceStream(options, pipeline.metadataStream);
+    pipeline.headOfPipeline = pipeline.aacStream;
 
-    aacStream.pipe(adtsStream);
-    aacStream.pipe(this.metadataStream);
-    this.metadataStream.pipe(coalesceStream);
+    pipeline.aacStream.pipe(pipeline.adtsStream);
+    pipeline.aacStream.pipe(pipeline.metadataStream);
+    pipeline.metadataStream.pipe(pipeline.coalesceStream);
 
-    this.metadataStream.on('timestamp', function(frame) {
-      aacStream.setTimestamp(frame.timeStamp);
+    pipeline.metadataStream.on('timestamp', function(frame) {
+      pipeline.aacStream.setTimestamp(frame.timeStamp);
     });
-    this.addAacListener();
-  };
 
-
-  this.addAacListener = function() {
-    aacStream.on('data', function(data) {
+    pipeline.aacStream.on('data', function(data) {
       var i;
 
-      if (data.type === 'timed-metadata') {
-        var track = {
-            timelineStartInfo: {
-            baseMediaDecodeTime: 0 },
-            codec: 'adts',
-            type: 'audio' };
-
-        if (track && !audioSegmentStream) {
-          // hook up the audio segment stream to the first track with aac data
-          coalesceStream.numberOfTracks++;
-          audioSegmentStream = new AudioSegmentStream(track);
-          // Set up the final part of the audio pipeline
-          adtsStream
-            .pipe(audioSegmentStream)
-            .pipe(coalesceStream);
-        }
+      if (data.type === 'timed-metadata' && !pipeline.audioSegmentStream) {
+        audioTrack = audioTrack || {
+          timelineStartInfo: {
+            baseMediaDecodeTime: self.baseMediaDecodeTime
+          },
+          codec: 'adts',
+          type: 'audio'
+        };
+        // hook up the audio segment stream to the first track with aac data
+        pipeline.coalesceStream.numberOfTracks++;
+        pipeline.audioSegmentStream = new AudioSegmentStream(audioTrack);
+        // Set up the final part of the audio pipeline
+        pipeline.adtsStream
+          .pipe(pipeline.audioSegmentStream)
+          .pipe(pipeline.coalesceStream);
       }
     });
+
+    // Re-emit any data coming from the coalesce stream to the outside world
+    pipeline.coalesceStream.on('data', this.trigger.bind(this, 'data'));
+    // Let the consumer know we have finished flushing the entire pipeline
+    pipeline.coalesceStream.on('done', this.trigger.bind(this, 'done'));
   };
 
   this.setupTsPipeline = function() {
-    this.metadataStream = new m2ts.MetadataStream();
+    var pipeline = {};
+    this.transmuxPipeline_ = pipeline;
 
-    options.metadataStream = this.metadataStream;
+    pipeline.type = 'ts';
+    pipeline.metadataStream = new m2ts.MetadataStream();
 
     // set up the parsing pipeline
-    packetStream = new m2ts.TransportPacketStream();
-    parseStream = new m2ts.TransportParseStream();
-    elementaryStream = new m2ts.ElementaryStream();
-    adtsStream = new AdtsStream();
-    h264Stream = new H264Stream();
-    captionStream = new m2ts.CaptionStream();
-    coalesceStream = new CoalesceStream(options);
-    headOfPipeline = packetStream;
+    pipeline.packetStream = new m2ts.TransportPacketStream();
+    pipeline.parseStream = new m2ts.TransportParseStream();
+    pipeline.elementaryStream = new m2ts.ElementaryStream();
+    pipeline.adtsStream = new AdtsStream();
+    pipeline.h264Stream = new H264Stream();
+    pipeline.captionStream = new m2ts.CaptionStream();
+    pipeline.coalesceStream = new CoalesceStream(options, pipeline.metadataStream);
+    pipeline.headOfPipeline = pipeline.packetStream;
 
     // disassemble MPEG2-TS packets into elementary streams
-    packetStream
-      .pipe(parseStream)
-      .pipe(elementaryStream);
+    pipeline.packetStream
+      .pipe(pipeline.parseStream)
+      .pipe(pipeline.elementaryStream);
 
     // !!THIS ORDER IS IMPORTANT!!
     // demux the streams
-    elementaryStream
-      .pipe(h264Stream);
-    elementaryStream
-      .pipe(adtsStream);
+    pipeline.elementaryStream
+      .pipe(pipeline.h264Stream);
+    pipeline.elementaryStream
+      .pipe(pipeline.adtsStream);
 
-    elementaryStream
-      .pipe(this.metadataStream)
-      .pipe(coalesceStream);
+    pipeline.elementaryStream
+      .pipe(pipeline.metadataStream)
+      .pipe(pipeline.coalesceStream);
 
     // Hook up CEA-608/708 caption stream
-    h264Stream.pipe(captionStream)
-      .pipe(coalesceStream);
-    this.addTsListener();
-  };
+    pipeline.h264Stream.pipe(pipeline.captionStream)
+      .pipe(pipeline.coalesceStream);
 
-  this.addTsListener = function() {
-
-    elementaryStream.on('data', function(data) {
+    pipeline.elementaryStream.on('data', function(data) {
       var i;
 
       if (data.type === 'metadata') {
@@ -1016,11 +1071,11 @@ Transmuxer = function(options) {
         }
 
         // hook up the video segment stream to the first track with h264 data
-        if (videoTrack && !videoSegmentStream) {
-          coalesceStream.numberOfTracks++;
-          videoSegmentStream = new VideoSegmentStream(videoTrack);
+        if (videoTrack && !pipeline.videoSegmentStream) {
+          pipeline.coalesceStream.numberOfTracks++;
+          pipeline.videoSegmentStream = new VideoSegmentStream(videoTrack);
 
-          videoSegmentStream.on('timelineStartInfo', function(timelineStartInfo){
+          pipeline.videoSegmentStream.on('timelineStartInfo', function(timelineStartInfo){
           // When video emits timelineStartInfo data after a flush, we forward that
           // info to the AudioSegmentStream, if it exists, because video timeline
           // data takes precedence.
@@ -1030,43 +1085,39 @@ Transmuxer = function(options) {
               // very earliest DTS we have seen in video because Chrome will
               // interpret any video track with a baseMediaDecodeTime that is
               // non-zero as a gap.
-              audioSegmentStream.setEarliestDts(timelineStartInfo.dts);
+              pipeline.audioSegmentStream.setEarliestDts(timelineStartInfo.dts);
             }
           });
 
           // Set up the final part of the video pipeline
-          h264Stream
-            .pipe(videoSegmentStream)
-            .pipe(coalesceStream);
+          pipeline.h264Stream
+            .pipe(pipeline.videoSegmentStream)
+            .pipe(pipeline.coalesceStream);
         }
 
-        if (audioTrack && !audioSegmentStream) {
+        if (audioTrack && !pipeline.audioSegmentStream) {
           // hook up the audio segment stream to the first track with aac data
-          coalesceStream.numberOfTracks++;
-          audioSegmentStream = new AudioSegmentStream(audioTrack);
+          pipeline.coalesceStream.numberOfTracks++;
+          pipeline.audioSegmentStream = new AudioSegmentStream(audioTrack);
 
           // Set up the final part of the audio pipeline
-          adtsStream
-            .pipe(audioSegmentStream)
-            .pipe(coalesceStream);
+          pipeline.adtsStream
+            .pipe(pipeline.audioSegmentStream)
+            .pipe(pipeline.coalesceStream);
         }
       }
     });
+
+    // Re-emit any data coming from the coalesce stream to the outside world
+    pipeline.coalesceStream.on('data', this.trigger.bind(this, 'data'));
+    // Let the consumer know we have finished flushing the entire pipeline
+    pipeline.coalesceStream.on('done', this.trigger.bind(this, 'done'));
   };
-  Transmuxer.prototype.init.call(this);
-  options = options || {};
-
-  this.baseMediaDecodeTime = options.baseMediaDecodeTime || 0;
-
-  // expose the metadata stream
-  if (options.aacfile === undefined) {
-    this.setupTsPipeline();
-  } else {
-    this.setupAacPipeline();
-  }
 
   // hook up the segment streams once track metadata is delivered
   this.setBaseMediaDecodeTime = function (baseMediaDecodeTime) {
+    var pipeline = this.transmuxPipeline_;
+
     this.baseMediaDecodeTime = baseMediaDecodeTime;
     if (audioTrack) {
       audioTrack.timelineStartInfo.dts = undefined;
@@ -1075,7 +1126,9 @@ Transmuxer = function(options) {
       audioTrack.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
     }
     if (videoTrack) {
-      videoSegmentStream.gopCache_ = [];
+      if (pipeline.videoSegmentStream) {
+        pipeline.videoSegmentStream.gopCache_ = [];
+      }
       videoTrack.timelineStartInfo.dts = undefined;
       videoTrack.timelineStartInfo.pts = undefined;
       clearDtsInfo(videoTrack);
@@ -1085,23 +1138,25 @@ Transmuxer = function(options) {
 
   // feed incoming data to the front of the parsing pipeline
   this.push = function(data) {
-    headOfPipeline.push(data);
+    if (hasFlushed) {
+      var isAac = isLikelyAacData(data);
+
+      if (isAac && this.transmuxPipeline_.type !== 'aac') {
+        this.setupAacPipeline();
+      } else if (!isAac && this.transmuxPipeline_.type !== 'ts') {
+        this.setupTsPipeline();
+      }
+      hasFlushed = false;
+    }
+    this.transmuxPipeline_.headOfPipeline.push(data);
   };
 
   // flush any buffered data
   this.flush = function() {
+      hasFlushed = true;
     // Start at the top of the pipeline and flush all pending work
-    headOfPipeline.flush();
+    this.transmuxPipeline_.headOfPipeline.flush();
   };
-
-  // Re-emit any data coming from the coalesce stream to the outside world
-  coalesceStream.on('data', function (data) {
-    self.trigger('data', data);
-  });
-  // Let the consumer know we have finished flushing the entire pipeline
-  coalesceStream.on('done', function () {
-    self.trigger('done');
-  });
 };
 Transmuxer.prototype = new Stream();
 
@@ -1109,4 +1164,6 @@ module.exports = {
   Transmuxer: Transmuxer,
   VideoSegmentStream: VideoSegmentStream,
   AudioSegmentStream: AudioSegmentStream,
+  AUDIO_PROPERTIES: AUDIO_PROPERTIES,
+  VIDEO_PROPERTIES: VIDEO_PROPERTIES
 };

--- a/lib/tools/mp4-inspector.js
+++ b/lib/tools/mp4-inspector.js
@@ -42,7 +42,8 @@ var
 
       // bail if this doesn't appear to be an H264 stream
       if (length <= 0) {
-        return;
+        result.push('<span style=\'color:red;\'>MALFORMED DATA</span>');
+        continue;
       }
 
       switch(avcStream[i] & 0x1F) {
@@ -65,7 +66,7 @@ var
         result.push('access_unit_delimiter_rbsp');
         break;
       default:
-        result.push(avcStream[i] & 0x1F);
+        result.push('UNKNOWN NAL - ' + avcStream[i] & 0x1F);
         break;
       }
     }

--- a/lib/utils/stream.js
+++ b/lib/utils/stream.js
@@ -94,8 +94,8 @@ Stream.prototype.pipe = function(destination) {
     destination.push(data);
   });
 
-  this.on('done', function() {
-    destination.flush();
+  this.on('done', function(flushSource) {
+    destination.flush(flushSource);
   });
 
   return destination;
@@ -109,8 +109,8 @@ Stream.prototype.push = function(data) {
   this.trigger('data', data);
 };
 
-Stream.prototype.flush = function() {
-  this.trigger('done');
+Stream.prototype.flush = function(flushSource) {
+  this.trigger('done', flushSource);
 };
 
 module.exports = Stream;

--- a/package.json
+++ b/package.json
@@ -46,6 +46,10 @@
   },
   "author": "Brightcove",
   "license": "Apache-2.0",
+  "files": [
+    "lib/",
+    "dist/"
+  ],
   "devDependencies": {
     "browserify": "^12.0.1",
     "express": "^4.13.3",

--- a/scripts/server.js
+++ b/scripts/server.js
@@ -4,15 +4,15 @@ var serveStatic = require('serve-static');
 var portscanner = require('portscanner');
 
 // Configuration for the server.
-const PORT = 9999;
-const MAX_PORT = PORT + 100;
-const HOST = '127.0.0.1';
+var PORT = 9999;
+var MAX_PORT = PORT + 100;
+var HOST = '127.0.0.1';
 
 var app = express();
 
 app.use(serveStatic(path.join(__dirname, '..')));
 
-portscanner.findAPortNotInUse(PORT, MAX_PORT, HOST, (error, port) => {
+portscanner.findAPortNotInUse(PORT, MAX_PORT, HOST, function(error, port) {
   if (error) {
     throw error;
   }

--- a/test/caption-stream.test.js
+++ b/test/caption-stream.test.js
@@ -439,7 +439,7 @@ QUnit.test('roll-up display mode', function() {
     { pts: 5 * 1000, ccData: 0x142d, type:0 }
   ].forEach(cea608Stream.push, cea608Stream);
 
-  QUnit.equal(captions.length, 3, 'detected another caption');
+  QUnit.equal(captions.length, 2, 'detected another caption');
   QUnit.deepEqual(captions[0], {
     startPts: 3 * 1000,
     endPts: 4 * 1000,
@@ -448,13 +448,8 @@ QUnit.test('roll-up display mode', function() {
   QUnit.deepEqual(captions[1], {
     startPts: 4 * 1000,
     endPts: 5 * 1000,
-    text: '01'
-  }, 'kept the caption up after the new caption');
-  QUnit.deepEqual(captions[2], {
-    startPts: 4 * 1000,
-    endPts: 5 * 1000,
-    text: '23'
-  }, 'parsed the new caption');
+    text: '01\n23'
+  }, 'parsed the new caption and kept the caption up after the new caption');
 });
 
 QUnit.test('roll-up displays multiple rows simultaneously', function() {
@@ -493,7 +488,7 @@ QUnit.test('roll-up displays multiple rows simultaneously', function() {
     { pts: 3 * 1000, ccData: 0x142d, type:0 }
   ].forEach(cea608Stream.push, cea608Stream);
 
-  QUnit.equal(captions.length, 3, 'detected three captions');
+  QUnit.equal(captions.length, 2, 'detected another caption');
   QUnit.deepEqual(captions[0], {
     startPts: 1 * 1000,
     endPts: 2 * 1000,
@@ -502,13 +497,8 @@ QUnit.test('roll-up displays multiple rows simultaneously', function() {
   QUnit.deepEqual(captions[1], {
     startPts: 2 * 1000,
     endPts: 3 * 1000,
-    text: '01'
-  }, 'created the top row after the shift up');
-  QUnit.deepEqual(captions[2], {
-    startPts: 2 * 1000,
-    endPts: 3 * 1000,
-    text: '23'
-  }, 'created the bottom row for the second period');
+    text: '01\n23'
+  }, 'created the top and bottom rows after the shift up');
   captions = [];
 
   [ // '45'
@@ -521,7 +511,7 @@ QUnit.test('roll-up displays multiple rows simultaneously', function() {
     { pts: 5 * 1000, ccData: 0x142d, type:0 }
   ].forEach(cea608Stream.push, cea608Stream);
 
-  QUnit.equal(captions.length, 3, 'detected three captions');
+  QUnit.equal(captions.length, 2, 'detected two captions');
   QUnit.deepEqual(captions[0], {
     startPts: 3 * 1000,
     endPts: 4 * 1000,
@@ -530,13 +520,8 @@ QUnit.test('roll-up displays multiple rows simultaneously', function() {
   QUnit.deepEqual(captions[1], {
     startPts: 4 * 1000,
     endPts: 5 * 1000,
-    text: '23'
-  }, 'created the top row after the shift up');
-  QUnit.deepEqual(captions[2], {
-    startPts: 4 * 1000,
-    endPts: 5 * 1000,
-    text: '45'
-  }, 'created the bottom row for the third period');
+    text: '23\n45'
+  }, 'created the top and bottom rows after the shift up');
 });
 
 QUnit.test('the roll-up count can be changed on-the-fly', function() {


### PR DESCRIPTION
* Support automatic AAC parsing by reconfiguring the pipeline
* Updates to the debug page to make it more useful and adding the ability to save the output of the transmuxer locally
* Add information about the output initialization segment to the object returned by the transmuxer
* Fixed a bug where we weren't parsing aspect ratio from sps
* Ignore empty nal units
* Fix a bug where a condition would be true even if frames.length was zero
* Roll-up captions are now emitted as a single cue point instead of one-per-line