### PR TITLE
MP4 Probe

### DIFF
--- a/lib/mp4/probe.js
+++ b/lib/mp4/probe.js
@@ -1,0 +1,173 @@
+/**
+ * mux.js
+ *
+ * Copyright (c) 2015 Brightcove
+ * All rights reserved.
+ *
+ * Utilities to detect basic properties and metadata about MP4s.
+ */
+'use strict';
+
+var findBox, parseType, timescale, startTime;
+
+// Find the data for a box specified by its path
+findBox = function(data, path) {
+  var results = [],
+      i, size, type, end, subresults;
+
+  if (!path.length) {
+    // short-circuit the search for empty paths
+    return null;
+  }
+
+  for (i = 0; i < data.byteLength;) {
+    size  = data[i]     << 24;
+    size |= data[i + 1] << 16;
+    size |= data[i + 2] << 8;
+    size |= data[i + 3];
+
+    type = parseType(data.subarray(i + 4, i + 8));
+
+    end = size > 1 ? i + size : data.byteLength;
+
+    if (type === path[0]) {
+      if (path.length === 1) {
+        // this is the end of the path and we've found the box we were
+        // looking for
+        results.push(data.subarray(i + 8, end));
+      } else {
+        // recursively search for the next box along the path
+        subresults = findBox(data.subarray(i + 8, end), path.slice(1));
+        if (subresults.length) {
+          results = results.concat(subresults);
+        }
+      }
+    }
+    i = end;
+  }
+
+  // we've finished searching all of data
+  return results;
+};
+
+/**
+ * Returns the string representation of an ASCII encoded four byte buffer.
+ * @param buffer {Uint8Array} a four-byte buffer to translate
+ * @return {string} the corresponding string
+ */
+parseType = function(buffer) {
+  var result = '';
+  result += String.fromCharCode(buffer[0]);
+  result += String.fromCharCode(buffer[1]);
+  result += String.fromCharCode(buffer[2]);
+  result += String.fromCharCode(buffer[3]);
+  return result;
+};
+
+/**
+ * Parses an MP4 initialization segment and extracts the timescale
+ * values for any declared tracks. Timescale values indicate the
+ * number of clock ticks per second to assume for time-based values
+ * elsewhere in the MP4.
+ *
+ * To determine the start time of an MP4, you need two pieces of
+ * information: the timescale unit and the earliest base media decode
+ * time. Multiple timescales can be specified within an MP4 but the
+ * base media decode time is always expressed in the timescale from
+ * the media header box for the track:
+ * ```
+ * moov > trak > mdia > mdhd.timescale
+ * ```
+ * @param init {Uint8Array} the bytes of the init segment
+ * @return {object} a hash of track ids to timescale values or null if
+ * the init segment is malformed.
+ */
+timescale = function(init) {
+  var
+    result = {},
+    traks = findBox(init, ['moov', 'trak']);
+
+  // mdhd timescale
+  return traks.reduce(function(result, trak) {
+    var tkhd, id, mdhd;
+
+    tkhd = findBox(trak, ['tkhd'])[0];
+    if (!tkhd) {
+      return null;
+    }
+    id = tkhd[20] << 24 |
+         tkhd[21] << 16 |
+         tkhd[22] << 8 |
+         tkhd[23];
+
+    mdhd = findBox(trak, ['mdia', 'mdhd'])[0];
+    if (!mdhd) {
+      return null;
+    }
+    result[id] = mdhd[20] << 24 |
+                 mdhd[21] << 16 |
+                 mdhd[22] << 8 |
+                 mdhd[23];
+    return result;
+  }, result);
+};
+
+/**
+ * Determine the base media decode start time, in seconds, for an MP4
+ * fragment. If multiple fragments are specified, the earliest time is
+ * returned.
+ *
+ * The base media decode time can be parsed from track fragment
+ * metadata:
+ * ```
+ * moof > traf > tfdt.baseMediaDecodeTime
+ * ```
+ * It requires the timescale value from the mdhd to interpret.
+ *
+ * @param timescale {object} a hash of track ids to timescale values.
+ * @return {number} the earliest base media decode start time for the
+ * fragment, in seconds
+ */
+startTime = function(timescale, fragment) {
+  var trafs, baseTimes, result;
+
+  // we need info from two childrend of each track fragment box
+  trafs = findBox(fragment, ['moof', 'traf']);
+
+  // determine the start times for each track
+  baseTimes = [].concat.apply([], trafs.map(function(traf) {
+    return findBox(traf, ['tfhd']).map(function(tfhd) {
+      var id, scale, baseTime;
+
+      // get the track id from the tfhd
+      id = tfhd[4] << 24 |
+           tfhd[5] << 16 |
+           tfhd[6] << 8 |
+           tfhd[7];
+      // assume a 90kHz clock if no timescale was specified
+      scale = timescale[id] || 90e3;
+
+      // get the base media decode time from the tfdt
+      baseTime = findBox(traf, ['tfdt']).map(function(tfdt) {
+        return tfdt[4] << 24 |
+               tfdt[5] << 16 |
+               tfdt[6] << 8 |
+               tfdt[7];
+      })[0];
+      baseTime = baseTime || Infinity;
+
+      // convert base time to seconds
+      return baseTime * scale;
+    });
+  }));
+
+  // return the minimum
+  result = Math.min.apply(null, baseTimes);
+  return isFinite(result) ? result : 0;
+};
+
+module.exports = {
+  parseType: parseType,
+  timescale: timescale,
+  startTime: startTime
+};

--- a/lib/tools/mp4-inspector.js
+++ b/lib/tools/mp4-inspector.js
@@ -1,21 +1,19 @@
+/**
+ * mux.js
+ *
+ * Copyright (c) 2015 Brightcove
+ * All rights reserved.
+ *
+ * Parse the internal MP4 structure into an equivalent javascript
+ * object.
+ */
 'use strict';
 
 var
   inspectMp4,
   textifyMp4,
-  /**
-   * Returns the string representation of an ASCII encoded four byte buffer.
-   * @param buffer {Uint8Array} a four-byte buffer to translate
-   * @return {string} the corresponding string
-   */
-  parseType = function(buffer) {
-    var result = '';
-    result += String.fromCharCode(buffer[0]);
-    result += String.fromCharCode(buffer[1]);
-    result += String.fromCharCode(buffer[2]);
-    result += String.fromCharCode(buffer[3]);
-    return result;
-  },
+
+  parseType = require('../mp4/probe').parseType,
   parseMp4Date = function(seconds) {
     return new Date(seconds * 1000 - 2082844800000);
   },

--- a/lib/tools/mp4-inspector.js
+++ b/lib/tools/mp4-inspector.js
@@ -507,11 +507,16 @@ var
       return parse.ftyp(data);
     },
     tfdt: function(data) {
-      return {
+      var result = {
         version: data[0],
         flags: new Uint8Array(data.subarray(1, 4)),
         baseMediaDecodeTime: data[4] << 24 | data[5] << 16 | data[6] << 8 | data[7]
       };
+      if (result.version === 1) {
+        result.baseMediaDecodeTime *= Math.pow(2, 32);
+        result.baseMediaDecodeTime += data[8] << 24 | data[9] << 16 | data[10] << 8 | data[11];
+      }
+      return result;
     },
     tfhd: function(data) {
       var

--- a/test/mp4-inspector.test.js
+++ b/test/mp4-inspector.test.js
@@ -21,53 +21,11 @@
 */
 var
   mp4 = require('../lib/mp4'),
+  mp4Helpers = require('./utils/mp4-helpers'),
   QUnit = require('qunit'),
-  typeBytes = function(type) {
-    return [
-      type.charCodeAt(0),
-      type.charCodeAt(1),
-      type.charCodeAt(2),
-      type.charCodeAt(3)
-    ];
-  },
-  box = function(type) {
-    var
-      array = Array.prototype.slice.call(arguments, 1),
-      result = [],
-      size,
-      i;
-
-    // "unwrap" any arrays that were passed as arguments
-    // e.g. box('etc', 1, [2, 3], 4) -> box('etc', 1, 2, 3, 4)
-    for (i = 0; i < array.length; i++) {
-      if (array[i] instanceof Array) {
-        array.splice.apply(array, [i, 1].concat(array[i]));
-      }
-    }
-
-    size = 8 + array.length;
-
-    result[0] = (size & 0xFF000000) >> 24;
-    result[1] = (size & 0x00FF0000) >> 16;
-    result[2] = (size & 0x0000FF00) >> 8;
-    result[3] = size & 0xFF;
-    result = result.concat(typeBytes(type));
-    result = result.concat(array);
-    return result;
-  },
-  unityMatrix = [
-    0, 0, 0x10, 0,
-    0, 0, 0, 0,
-    0, 0, 0, 0,
-
-    0, 0, 0, 0,
-    0, 0, 0x10, 0,
-    0, 0, 0, 0,
-
-    0, 0, 0, 0,
-    0, 0, 0, 0,
-    0x40, 0, 0, 0
-  ],
+  typeBytes = mp4Helpers.typeBytes,
+  box = mp4Helpers.box,
+  unityMatrix = mp4Helpers.unityMatrix,
 
   mvhd0 = box('mvhd',
              0x00, // version 0
@@ -251,107 +209,7 @@ QUnit.test('can parse a version 0 mdhd', function() {
 });
 
 QUnit.test('can parse a moov', function() {
-  var data =
-    box('moov',
-        box('mvhd',
-            0x01, // version 1
-            0x00, 0x00, 0x00, // flags
-            0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x01, // creation_time
-            0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x02, // modification_time
-            0x00, 0x00, 0x00, 0x3c, // timescale
-            0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x02, 0x58, // 600 = 0x258 duration
-            0x00, 0x01, 0x00, 0x00, // 1.0 rate
-            0x01, 0x00, // 1.0 volume
-            0x00, 0x00, // reserved
-            0x00, 0x00, 0x00, 0x00, // reserved
-            0x00, 0x00, 0x00, 0x00, // reserved
-            unityMatrix,
-            0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00,
-            0x00, 0x00, 0x00, 0x00, // pre_defined
-            0x00, 0x00, 0x00, 0x02), // next_track_ID
-        box('trak',
-            box('tkhd',
-                0x01, // version 1
-                0x00, 0x00, 0x00, // flags
-                0x00, 0x00, 0x00, 0x00,
-                0x00, 0x00, 0x00, 0x02, // creation_time
-                0x00, 0x00, 0x00, 0x00,
-                0x00, 0x00, 0x00, 0x03, // modification_time
-                0x00, 0x00, 0x00, 0x01, // track_ID
-                0x00, 0x00, 0x00, 0x00, // reserved
-                0x00, 0x00, 0x00, 0x00,
-                0x00, 0x00, 0x02, 0x58, // 600 = 0x258 duration
-                0x00, 0x00, 0x00, 0x00,
-                0x00, 0x00, 0x00, 0x00, // reserved
-                0x00, 0x00, // layer
-                0x00, 0x00, // alternate_group
-                0x00, 0x00, // non-audio track volume
-                0x00, 0x00, // reserved
-                unityMatrix,
-                0x01, 0x2c, 0x00, 0x00, // 300 in 16.16 fixed-point
-                0x00, 0x96, 0x00, 0x00), // 150 in 16.16 fixed-point
-            box('mdia',
-                box('mdhd',
-                    0x01, // version 1
-                    0x00, 0x00, 0x00, // flags
-                    0x00, 0x00, 0x00, 0x00,
-                    0x00, 0x00, 0x00, 0x02, // creation_time
-                    0x00, 0x00, 0x00, 0x00,
-                    0x00, 0x00, 0x00, 0x03, // modification_time
-                    0x00, 0x00, 0x00, 0x3c, // timescale
-                    0x00, 0x00, 0x00, 0x00,
-                    0x00, 0x00, 0x02, 0x58, // 600 = 0x258 duration
-                    0x15, 0xc7, // 'eng' language
-                    0x00, 0x00),
-                box('hdlr',
-                    0x01, // version 1
-                    0x00, 0x00, 0x00, // flags
-                    0x00, 0x00, 0x00, 0x00, // pre_defined
-                    typeBytes('vide'), // handler_type
-                    0x00, 0x00, 0x00, 0x00, // reserved
-                    0x00, 0x00, 0x00, 0x00, // reserved
-                    0x00, 0x00, 0x00, 0x00, // reserved
-                    typeBytes('one'), 0x00), // name
-                box('minf',
-                    box('dinf',
-                        box('dref',
-                            0x01, // version 1
-                            0x00, 0x00, 0x00, // flags
-                            0x00, 0x00, 0x00, 0x01, // entry_count
-                            box('url ',
-                            0x00, // version
-                            0x00, 0x00, 0x01))), // flags
-                    box('stbl',
-                        box('stsd',
-                            0x01, // version 1
-                            0x00, 0x00, 0x00, // flags
-                            0x00, 0x00, 0x00, 0x00), // entry_count
-                        box('stts',
-                            0x01, // version 1
-                            0x00, 0x00, 0x00, // flags
-                            0x00, 0x00, 0x00, 0x01, // entry_count
-                            0x00, 0x00, 0x00, 0x01, // sample_count
-                            0x00, 0x00, 0x00, 0x01), // sample_delta
-                        box('stsc',
-                            0x01, // version 1
-                            0x00, 0x00, 0x00, // flags
-                            0x00, 0x00, 0x00, 0x01, // entry_count
-                            0x00, 0x00, 0x00, 0x02, // first_chunk
-                            0x00, 0x00, 0x00, 0x03, // samples_per_chunk
-                            0x00, 0x00, 0x00, 0x01), // sample_description_index
-                        box('stco',
-                            0x01, // version 1
-                            0x00, 0x00, 0x00, // flags
-                            0x00, 0x00, 0x00, 0x01, // entry_count
-                            0x00, 0x00, 0x00, 0x01)))))); // chunk_offset
-
+  var data = mp4Helpers.sampleMoov;
 
   QUnit.deepEqual(mp4.tools.inspect(new Uint8Array(data)), [{
     type: 'moov',
@@ -362,7 +220,7 @@ QUnit.test('can parse a moov', function() {
       flags: new Uint8Array([0, 0, 0]),
       creationTime: new Date(1000 - 2082844800000),
       modificationTime: new Date(2000 - 2082844800000),
-      timescale: 60,
+      timescale: 1000,
       duration: 600,
       rate: 1,
       size: 120,
@@ -396,7 +254,7 @@ QUnit.test('can parse a moov', function() {
           flags: new Uint8Array([0, 0, 0]),
           creationTime: new Date(2000 - 2082844800000),
           modificationTime: new Date(3000 - 2082844800000),
-          timescale: 60,
+          timescale: 90e3,
           duration: 600,
           language: 'eng',
           size: 44

--- a/test/mp4-probe.test.js
+++ b/test/mp4-probe.test.js
@@ -1,0 +1,156 @@
+'use strict';
+
+var
+  QUnit = require('qunit'),
+  deepEqual = QUnit.deepEqual,
+  equal = QUnit.equal,
+  test = QUnit.test,
+
+  probe = require('../lib/mp4/probe'),
+  mp4Helpers = require('./utils/mp4-helpers'),
+  box = mp4Helpers.box,
+
+  // defined below
+  moovWithoutMdhd,
+  moovWithoutTkhd,
+  moofWithTfdt,
+  multiMoof;
+
+QUnit.module('MP4 Probe');
+
+test('reads the timescale from an mdhd', function() {
+  // sampleMoov has a base timescale of 1000 with an override to 90kHz
+  // in the mdhd
+  deepEqual(probe.timescale(new Uint8Array(mp4Helpers.sampleMoov)), {
+    1: 90e3
+  }, 'found the timescale');
+});
+
+test('returns null if the tkhd is missing', function() {
+  equal(probe.timescale(new Uint8Array(moovWithoutTkhd)), null, 'indicated missing info');
+});
+
+test('returns null if the mdhd is missing', function() {
+  equal(probe.timescale(new Uint8Array(moovWithoutMdhd)), null, 'indicated missing info');
+});
+
+test('reads the base decode time from a tfdt', function() {
+  equal(probe.startTime({
+    4: 2
+  }, new Uint8Array(moofWithTfdt)), 0x02040608, 'calculated base decode time');
+});
+
+test('returns the earliest base decode time', function() {
+  equal(probe.startTime({
+    4: 2,
+    6: 1
+  }, new Uint8Array(multiMoof)), 0x01020304, 'returned the earlier time');
+});
+
+// ---------
+// Test Data
+// ---------
+
+moovWithoutTkhd =
+  box('moov',
+      box('trak',
+          box('mdia',
+              box('mdhd',
+                  0x01, // version 1
+                  0x00, 0x00, 0x00, // flags
+                  0x00, 0x00, 0x00, 0x00,
+                  0x00, 0x00, 0x00, 0x02, // creation_time
+                  0x00, 0x00, 0x00, 0x00,
+                  0x00, 0x00, 0x00, 0x03, // modification_time
+                  0x00, 0x00, 0x03, 0xe8, // timescale = 1000
+                  0x00, 0x00, 0x00, 0x00,
+                  0x00, 0x00, 0x02, 0x58, // 600 = 0x258 duration
+                  0x15, 0xc7, // 'eng' language
+                  0x00, 0x00),
+              box('hdlr',
+                  0x01, // version 1
+                  0x00, 0x00, 0x00, // flags
+                  0x00, 0x00, 0x00, 0x00, // pre_defined
+                  mp4Helpers.typeBytes('vide'), // handler_type
+                  0x00, 0x00, 0x00, 0x00, // reserved
+                  0x00, 0x00, 0x00, 0x00, // reserved
+                  0x00, 0x00, 0x00, 0x00, // reserved
+                  mp4Helpers.typeBytes('one'), 0x00)))); // name
+
+moovWithoutMdhd =
+  box('moov',
+      box('trak',
+          box('tkhd',
+              0x01, // version 1
+              0x00, 0x00, 0x00, // flags
+              0x00, 0x00, 0x00, 0x00,
+              0x00, 0x00, 0x00, 0x02, // creation_time
+              0x00, 0x00, 0x00, 0x00,
+              0x00, 0x00, 0x00, 0x03, // modification_time
+              0x00, 0x00, 0x00, 0x01, // track_ID
+              0x00, 0x00, 0x00, 0x00, // reserved
+              0x00, 0x00, 0x00, 0x00,
+              0x00, 0x00, 0x02, 0x58, // 600 = 0x258 duration
+              0x00, 0x00, 0x00, 0x00,
+              0x00, 0x00, 0x00, 0x00, // reserved
+              0x00, 0x00, // layer
+              0x00, 0x00, // alternate_group
+              0x00, 0x00, // non-audio track volume
+              0x00, 0x00, // reserved
+              mp4Helpers.unityMatrix,
+              0x01, 0x2c, 0x00, 0x00, // 300 in 16.16 fixed-point
+              0x00, 0x96, 0x00, 0x00), // 150 in 16.16 fixed-point
+          box('mdia',
+              box('hdlr',
+                  0x01, // version 1
+                  0x00, 0x00, 0x00, // flags
+                  0x00, 0x00, 0x00, 0x00, // pre_defined
+                  mp4Helpers.typeBytes('vide'), // handler_type
+                  0x00, 0x00, 0x00, 0x00, // reserved
+                  0x00, 0x00, 0x00, 0x00, // reserved
+                  0x00, 0x00, 0x00, 0x00, // reserved
+                  mp4Helpers.typeBytes('one'), 0x00)))); // name
+
+moofWithTfdt =
+  box('moof',
+      box('mfhd',
+          0x00, // version
+          0x00, 0x00, 0x00, // flags
+          0x00, 0x00, 0x00, 0x04), // sequence_number
+      box('traf',
+          box('tfhd',
+              0x00, // version
+              0x00, 0x00, 0x3b, // flags
+              0x00, 0x00, 0x00, 0x04, // track_ID = 4
+              0x00, 0x00, 0x00, 0x00,
+              0x00, 0x00, 0x00, 0x01, // base_data_offset
+              0x00, 0x00, 0x00, 0x02, // sample_description_index
+              0x00, 0x00, 0x00, 0x03, // default_sample_duration,
+              0x00, 0x00, 0x00, 0x04, // default_sample_size
+              0x00, 0x00, 0x00, 0x05),
+          box('tfdt',
+              0x00, // version
+              0x00, 0x00, 0x00, // flags
+              0x01, 0x02, 0x03, 0x04))); // baseMediaDecodeTime
+
+multiMoof = moofWithTfdt
+  .concat(box('moof',
+              box('mfhd',
+                  0x00, // version
+                  0x00, 0x00, 0x00, // flags
+                  0x00, 0x00, 0x00, 0x04), // sequence_number
+              box('traf',
+                  box('tfhd',
+                      0x00, // version
+                      0x00, 0x00, 0x3b, // flags
+                      0x00, 0x00, 0x00, 0x06, // track_ID = 6
+                      0x00, 0x00, 0x00, 0x00,
+                      0x00, 0x00, 0x00, 0x01, // base_data_offset
+                      0x00, 0x00, 0x00, 0x02, // sample_description_index
+                      0x00, 0x00, 0x00, 0x03, // default_sample_duration,
+                      0x00, 0x00, 0x00, 0x04, // default_sample_size
+                      0x00, 0x00, 0x00, 0x05),
+                  box('tfdt',
+                      0x00, // version
+                      0x00, 0x00, 0x00, // flags
+                      0x01, 0x02, 0x03, 0x04))));

--- a/test/utils/mp4-helpers.js
+++ b/test/utils/mp4-helpers.js
@@ -1,0 +1,165 @@
+/**
+ * Helper functions for creating test MP4 data.
+ */
+'use strict';
+var box, typeBytes, unityMatrix;
+
+module.exports = {};
+
+// ----------------------
+// Box Generation Helpers
+// ----------------------
+
+module.exports.typeBytes = typeBytes = function(type) {
+  return [
+    type.charCodeAt(0),
+    type.charCodeAt(1),
+    type.charCodeAt(2),
+    type.charCodeAt(3)
+  ];
+};
+
+module.exports.box = box = function(type) {
+  var
+    array = Array.prototype.slice.call(arguments, 1),
+    result = [],
+    size,
+    i;
+
+  // "unwrap" any arrays that were passed as arguments
+  // e.g. box('etc', 1, [2, 3], 4) -> box('etc', 1, 2, 3, 4)
+  for (i = 0; i < array.length; i++) {
+    if (array[i] instanceof Array) {
+      array.splice.apply(array, [i, 1].concat(array[i]));
+    }
+  }
+
+  size = 8 + array.length;
+
+  result[0] = (size & 0xFF000000) >> 24;
+  result[1] = (size & 0x00FF0000) >> 16;
+  result[2] = (size & 0x0000FF00) >> 8;
+  result[3] = size & 0xFF;
+  result = result.concat(typeBytes(type));
+  result = result.concat(array);
+  return result;
+};
+
+module.exports.unityMatrix = unityMatrix = [
+  0, 0, 0x10, 0,
+  0, 0, 0, 0,
+  0, 0, 0, 0,
+
+  0, 0, 0, 0,
+  0, 0, 0x10, 0,
+  0, 0, 0, 0,
+
+  0, 0, 0, 0,
+  0, 0, 0, 0,
+  0x40, 0, 0, 0
+];
+
+// ------------
+// Example Data
+// ------------
+
+module.exports.sampleMoov =
+  box('moov',
+      box('mvhd',
+          0x01, // version 1
+          0x00, 0x00, 0x00, // flags
+          0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x01, // creation_time
+          0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x02, // modification_time
+          0x00, 0x00, 0x03, 0xe8, // timescale = 1000
+          0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x02, 0x58, // 600 = 0x258 duration
+          0x00, 0x01, 0x00, 0x00, // 1.0 rate
+          0x01, 0x00, // 1.0 volume
+          0x00, 0x00, // reserved
+          0x00, 0x00, 0x00, 0x00, // reserved
+          0x00, 0x00, 0x00, 0x00, // reserved
+          unityMatrix,
+          0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, // pre_defined
+          0x00, 0x00, 0x00, 0x02), // next_track_ID
+      box('trak',
+          box('tkhd',
+              0x01, // version 1
+              0x00, 0x00, 0x00, // flags
+              0x00, 0x00, 0x00, 0x00,
+              0x00, 0x00, 0x00, 0x02, // creation_time
+              0x00, 0x00, 0x00, 0x00,
+              0x00, 0x00, 0x00, 0x03, // modification_time
+              0x00, 0x00, 0x00, 0x01, // track_ID
+              0x00, 0x00, 0x00, 0x00, // reserved
+              0x00, 0x00, 0x00, 0x00,
+              0x00, 0x00, 0x02, 0x58, // 600 = 0x258 duration
+              0x00, 0x00, 0x00, 0x00,
+              0x00, 0x00, 0x00, 0x00, // reserved
+              0x00, 0x00, // layer
+              0x00, 0x00, // alternate_group
+              0x00, 0x00, // non-audio track volume
+              0x00, 0x00, // reserved
+              unityMatrix,
+              0x01, 0x2c, 0x00, 0x00, // 300 in 16.16 fixed-point
+              0x00, 0x96, 0x00, 0x00), // 150 in 16.16 fixed-point
+          box('mdia',
+              box('mdhd',
+                  0x01, // version 1
+                  0x00, 0x00, 0x00, // flags
+                  0x00, 0x00, 0x00, 0x00,
+                  0x00, 0x00, 0x00, 0x02, // creation_time
+                  0x00, 0x00, 0x00, 0x00,
+                  0x00, 0x00, 0x00, 0x03, // modification_time
+                  0x00, 0x01, 0x5f, 0x90, // timescale = 90000
+                  0x00, 0x00, 0x00, 0x00,
+                  0x00, 0x00, 0x02, 0x58, // 600 = 0x258 duration
+                  0x15, 0xc7, // 'eng' language
+                  0x00, 0x00),
+              box('hdlr',
+                  0x01, // version 1
+                  0x00, 0x00, 0x00, // flags
+                  0x00, 0x00, 0x00, 0x00, // pre_defined
+                  typeBytes('vide'), // handler_type
+                  0x00, 0x00, 0x00, 0x00, // reserved
+                  0x00, 0x00, 0x00, 0x00, // reserved
+                  0x00, 0x00, 0x00, 0x00, // reserved
+                  typeBytes('one'), 0x00), // name
+              box('minf',
+                  box('dinf',
+                      box('dref',
+                          0x01, // version 1
+                          0x00, 0x00, 0x00, // flags
+                          0x00, 0x00, 0x00, 0x01, // entry_count
+                          box('url ',
+                              0x00, // version
+                              0x00, 0x00, 0x01))), // flags
+                  box('stbl',
+                      box('stsd',
+                          0x01, // version 1
+                          0x00, 0x00, 0x00, // flags
+                          0x00, 0x00, 0x00, 0x00), // entry_count
+                      box('stts',
+                          0x01, // version 1
+                          0x00, 0x00, 0x00, // flags
+                          0x00, 0x00, 0x00, 0x01, // entry_count
+                          0x00, 0x00, 0x00, 0x01, // sample_count
+                          0x00, 0x00, 0x00, 0x01), // sample_delta
+                      box('stsc',
+                          0x01, // version 1
+                          0x00, 0x00, 0x00, // flags
+                          0x00, 0x00, 0x00, 0x01, // entry_count
+                          0x00, 0x00, 0x00, 0x02, // first_chunk
+                          0x00, 0x00, 0x00, 0x03, // samples_per_chunk
+                          0x00, 0x00, 0x00, 0x01), // sample_description_index
+                      box('stco',
+                          0x01, // version 1
+                          0x00, 0x00, 0x00, // flags
+                          0x00, 0x00, 0x00, 0x01, // entry_count
+                          0x00, 0x00, 0x00, 0x01)))))); // chunk_offset


### PR DESCRIPTION
- Add support for v2 tfdt
Correctly parse tfdts with 64-bit fields. We can't avoid the possibility of overflow but values that aren't too big for js numbers should work.

- Utility for probing start times from MP4s
Add functions to extract track timescales and base media decode times from fragmented MP4s. This is intended to be used to correctly set the timestampOffset when playing back MP4s that have a non-zero base media decode time to start with. Re-arrange some test utility functions to avoid duplicating sample test data.