### PR TITLE
Add support for v2 tfdt

### DIFF
--- a/lib/tools/mp4-inspector.js
+++ b/lib/tools/mp4-inspector.js
@@ -507,11 +507,16 @@ var
       return parse.ftyp(data);
     },
     tfdt: function(data) {
-      return {
+      var result = {
         version: data[0],
         flags: new Uint8Array(data.subarray(1, 4)),
         baseMediaDecodeTime: data[4] << 24 | data[5] << 16 | data[6] << 8 | data[7]
       };
+      if (result.version === 1) {
+        result.baseMediaDecodeTime *= Math.pow(2, 32);
+        result.baseMediaDecodeTime += data[8] << 24 | data[9] << 16 | data[10] << 8 | data[11];
+      }
+      return result;
     },
     tfhd: function(data) {
       var


### PR DESCRIPTION
Correctly parse tfdts with 64-bit fields. We can't avoid the possibility of overflow but values that aren't too big for js numbers should work.