### PR TITLE
Timestamp Rollover

### DIFF
--- a/lib/flv/transmuxer.js
+++ b/lib/flv/transmuxer.js
@@ -403,7 +403,8 @@ Transmuxer = function(options) {
     self = this,
 
     packetStream, parseStream, elementaryStream,
-    videoCorrectionStream, audioCorrectionStream, timedMetadataCorrectionStream,
+    videoTimestampRolloverStream, audioTimestampRolloverStream,
+    timedMetadataTimestampRolloverStream,
     adtsStream, h264Stream,
     videoSegmentStream, audioSegmentStream, captionStream,
     coalesceStream;
@@ -421,9 +422,9 @@ Transmuxer = function(options) {
   packetStream = new m2ts.TransportPacketStream();
   parseStream = new m2ts.TransportParseStream();
   elementaryStream = new m2ts.ElementaryStream();
-  videoCorrectionStream = new m2ts.TSCorrectionStream('video');
-  audioCorrectionStream = new m2ts.TSCorrectionStream('audio');
-  timedMetadataCorrectionStream = new m2ts.TSCorrectionStream('timed-metadata');
+  videoTimestampRolloverStream = new m2ts.TimestampRolloverStream('video');
+  audioTimestampRolloverStream = new m2ts.TimestampRolloverStream('audio');
+  timedMetadataTimestampRolloverStream = new m2ts.TimestampRolloverStream('timed-metadata');
 
   adtsStream = new AdtsStream();
   h264Stream = new H264Stream();
@@ -437,14 +438,14 @@ Transmuxer = function(options) {
   // !!THIS ORDER IS IMPORTANT!!
   // demux the streams
   elementaryStream
-    .pipe(videoCorrectionStream)
+    .pipe(videoTimestampRolloverStream)
     .pipe(h264Stream);
   elementaryStream
-    .pipe(audioCorrectionStream)
+    .pipe(audioTimestampRolloverStream)
     .pipe(adtsStream);
 
   elementaryStream
-    .pipe(timedMetadataCorrectionStream)
+    .pipe(timedMetadataTimestampRolloverStream)
     .pipe(this.metadataStream)
     .pipe(coalesceStream);
   // if CEA-708 parsing is available, hook up a caption stream

--- a/lib/flv/transmuxer.js
+++ b/lib/flv/transmuxer.js
@@ -403,6 +403,7 @@ Transmuxer = function(options) {
     self = this,
 
     packetStream, parseStream, elementaryStream,
+    videoCorrectionStream, audioCorrectionStream, timedMetadataCorrectionStream,
     adtsStream, h264Stream,
     videoSegmentStream, audioSegmentStream, captionStream,
     coalesceStream;
@@ -420,6 +421,10 @@ Transmuxer = function(options) {
   packetStream = new m2ts.TransportPacketStream();
   parseStream = new m2ts.TransportParseStream();
   elementaryStream = new m2ts.ElementaryStream();
+  videoCorrectionStream = new m2ts.TSCorrectionStream('video');
+  audioCorrectionStream = new m2ts.TSCorrectionStream('audio');
+  timedMetadataCorrectionStream = new m2ts.TSCorrectionStream('timed-metadata');
+
   adtsStream = new AdtsStream();
   h264Stream = new H264Stream();
   coalesceStream = new CoalesceStream(options);
@@ -432,11 +437,14 @@ Transmuxer = function(options) {
   // !!THIS ORDER IS IMPORTANT!!
   // demux the streams
   elementaryStream
+    .pipe(videoCorrectionStream)
     .pipe(h264Stream);
   elementaryStream
+    .pipe(audioCorrectionStream)
     .pipe(adtsStream);
 
   elementaryStream
+    .pipe(timedMetadataCorrectionStream)
     .pipe(this.metadataStream)
     .pipe(coalesceStream);
   // if CEA-708 parsing is available, hook up a caption stream

--- a/lib/m2ts/m2ts.js
+++ b/lib/m2ts/m2ts.js
@@ -296,14 +296,6 @@ ElementaryStream = function() {
           (payload[13] & 0xFE) >>>  3;
         pes.pts *= 4; // Left shift by 2
         pes.pts += (payload[13] & 0x06) >>> 1; // OR by the two LSBs
-        // Check if pts is greater than 2^32 - 1. Rollover might happen.
-        // We will normalize later in the transmuxer.
-        // if (pes.pts > 4294967295) {
-        //   pes.pts -= 8589934592; // decrement max pts value 2^33
-        //   console.log('WRAP');
-        // } else {
-        //   console.log('NO WRAP');
-        // }
         pes.dts = pes.pts;
         if (ptsDtsFlags & 0x40) {
           pes.dts = (payload[14] & 0x0E) << 27 |
@@ -313,11 +305,6 @@ ElementaryStream = function() {
             (payload[18] & 0xFE) >>> 3;
           pes.dts *= 4; // Left shift by 2
           pes.dts += (payload[18] & 0x06) >>> 1; // OR by the two LSBs
-          // Check if dts is greater than 2^32 - 1. Rollover might happen.
-          // We will normalize later in the transmuxer.
-          // if (pes.dts > 4294967295) {
-          //   pes.dts -= 8589934592; // decrement max pts value 2^33
-          // }
         }
       }
       // console.log(`pts: ${pes.pts}\ndts: ${pes.dts}\n----------`);

--- a/lib/m2ts/m2ts.js
+++ b/lib/m2ts/m2ts.js
@@ -12,7 +12,7 @@
 var Stream = require('../utils/stream.js'),
   CaptionStream = require('./caption-stream'),
   StreamTypes = require('./stream-types'),
-  TSCorrectionStream = require('./ts-correction-stream');
+  TimestampRolloverStream = require('./timestamp-rollover-stream');
 
 var m2tsStreamTypes = require('./stream-types.js');
 
@@ -444,7 +444,7 @@ var m2ts = {
   TransportPacketStream: TransportPacketStream,
   TransportParseStream: TransportParseStream,
   ElementaryStream: ElementaryStream,
-  TSCorrectionStream: TSCorrectionStream,
+  TimestampRolloverStream: TimestampRolloverStream,
   CaptionStream: CaptionStream.CaptionStream,
   Cea608Stream: CaptionStream.Cea608Stream,
   MetadataStream: require('./metadata-stream')

--- a/lib/m2ts/m2ts.js
+++ b/lib/m2ts/m2ts.js
@@ -295,6 +295,14 @@ ElementaryStream = function() {
           (payload[13] & 0xFE) >>>  3;
         pes.pts *= 4; // Left shift by 2
         pes.pts += (payload[13] & 0x06) >>> 1; // OR by the two LSBs
+        // Check if pts is greater than 2^32 - 1. Rollover might happen.
+        // We will normalize later in the transmuxer.
+        if (pes.pts > 4294967295) {
+          pes.pts -= 8589934592; // decrement max pts value 2^33
+          console.log('WRAP');
+        } else {
+          console.log('NO WRAP');
+        }
         pes.dts = pes.pts;
         if (ptsDtsFlags & 0x40) {
           pes.dts = (payload[14] & 0x0E) << 27 |
@@ -304,9 +312,14 @@ ElementaryStream = function() {
             (payload[18] & 0xFE) >>> 3;
           pes.dts *= 4; // Left shift by 2
           pes.dts += (payload[18] & 0x06) >>> 1; // OR by the two LSBs
+          // Check if dts is greater than 2^32 - 1. Rollover might happen.
+          // We will normalize later in the transmuxer.
+          if (pes.dts > 4294967295) {
+            pes.dts -= 8589934592; // decrement max pts value 2^33
+          }
         }
       }
-
+      // console.log(`pts: ${pes.pts}\ndts: ${pes.dts}\n----------`);
       // the data section starts immediately after the PES header.
       // pes_header_data_length specifies the number of header bytes
       // that follow the last byte of the field.

--- a/lib/m2ts/m2ts.js
+++ b/lib/m2ts/m2ts.js
@@ -11,7 +11,8 @@
 'use strict';
 var Stream = require('../utils/stream.js'),
   CaptionStream = require('./caption-stream'),
-  StreamTypes = require('./stream-types');
+  StreamTypes = require('./stream-types'),
+  TSCorrectionStream = require('./ts-correction-stream');
 
 var m2tsStreamTypes = require('./stream-types.js');
 
@@ -297,12 +298,12 @@ ElementaryStream = function() {
         pes.pts += (payload[13] & 0x06) >>> 1; // OR by the two LSBs
         // Check if pts is greater than 2^32 - 1. Rollover might happen.
         // We will normalize later in the transmuxer.
-        if (pes.pts > 4294967295) {
-          pes.pts -= 8589934592; // decrement max pts value 2^33
-          console.log('WRAP');
-        } else {
-          console.log('NO WRAP');
-        }
+        // if (pes.pts > 4294967295) {
+        //   pes.pts -= 8589934592; // decrement max pts value 2^33
+        //   console.log('WRAP');
+        // } else {
+        //   console.log('NO WRAP');
+        // }
         pes.dts = pes.pts;
         if (ptsDtsFlags & 0x40) {
           pes.dts = (payload[14] & 0x0E) << 27 |
@@ -314,9 +315,9 @@ ElementaryStream = function() {
           pes.dts += (payload[18] & 0x06) >>> 1; // OR by the two LSBs
           // Check if dts is greater than 2^32 - 1. Rollover might happen.
           // We will normalize later in the transmuxer.
-          if (pes.dts > 4294967295) {
-            pes.dts -= 8589934592; // decrement max pts value 2^33
-          }
+          // if (pes.dts > 4294967295) {
+          //   pes.dts -= 8589934592; // decrement max pts value 2^33
+          // }
         }
       }
       // console.log(`pts: ${pes.pts}\ndts: ${pes.dts}\n----------`);
@@ -457,6 +458,7 @@ var m2ts = {
   TransportPacketStream: TransportPacketStream,
   TransportParseStream: TransportParseStream,
   ElementaryStream: ElementaryStream,
+  TSCorrectionStream: TSCorrectionStream,
   CaptionStream: CaptionStream.CaptionStream,
   Cea608Stream: CaptionStream.Cea608Stream,
   MetadataStream: require('./metadata-stream')

--- a/lib/m2ts/m2ts.js
+++ b/lib/m2ts/m2ts.js
@@ -307,7 +307,6 @@ ElementaryStream = function() {
           pes.dts += (payload[18] & 0x06) >>> 1; // OR by the two LSBs
         }
       }
-      // console.log(`pts: ${pes.pts}\ndts: ${pes.dts}\n----------`);
       // the data section starts immediately after the PES header.
       // pes_header_data_length specifies the number of header bytes
       // that follow the last byte of the field.

--- a/lib/m2ts/timestamp-rollover-stream.js
+++ b/lib/m2ts/timestamp-rollover-stream.js
@@ -17,10 +17,10 @@ var MAX_TS = 8589934592;
 
 var RO_THRESH = 4294967296;
 
-var TSCorrectionStream = function(type) {
+var TimestampRolloverStream = function(type) {
   var lastDTS, referenceDTS;
 
-  TSCorrectionStream.prototype.init.call(this);
+  TimestampRolloverStream.prototype.init.call(this);
 
   this.type_ = type;
 
@@ -71,6 +71,6 @@ var TSCorrectionStream = function(type) {
 
 };
 
-TSCorrectionStream.prototype = new Stream();
+TimestampRolloverStream.prototype = new Stream();
 
-module.exports = TSCorrectionStream;
+module.exports = TimestampRolloverStream;

--- a/lib/m2ts/ts-correction-stream.js
+++ b/lib/m2ts/ts-correction-stream.js
@@ -23,27 +23,15 @@ var TSCorrectionStream = function() {
     reference = {
       video: {
         lastDTS: undefined,
-        referenceDTS: undefined,
-        lastPTS: undefined,
-        referencePTS: undefined,
-        rolloverDTSCount: 0,
-        rolloverPTSCount: 0
+        referenceDTS: undefined
       },
       audio: {
         lastDTS: undefined,
-        referenceDTS: undefined,
-        lastPTS: undefined,
-        referencePTS: undefined,
-        rolloverDTSCount: 0,
-        rolloverPTSCount: 0
+        referenceDTS: undefined
       },
       'timed-metadata': {
         lastDTS: undefined,
-        referenceDTS: undefined,
-        lastPTS: undefined,
-        referencePTS: undefined,
-        rolloverDTSCount: 0,
-        rolloverPTSCount: 0
+        referenceDTS: undefined
       }
     };
 
@@ -56,14 +44,11 @@ var TSCorrectionStream = function() {
       direction = -1;
     }
 
-    var count = 0;
-
     while (Math.abs(reference - value) > RO_THRESH) {
-      count += direction;
       value += (direction * MAX_TS);
     }
 
-    return count;
+    return value;
   }
 
   this.push = function(data) {
@@ -75,27 +60,12 @@ var TSCorrectionStream = function() {
 
     if (ref.referenceDTS === undefined) {
       ref.referenceDTS = data.dts;
-      ref.lastDTS = data.dts
     }
 
-    if (ref.referencePTS === undefined) {
-      ref.referencePTS = data.pts;
-      ref.lastPTS = data.pts;
-    }
-
-    data.dts += (MAX_TS * ref.rolloverDTSCount);
-    data.pts += (MAX_TS * ref.rolloverPTSCount);
-
-    var dtsRoll = handleRollover(data.dts, ref.referenceDTS);
-    ref.rolloverDTSCount += dtsRoll;
-    data.dts += (MAX_TS * dtsRoll);
-
-    var ptsRoll = handleRollover(data.pts, ref.referencePTS);
-    ref.rolloverPTSCount += ptsRoll;
-    data.pts += (MAX_TS * ptsRoll);
+    data.dts = handleRollover(data.dts, ref.referenceDTS);
+    data.pts = handleRollover(data.pts, ref.referenceDTS);
 
     ref.lastDTS = data.dts
-    ref.lastPTS = data.pts
 
     this.trigger('data', data);
   };
@@ -105,7 +75,6 @@ var TSCorrectionStream = function() {
       if (reference.hasOwnProperty(type)) {
         var ref = reference[type];
         ref.referenceDTS = ref.lastDTS;
-        ref.referencePTS = ref.lastPTS;
       }
     }
 

--- a/lib/m2ts/ts-correction-stream.js
+++ b/lib/m2ts/ts-correction-stream.js
@@ -18,9 +18,7 @@ var MAX_TS = 8589934592;
 var RO_THRESH = 4294967296;
 
 var TSCorrectionStream = function(type) {
-  var
-    lastDTS = undefined,
-    referenceDTS = undefined;
+  var lastDTS, referenceDTS;
 
   TSCorrectionStream.prototype.init.call(this);
 
@@ -47,7 +45,7 @@ var TSCorrectionStream = function(type) {
     }
 
     return value;
-  }
+  };
 
   this.push = function(data) {
     if (data.type !== this.type_) {
@@ -61,7 +59,7 @@ var TSCorrectionStream = function(type) {
     data.dts = handleRollover(data.dts, referenceDTS);
     data.pts = handleRollover(data.pts, referenceDTS);
 
-    lastDTS = data.dts
+    lastDTS = data.dts;
 
     this.trigger('data', data);
   };

--- a/lib/m2ts/ts-correction-stream.js
+++ b/lib/m2ts/ts-correction-stream.js
@@ -1,0 +1,119 @@
+/**
+ * mux.js
+ *
+ * Copyright (c) 2016 Brightcove
+ * All rights reserved.
+ *
+ * Accepts program elementary stream (PES) data events and corrects
+ * decode and presentation time stamps to account for a rollover
+ * of the 33 bit value.
+ */
+ 
+'use strict';
+
+var Stream = require('../utils/stream');
+
+var MAX_TS = 8589934592;
+
+var RO_THRESH = 4294967296;
+
+var TSCorrectionStream = function() {
+
+  var
+    reference = {
+      video: {
+        lastDTS: undefined,
+        referenceDTS: undefined,
+        lastPTS: undefined,
+        referencePTS: undefined,
+        rolloverDTSCount: 0,
+        rolloverPTSCount: 0
+      },
+      audio: {
+        lastDTS: undefined,
+        referenceDTS: undefined,
+        lastPTS: undefined,
+        referencePTS: undefined,
+        rolloverDTSCount: 0,
+        rolloverPTSCount: 0
+      },
+      'timed-metadata': {
+        lastDTS: undefined,
+        referenceDTS: undefined,
+        lastPTS: undefined,
+        referencePTS: undefined,
+        rolloverDTSCount: 0,
+        rolloverPTSCount: 0
+      }
+    };
+
+  TSCorrectionStream.prototype.init.call(this);
+
+  var handleRollover = function(value, reference) {
+    var direction = 1;
+
+    if (value > reference) {
+      direction = -1;
+    }
+
+    var count = 0;
+
+    while (Math.abs(reference - value) > RO_THRESH) {
+      count += direction;
+      value += (direction * MAX_TS);
+    }
+
+    return count;
+  }
+
+  this.push = function(data) {
+    if (!reference.hasOwnProperty(data.type)) {
+      return;
+    }
+
+    var ref = reference[data.type];
+
+    if (ref.referenceDTS === undefined) {
+      ref.referenceDTS = data.dts;
+      ref.lastDTS = data.dts
+    }
+
+    if (ref.referencePTS === undefined) {
+      ref.referencePTS = data.pts;
+      ref.lastPTS = data.pts;
+    }
+
+    data.dts += (MAX_TS * ref.rolloverDTSCount);
+    data.pts += (MAX_TS * ref.rolloverPTSCount);
+
+    var dtsRoll = handleRollover(data.dts, ref.referenceDTS);
+    ref.rolloverDTSCount += dtsRoll;
+    data.dts += (MAX_TS * dtsRoll);
+
+    var ptsRoll = handleRollover(data.pts, ref.referencePTS);
+    ref.rolloverPTSCount += ptsRoll;
+    data.pts += (MAX_TS * ptsRoll);
+
+    ref.lastDTS = data.dts
+    ref.lastPTS = data.pts
+
+    this.trigger('data', data);
+  };
+
+  this.flush = function() {
+    for (var type in reference) {
+      if (reference.hasOwnProperty(type)) {
+        var ref = reference[type];
+        ref.referenceDTS = ref.lastDTS;
+        ref.referencePTS = ref.lastPTS;
+      }
+    }
+
+    this.trigger('done');
+  };
+
+};
+
+TSCorrectionStream.prototype = new Stream();
+
+module.exports = TSCorrectionStream;

--- a/lib/m2ts/ts-correction-stream.js
+++ b/lib/m2ts/ts-correction-stream.js
@@ -8,7 +8,7 @@
  * decode and presentation time stamps to account for a rollover
  * of the 33 bit value.
  */
- 
+
 'use strict';
 
 var Stream = require('../utils/stream');
@@ -17,33 +17,31 @@ var MAX_TS = 8589934592;
 
 var RO_THRESH = 4294967296;
 
-var TSCorrectionStream = function() {
-
+var TSCorrectionStream = function(type) {
   var
-    reference = {
-      video: {
-        lastDTS: undefined,
-        referenceDTS: undefined
-      },
-      audio: {
-        lastDTS: undefined,
-        referenceDTS: undefined
-      },
-      'timed-metadata': {
-        lastDTS: undefined,
-        referenceDTS: undefined
-      }
-    };
+    lastDTS = undefined,
+    referenceDTS = undefined;
 
   TSCorrectionStream.prototype.init.call(this);
+
+  this.type_ = type;
 
   var handleRollover = function(value, reference) {
     var direction = 1;
 
     if (value > reference) {
+      // If the current timestamp value is greater than our reference timestamp and we detect a
+      // timestamp rollover, this means the roll over is happening in the opposite direction.
+      // Example scenario: Enter a long stream/video just after a rollover occurred. The reference
+      // point will be set to a small number, e.g. 1. The user then seeks backwards over the
+      // rollover point. In loading this segment, the timestamp values will be very large,
+      // e.g. 2^33 - 1. Since this comes before the data we loaded previously, we want to adjust
+      // the time stamp to be `value - 2^33`.
       direction = -1;
     }
 
+    // Note: A seek forwards or back that is greater than the RO_THRESH (2^32, ~13 hours) will
+    // cause an incorrect adjustment.
     while (Math.abs(reference - value) > RO_THRESH) {
       value += (direction * MAX_TS);
     }
@@ -52,32 +50,24 @@ var TSCorrectionStream = function() {
   }
 
   this.push = function(data) {
-    if (!reference.hasOwnProperty(data.type)) {
+    if (data.type !== this.type_) {
       return;
     }
 
-    var ref = reference[data.type];
-
-    if (ref.referenceDTS === undefined) {
-      ref.referenceDTS = data.dts;
+    if (referenceDTS === undefined) {
+      referenceDTS = data.dts;
     }
 
-    data.dts = handleRollover(data.dts, ref.referenceDTS);
-    data.pts = handleRollover(data.pts, ref.referenceDTS);
+    data.dts = handleRollover(data.dts, referenceDTS);
+    data.pts = handleRollover(data.pts, referenceDTS);
 
-    ref.lastDTS = data.dts
+    lastDTS = data.dts
 
     this.trigger('data', data);
   };
 
   this.flush = function() {
-    for (var type in reference) {
-      if (reference.hasOwnProperty(type)) {
-        var ref = reference[type];
-        ref.referenceDTS = ref.lastDTS;
-      }
-    }
-
+    referenceDTS = lastDTS;
     this.trigger('done');
   };
 

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -971,17 +971,17 @@ Transmuxer = function(options) {
 
     // set up the parsing pipeline
     pipeline.aacStream = new AacStream();
-    pipeline.audioCorrectionStream = new m2ts.TSCorrectionStream('audio');
-    pipeline.timedMetadataCorrectionStream = new m2ts.TSCorrectionStream('timed-metadata');
+    pipeline.audioTimestampRolloverStream = new m2ts.TimestampRolloverStream('audio');
+    pipeline.timedMetadataTimestampRolloverStream = new m2ts.TimestampRolloverStream('timed-metadata');
     pipeline.adtsStream = new AdtsStream();
     pipeline.coalesceStream = new CoalesceStream(options, pipeline.metadataStream);
     pipeline.headOfPipeline = pipeline.aacStream;
 
     pipeline.aacStream
-      .pipe(pipeline.audioCorrectionStream)
+      .pipe(pipeline.audioTimestampRolloverStream)
       .pipe(pipeline.adtsStream);
     pipeline.aacStream
-      .pipe(pipeline.timedMetadataCorrectionStream)
+      .pipe(pipeline.timedMetadataTimestampRolloverStream)
       .pipe(pipeline.metadataStream)
       .pipe(pipeline.coalesceStream);
 
@@ -1025,9 +1025,9 @@ Transmuxer = function(options) {
     pipeline.packetStream = new m2ts.TransportPacketStream();
     pipeline.parseStream = new m2ts.TransportParseStream();
     pipeline.elementaryStream = new m2ts.ElementaryStream();
-    pipeline.videoCorrectionStream = new m2ts.TSCorrectionStream('video');
-    pipeline.audioCorrectionStream = new m2ts.TSCorrectionStream('audio');
-    pipeline.timedMetadataCorrectionStream = new m2ts.TSCorrectionStream('timed-metadata');
+    pipeline.videoTimestampRolloverStream = new m2ts.TimestampRolloverStream('video');
+    pipeline.audioTimestampRolloverStream = new m2ts.TimestampRolloverStream('audio');
+    pipeline.timedMetadataTimestampRolloverStream = new m2ts.TimestampRolloverStream('timed-metadata');
     pipeline.adtsStream = new AdtsStream();
     pipeline.h264Stream = new H264Stream();
     pipeline.captionStream = new m2ts.CaptionStream();
@@ -1042,14 +1042,14 @@ Transmuxer = function(options) {
     // !!THIS ORDER IS IMPORTANT!!
     // demux the streams
     pipeline.elementaryStream
-      .pipe(pipeline.videoCorrectionStream)
+      .pipe(pipeline.videoTimestampRolloverStream)
       .pipe(pipeline.h264Stream);
     pipeline.elementaryStream
-      .pipe(pipeline.audioCorrectionStream)
+      .pipe(pipeline.audioTimestampRolloverStream)
       .pipe(pipeline.adtsStream);
 
     pipeline.elementaryStream
-      .pipe(pipeline.timedMetadataCorrectionStream)
+      .pipe(pipeline.timedMetadataTimestampRolloverStream)
       .pipe(pipeline.metadataStream)
       .pipe(pipeline.coalesceStream);
 

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -971,21 +971,25 @@ Transmuxer = function(options) {
 
     // set up the parsing pipeline
     pipeline.aacStream = new AacStream();
-    pipeline.tsCorrectionStream = new m2ts.TSCorrectionStream();
+    pipeline.audioCorrectionStream = new m2ts.TSCorrectionStream('audio');
+    pipeline.timedMetadataCorrectionStream = new m2ts.TSCorrectionStream('timed-metadata');
     pipeline.adtsStream = new AdtsStream();
     pipeline.coalesceStream = new CoalesceStream(options, pipeline.metadataStream);
     pipeline.headOfPipeline = pipeline.aacStream;
-    
-    pipeline.aacStream.pipe(pipeline.tsCorrectionStream);
-    pipeline.tsCorrectionStream.pipe(pipeline.adtsStream);
-    pipeline.tsCorrectionStream.pipe(pipeline.metadataStream);
-    pipeline.metadataStream.pipe(pipeline.coalesceStream);
+
+    pipeline.aacStream
+      .pipe(pipeline.audioCorrectionStream)
+      .pipe(pipeline.adtsStream);
+    pipeline.aacStream
+      .pipe(pipeline.timedMetadataCorrectionStream)
+      .pipe(pipeline.metadataStream)
+      .pipe(pipeline.coalesceStream);
 
     pipeline.metadataStream.on('timestamp', function(frame) {
       pipeline.aacStream.setTimestamp(frame.timeStamp);
     });
 
-    pipeline.tsCorrectionStream.on('data', function(data) {
+    pipeline.aacStream.on('data', function(data) {
       if (data.type === 'timed-metadata' && !pipeline.audioSegmentStream) {
         audioTrack = audioTrack || {
           timelineStartInfo: {
@@ -1021,7 +1025,9 @@ Transmuxer = function(options) {
     pipeline.packetStream = new m2ts.TransportPacketStream();
     pipeline.parseStream = new m2ts.TransportParseStream();
     pipeline.elementaryStream = new m2ts.ElementaryStream();
-    pipeline.tsCorrectionStream = new m2ts.TSCorrectionStream();
+    pipeline.videoCorrectionStream = new m2ts.TSCorrectionStream('video');
+    pipeline.audioCorrectionStream = new m2ts.TSCorrectionStream('audio');
+    pipeline.timedMetadataCorrectionStream = new m2ts.TSCorrectionStream('timed-metadata');
     pipeline.adtsStream = new AdtsStream();
     pipeline.h264Stream = new H264Stream();
     pipeline.captionStream = new m2ts.CaptionStream();
@@ -1031,17 +1037,19 @@ Transmuxer = function(options) {
     // disassemble MPEG2-TS packets into elementary streams
     pipeline.packetStream
       .pipe(pipeline.parseStream)
-      .pipe(pipeline.elementaryStream)
-      .pipe(pipeline.tsCorrectionStream);
+      .pipe(pipeline.elementaryStream);
 
     // !!THIS ORDER IS IMPORTANT!!
     // demux the streams
-    pipeline.tsCorrectionStream
+    pipeline.elementaryStream
+      .pipe(pipeline.videoCorrectionStream)
       .pipe(pipeline.h264Stream);
-    pipeline.tsCorrectionStream
+    pipeline.elementaryStream
+      .pipe(pipeline.audioCorrectionStream)
       .pipe(pipeline.adtsStream);
 
-    pipeline.tsCorrectionStream
+    pipeline.elementaryStream
+      .pipe(pipeline.timedMetadataCorrectionStream)
       .pipe(pipeline.metadataStream)
       .pipe(pipeline.coalesceStream);
 

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -125,8 +125,6 @@ AudioSegmentStream = function(track) {
 
   AudioSegmentStream.prototype.init.call(this);
 
-  this.refPTS_ = undefined;
-
   this.push = function(data) {
     collectDtsInfo(track, data);
 
@@ -207,19 +205,6 @@ AudioSegmentStream = function(track) {
       return false;
     });
   };
-
-  this.normalizeAdtsFrames_ = function(adtsFrames) {
-    clearDtsInfo(track);
-
-    let refPTS;
-    if (this.refPTS_ !== undefined) {
-      refPTS = this.refPTS_;
-    } else {
-      refPTS = track.timelineStartInfo.baseMediaDecodeTime;
-    }
-
-    // debugger;
-  }
 
   // generate the track's raw mdat data from an array of frames
   this.generateSampleTable_ = function(frames) {
@@ -349,7 +334,6 @@ VideoSegmentStream = function(track) {
     //
     // #1 is far prefereable over #2 which can cause "stuttering" but
     // requires more things to be just right.
-    // debugger;
     if (!gops[0][0].keyFrame) {
       // Search for a gop for fusion from our gopCache
       gopForFusion = this.getGopForFusion_(nalUnits[0], track);
@@ -436,7 +420,6 @@ VideoSegmentStream = function(track) {
       currentGopObj,
       i;
 
-    // debugger;
     // Search for the GOP nearest to the beginning of this nal unit
     for (i = 0; i < this.gopCache_.length; i++) {
       currentGopObj = this.gopCache_[i];
@@ -988,19 +971,21 @@ Transmuxer = function(options) {
 
     // set up the parsing pipeline
     pipeline.aacStream = new AacStream();
+    pipeline.tsCorrectionStream = new m2ts.TSCorrectionStream();
     pipeline.adtsStream = new AdtsStream();
     pipeline.coalesceStream = new CoalesceStream(options, pipeline.metadataStream);
     pipeline.headOfPipeline = pipeline.aacStream;
-
-    pipeline.aacStream.pipe(pipeline.adtsStream);
-    pipeline.aacStream.pipe(pipeline.metadataStream);
+    
+    pipeline.aacStream.pipe(pipeline.tsCorrectionStream);
+    pipeline.tsCorrectionStream.pipe(pipeline.adtsStream);
+    pipeline.tsCorrectionStream.pipe(pipeline.metadataStream);
     pipeline.metadataStream.pipe(pipeline.coalesceStream);
 
     pipeline.metadataStream.on('timestamp', function(frame) {
       pipeline.aacStream.setTimestamp(frame.timeStamp);
     });
 
-    pipeline.aacStream.on('data', function(data) {
+    pipeline.tsCorrectionStream.on('data', function(data) {
       if (data.type === 'timed-metadata' && !pipeline.audioSegmentStream) {
         audioTrack = audioTrack || {
           timelineStartInfo: {

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -45,7 +45,8 @@ var
   clearDtsInfo,
   calculateTrackBaseMediaDecodeTime,
   arrayEquals,
-  sumFrameByteLengths;
+  sumFrameByteLengths,
+  normalizePTS;
 
 /**
  * Default sample object
@@ -113,6 +114,27 @@ sumFrameByteLengths = function(array) {
 };
 
 /**
+ * Normalize PTS value based on reference value to account for 
+ * PTS rollover
+ */
+normalizePTS = function(value, ref) {
+  var offset = 8589934592; // 2^33
+
+  if (ref === undefined) {
+    return value;
+  }
+  if (ref < value) {
+    offset *= -1;
+  }
+  // If the difference between the pts value and the reference pts is greater
+  // than half (2^32), then a rollover occured
+  while(Math.abs(value - ref) > 4294967296) {
+    value += offset;
+  }
+  return value;
+}
+
+/**
  * Constructs a single-track, ISO BMFF media segment from AAC data
  * events. The output of this stream can be fed to a SourceBuffer
  * configured with a suitable initialization segment.
@@ -124,6 +146,8 @@ AudioSegmentStream = function(track) {
     earliestAllowedDts = 0;
 
   AudioSegmentStream.prototype.init.call(this);
+
+  this.refPTS_ = undefined;
 
   this.push = function(data) {
     collectDtsInfo(track, data);
@@ -156,6 +180,12 @@ AudioSegmentStream = function(track) {
     }
 
     frames = this.trimAdtsFramesByEarliestDts_(adtsFrames);
+
+    // adtsFrames.forEach((frame) => {
+    //   console.log('pts', frame.pts, '\ndts', frame.dts, '\n--------');
+    // });
+
+    // this.normalizeAdtsFrames_(adtsFrames);
 
     // we have to build the index from byte locations to
     // samples (that is, adts frames) in the audio data
@@ -205,6 +235,19 @@ AudioSegmentStream = function(track) {
       return false;
     });
   };
+
+  this.normalizeAdtsFrames_ = function(adtsFrames) {
+    clearDtsInfo(track);
+
+    let refPTS;
+    if (this.refPTS_ !== undefined) {
+      refPTS = this.refPTS_;
+    } else {
+      refPTS = track.timelineStartInfo.baseMediaDecodeTime;
+    }
+
+    // debugger;
+  }
 
   // generate the track's raw mdat data from an array of frames
   this.generateSampleTable_ = function(frames) {
@@ -262,6 +305,8 @@ VideoSegmentStream = function(track) {
 
   this.gopCache_ = [];
 
+  this.refDTS_ = undefined;
+
   this.push = function(nalUnit) {
     collectDtsInfo(track, nalUnit);
 
@@ -309,6 +354,8 @@ VideoSegmentStream = function(track) {
       this.trigger('done', 'VideoSegmentStream');
       return;
     }
+    debugger;
+    this.normalizeNalPTS_(nalUnits);
 
     // Organize the raw nal-units into arrays that represent
     // higher-level constructs such as frames and gops
@@ -334,6 +381,7 @@ VideoSegmentStream = function(track) {
     //
     // #1 is far prefereable over #2 which can cause "stuttering" but
     // requires more things to be just right.
+    // debugger;
     if (!gops[0][0].keyFrame) {
       // Search for a gop for fusion from our gopCache
       gopForFusion = this.getGopForFusion_(nalUnits[0], track);
@@ -352,7 +400,17 @@ VideoSegmentStream = function(track) {
         gops = this.extendFirstKeyFrame_(gops);
       }
     }
-    collectDtsInfo(track, gops);
+    // collectDtsInfo(track, gops);
+    // var pr = frames[0].pts;
+    // frames.forEach(nal => {
+    //   console.log(`>> pts: ${nal.pts}`);
+    //   if (nal.pts < pr) {
+    //     console.log('>> ****************************');
+    //   }
+    //   pr = nal.pts;
+    // });
+
+    this.refDTS_ = gops[gops.length - 1].dts + gops[gops.length - 1].duration;
 
     // First, we have to build the index from byte locations to
     // samples (that is, frames) in the video data
@@ -373,6 +431,8 @@ VideoSegmentStream = function(track) {
 
     // Clear nalUnits
     nalUnits = [];
+
+    // debugger;
 
     calculateTrackBaseMediaDecodeTime(track);
 
@@ -398,6 +458,56 @@ VideoSegmentStream = function(track) {
     this.trigger('done', 'VideoSegmentStream');
   };
 
+  this.normalizeNalPTS_ = function(nalUnits) {
+    let refDTS, firstDTS, firstPTS, lastDTS, lastPTS, nalUnit, i, initDTS;
+
+    // debugger;
+    initDTS = track.timelineStartInfo.dts;
+
+    if (this.refDTS_ !== undefined) {
+      refDTS = this.refDTS_
+    } else {
+      refDTS = track.timelineStartInfo.baseMediaDecodeTime;
+      // debugger;
+    }
+
+    // clearDtsInfo(track);
+
+    nalUnit = nalUnits[0];
+    // initDTS = 0;
+
+    firstDTS = Math.max(normalizePTS(nalUnit.dts, refDTS) - initDTS, 0);
+    firstPTS = Math.max(normalizePTS(nalUnit.pts, refDTS) - initDTS, 0);
+
+    if (this.refDTS_ !== undefined) {
+      // track contiguous with previous
+      let delta = Math.round((firstDTS - refDTS) / 90);
+
+      if (delta) {
+        // debugger;
+        firstDTS = refDTS;
+        nalUnit.dts = firstDTS + initDTS;
+        firstPTS = Math.max(firstPTS - delta, refDTS);
+        nalUnit.pts = firstPTS + initDTS;
+      }
+    }
+
+    nalUnit = nalUnits[nalUnits.length - 1];
+
+    lastDTS = Math.max(normalizePTS(nalUnit.dts, refDTS) - initDTS, 0);
+    lastPTS = Math.max(normalizePTS(nalUnit.pts, refDTS) - initDTS, 0);
+    lastPTS = Math.max(lastPTS, lastDTS);
+
+    for (i = 0; i < nalUnits.length; i++) {
+      nalUnit = nalUnits[i];
+
+      nalUnit.dts = Math.max(normalizePTS(nalUnit.dts, refDTS) - initDTS, firstDTS);
+      nalUnit.pts = Math.max(normalizePTS(nalUnit.pts, refDTS) - initDTS, nalUnit.dts);
+
+      // collectDtsInfo(track, nalUnit);
+    }
+  }
+
   this.resetStream_ = function() {
     clearDtsInfo(track);
 
@@ -420,6 +530,7 @@ VideoSegmentStream = function(track) {
       currentGopObj,
       i;
 
+    // debugger;
     // Search for the GOP nearest to the beginning of this nal unit
     for (i = 0; i < this.gopCache_.length; i++) {
       currentGopObj = this.gopCache_[i];
@@ -738,10 +849,13 @@ calculateTrackBaseMediaDecodeTime = function(track) {
     scale,
     // Calculate the distance, in time, that this segment starts from the start
     // of the timeline (earliest time seen since the transmuxer initialized)
-    timeSinceStartOfTimeline = track.minSegmentDts - track.timelineStartInfo.dts,
+    timeSinceStartOfTimeline = normalizePTS(track.minSegmentDts - track.timelineStartInfo.dts,
+      track.timelineStartInfo.baseMediaDecodeTime),
+    // timeSinceStartOfTimeline = track.minSegmentDts,
     // Calculate the first sample's effective compositionTimeOffset
     firstSampleCompositionOffset = track.minSegmentPts - track.minSegmentDts;
 
+  // debugger;
   // track.timelineStartInfo.baseMediaDecodeTime is the location, in time, where
   // we want the start of the first segment to be placed
   track.baseMediaDecodeTime = track.timelineStartInfo.baseMediaDecodeTime;
@@ -1112,6 +1226,9 @@ Transmuxer = function(options) {
 
     this.baseMediaDecodeTime = baseMediaDecodeTime;
     if (audioTrack) {
+      if (pipeline.audioSegmentStream) {
+        pipeline.audioSegmentStream.refPTS_ = undefined;
+      }
       audioTrack.timelineStartInfo.dts = undefined;
       audioTrack.timelineStartInfo.pts = undefined;
       clearDtsInfo(audioTrack);
@@ -1120,6 +1237,7 @@ Transmuxer = function(options) {
     if (videoTrack) {
       if (pipeline.videoSegmentStream) {
         pipeline.videoSegmentStream.gopCache_ = [];
+        pipeline.videoSegmentStream.refDTS_ = undefined;
       }
       videoTrack.timelineStartInfo.dts = undefined;
       videoTrack.timelineStartInfo.pts = undefined;

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -45,8 +45,7 @@ var
   clearDtsInfo,
   calculateTrackBaseMediaDecodeTime,
   arrayEquals,
-  sumFrameByteLengths,
-  normalizePTS;
+  sumFrameByteLengths;
 
 /**
  * Default sample object
@@ -114,27 +113,6 @@ sumFrameByteLengths = function(array) {
 };
 
 /**
- * Normalize PTS value based on reference value to account for 
- * PTS rollover
- */
-normalizePTS = function(value, ref) {
-  var offset = 8589934592; // 2^33
-
-  if (ref === undefined) {
-    return value;
-  }
-  if (ref < value) {
-    offset *= -1;
-  }
-  // If the difference between the pts value and the reference pts is greater
-  // than half (2^32), then a rollover occured
-  while(Math.abs(value - ref) > 4294967296) {
-    value += offset;
-  }
-  return value;
-}
-
-/**
  * Constructs a single-track, ISO BMFF media segment from AAC data
  * events. The output of this stream can be fed to a SourceBuffer
  * configured with a suitable initialization segment.
@@ -180,12 +158,6 @@ AudioSegmentStream = function(track) {
     }
 
     frames = this.trimAdtsFramesByEarliestDts_(adtsFrames);
-
-    // adtsFrames.forEach((frame) => {
-    //   console.log('pts', frame.pts, '\ndts', frame.dts, '\n--------');
-    // });
-
-    // this.normalizeAdtsFrames_(adtsFrames);
 
     // we have to build the index from byte locations to
     // samples (that is, adts frames) in the audio data
@@ -305,8 +277,6 @@ VideoSegmentStream = function(track) {
 
   this.gopCache_ = [];
 
-  this.refDTS_ = undefined;
-
   this.push = function(nalUnit) {
     collectDtsInfo(track, nalUnit);
 
@@ -354,8 +324,6 @@ VideoSegmentStream = function(track) {
       this.trigger('done', 'VideoSegmentStream');
       return;
     }
-    debugger;
-    this.normalizeNalPTS_(nalUnits);
 
     // Organize the raw nal-units into arrays that represent
     // higher-level constructs such as frames and gops
@@ -400,17 +368,7 @@ VideoSegmentStream = function(track) {
         gops = this.extendFirstKeyFrame_(gops);
       }
     }
-    // collectDtsInfo(track, gops);
-    // var pr = frames[0].pts;
-    // frames.forEach(nal => {
-    //   console.log(`>> pts: ${nal.pts}`);
-    //   if (nal.pts < pr) {
-    //     console.log('>> ****************************');
-    //   }
-    //   pr = nal.pts;
-    // });
-
-    this.refDTS_ = gops[gops.length - 1].dts + gops[gops.length - 1].duration;
+    collectDtsInfo(track, gops);
 
     // First, we have to build the index from byte locations to
     // samples (that is, frames) in the video data
@@ -431,8 +389,6 @@ VideoSegmentStream = function(track) {
 
     // Clear nalUnits
     nalUnits = [];
-
-    // debugger;
 
     calculateTrackBaseMediaDecodeTime(track);
 
@@ -457,56 +413,6 @@ VideoSegmentStream = function(track) {
     // Continue with the flush process now
     this.trigger('done', 'VideoSegmentStream');
   };
-
-  this.normalizeNalPTS_ = function(nalUnits) {
-    let refDTS, firstDTS, firstPTS, lastDTS, lastPTS, nalUnit, i, initDTS;
-
-    // debugger;
-    initDTS = track.timelineStartInfo.dts;
-
-    if (this.refDTS_ !== undefined) {
-      refDTS = this.refDTS_
-    } else {
-      refDTS = track.timelineStartInfo.baseMediaDecodeTime;
-      // debugger;
-    }
-
-    // clearDtsInfo(track);
-
-    nalUnit = nalUnits[0];
-    // initDTS = 0;
-
-    firstDTS = Math.max(normalizePTS(nalUnit.dts, refDTS) - initDTS, 0);
-    firstPTS = Math.max(normalizePTS(nalUnit.pts, refDTS) - initDTS, 0);
-
-    if (this.refDTS_ !== undefined) {
-      // track contiguous with previous
-      let delta = Math.round((firstDTS - refDTS) / 90);
-
-      if (delta) {
-        // debugger;
-        firstDTS = refDTS;
-        nalUnit.dts = firstDTS + initDTS;
-        firstPTS = Math.max(firstPTS - delta, refDTS);
-        nalUnit.pts = firstPTS + initDTS;
-      }
-    }
-
-    nalUnit = nalUnits[nalUnits.length - 1];
-
-    lastDTS = Math.max(normalizePTS(nalUnit.dts, refDTS) - initDTS, 0);
-    lastPTS = Math.max(normalizePTS(nalUnit.pts, refDTS) - initDTS, 0);
-    lastPTS = Math.max(lastPTS, lastDTS);
-
-    for (i = 0; i < nalUnits.length; i++) {
-      nalUnit = nalUnits[i];
-
-      nalUnit.dts = Math.max(normalizePTS(nalUnit.dts, refDTS) - initDTS, firstDTS);
-      nalUnit.pts = Math.max(normalizePTS(nalUnit.pts, refDTS) - initDTS, nalUnit.dts);
-
-      // collectDtsInfo(track, nalUnit);
-    }
-  }
 
   this.resetStream_ = function() {
     clearDtsInfo(track);
@@ -849,13 +755,10 @@ calculateTrackBaseMediaDecodeTime = function(track) {
     scale,
     // Calculate the distance, in time, that this segment starts from the start
     // of the timeline (earliest time seen since the transmuxer initialized)
-    timeSinceStartOfTimeline = normalizePTS(track.minSegmentDts - track.timelineStartInfo.dts,
-      track.timelineStartInfo.baseMediaDecodeTime),
-    // timeSinceStartOfTimeline = track.minSegmentDts,
+    timeSinceStartOfTimeline = track.minSegmentDts - track.timelineStartInfo.dts,
     // Calculate the first sample's effective compositionTimeOffset
     firstSampleCompositionOffset = track.minSegmentPts - track.minSegmentDts;
 
-  // debugger;
   // track.timelineStartInfo.baseMediaDecodeTime is the location, in time, where
   // we want the start of the first segment to be placed
   track.baseMediaDecodeTime = track.timelineStartInfo.baseMediaDecodeTime;
@@ -1133,6 +1036,7 @@ Transmuxer = function(options) {
     pipeline.packetStream = new m2ts.TransportPacketStream();
     pipeline.parseStream = new m2ts.TransportParseStream();
     pipeline.elementaryStream = new m2ts.ElementaryStream();
+    pipeline.tsCorrectionStream = new m2ts.TSCorrectionStream();
     pipeline.adtsStream = new AdtsStream();
     pipeline.h264Stream = new H264Stream();
     pipeline.captionStream = new m2ts.CaptionStream();
@@ -1142,16 +1046,17 @@ Transmuxer = function(options) {
     // disassemble MPEG2-TS packets into elementary streams
     pipeline.packetStream
       .pipe(pipeline.parseStream)
-      .pipe(pipeline.elementaryStream);
+      .pipe(pipeline.elementaryStream)
+      .pipe(pipeline.tsCorrectionStream);
 
     // !!THIS ORDER IS IMPORTANT!!
     // demux the streams
-    pipeline.elementaryStream
+    pipeline.tsCorrectionStream
       .pipe(pipeline.h264Stream);
-    pipeline.elementaryStream
+    pipeline.tsCorrectionStream
       .pipe(pipeline.adtsStream);
 
-    pipeline.elementaryStream
+    pipeline.tsCorrectionStream
       .pipe(pipeline.metadataStream)
       .pipe(pipeline.coalesceStream);
 
@@ -1226,9 +1131,6 @@ Transmuxer = function(options) {
 
     this.baseMediaDecodeTime = baseMediaDecodeTime;
     if (audioTrack) {
-      if (pipeline.audioSegmentStream) {
-        pipeline.audioSegmentStream.refPTS_ = undefined;
-      }
       audioTrack.timelineStartInfo.dts = undefined;
       audioTrack.timelineStartInfo.pts = undefined;
       clearDtsInfo(audioTrack);
@@ -1237,7 +1139,6 @@ Transmuxer = function(options) {
     if (videoTrack) {
       if (pipeline.videoSegmentStream) {
         pipeline.videoSegmentStream.gopCache_ = [];
-        pipeline.videoSegmentStream.refDTS_ = undefined;
       }
       videoTrack.timelineStartInfo.dts = undefined;
       videoTrack.timelineStartInfo.pts = undefined;

--- a/test/transmuxer.test.js
+++ b/test/transmuxer.test.js
@@ -16,8 +16,8 @@ var mp2t = require('../lib/m2ts'),
     transportParseStream,
     ElementaryStream = mp2t.ElementaryStream,
     elementaryStream,
-    TSCorrectionStream = mp2t.TSCorrectionStream,
-    tsCorrectionStream,
+    TimestampRolloverStream = mp2t.TimestampRolloverStream,
+    timestampRolloverStream,
     AacStream = aac,
     H264Stream = codecs.h264.H264Stream,
     h264Stream,
@@ -886,11 +886,11 @@ QUnit.test('drops packets with unknown stream types', function() {
   QUnit.equal(packets.length, 0, 'ignored unknown packets');
 });
 
-QUnit.module('MP2T TSCorrectionStream', {
+QUnit.module('MP2T TimestampRolloverStream', {
   setup: function() {
-    tsCorrectionStream = new TSCorrectionStream('audio');
+    timestampRolloverStream = new TimestampRolloverStream('audio');
     elementaryStream = new ElementaryStream();
-    elementaryStream.pipe(tsCorrectionStream);
+    elementaryStream.pipe(timestampRolloverStream);
   }
 });
 
@@ -904,7 +904,7 @@ QUnit.test('Correctly parses rollover PTS', function() {
     pesHeadThree = pesHeader(false, maxTS),
     pesHeadFour = pesHeader(false, 50);
 
-  tsCorrectionStream.on('data', function(packet) {
+  timestampRolloverStream.on('data', function(packet) {
     packets.push(packet);
   });
   elementaryStream.push({
@@ -958,7 +958,7 @@ QUnit.test('Correctly parses multiple PTS rollovers', function() {
                 pesHeader(false, Math.floor(maxTS * (2 / 3))),
                 pesHeader(false, 1)];
 
-  tsCorrectionStream.on('data', function(packet) {
+  timestampRolloverStream.on('data', function(packet) {
     packets.push(packet);
   });
 

--- a/test/transmuxer.test.js
+++ b/test/transmuxer.test.js
@@ -896,12 +896,12 @@ QUnit.module('MP2T TSCorrectionStream', {
 
 QUnit.test('Correctly parses rollover PTS', function() {
   var
-    max_ts = 8589934592,
+    maxTS = 8589934592,
     packets = [],
     packetData = [0x01, 0x02],
-    pesHeadOne = pesHeader(false, max_ts - 400),
-    pesHeadTwo = pesHeader(false, max_ts - 100),
-    pesHeadThree = pesHeader(false, max_ts),
+    pesHeadOne = pesHeader(false, maxTS - 400),
+    pesHeadTwo = pesHeader(false, maxTS - 100),
+    pesHeadThree = pesHeader(false, maxTS),
     pesHeadFour = pesHeader(false, 50);
 
   tsCorrectionStream.on('data', function(packet) {
@@ -936,26 +936,26 @@ QUnit.test('Correctly parses rollover PTS', function() {
   QUnit.equal(packets.length, 4, 'built four packets');
   QUnit.equal(packets[0].type, 'audio', 'identified audio data');
   QUnit.equal(packets[0].data.byteLength, packetData.length, 'parsed the correct payload size');
-  QUnit.equal(packets[0].pts, max_ts - 400, 'correctly parsed the pts value');
-  QUnit.equal(packets[1].pts, max_ts - 100, 'Does not rollover on minor change');
-  QUnit.equal(packets[2].pts, max_ts, 'correctly parses the max pts value');
-  QUnit.equal(packets[3].pts, max_ts + 50, 'correctly parsed the rollover pts value');
+  QUnit.equal(packets[0].pts, maxTS - 400, 'correctly parsed the pts value');
+  QUnit.equal(packets[1].pts, maxTS - 100, 'Does not rollover on minor change');
+  QUnit.equal(packets[2].pts, maxTS, 'correctly parses the max pts value');
+  QUnit.equal(packets[3].pts, maxTS + 50, 'correctly parsed the rollover pts value');
 });
 
 QUnit.test('Correctly parses multiple PTS rollovers', function() {
   var
-    max_ts = 8589934592,
+    maxTS = 8589934592,
     packets = [],
     packetData = [0x01, 0x02],
     pesArray = [pesHeader(false, 1),
-                pesHeader(false, Math.floor(max_ts * (1 / 3))),
-                pesHeader(false, Math.floor(max_ts * (2 / 3))),
+                pesHeader(false, Math.floor(maxTS * (1 / 3))),
+                pesHeader(false, Math.floor(maxTS * (2 / 3))),
                 pesHeader(false, 1),
-                pesHeader(false, Math.floor(max_ts * (1 / 3))),
-                pesHeader(false, Math.floor(max_ts * (2 / 3))),
+                pesHeader(false, Math.floor(maxTS * (1 / 3))),
+                pesHeader(false, Math.floor(maxTS * (2 / 3))),
                 pesHeader(false, 1),
-                pesHeader(false, Math.floor(max_ts * (1 / 3))),
-                pesHeader(false, Math.floor(max_ts * (2 / 3))),
+                pesHeader(false, Math.floor(maxTS * (1 / 3))),
+                pesHeader(false, Math.floor(maxTS * (2 / 3))),
                 pesHeader(false, 1)];
 
   tsCorrectionStream.on('data', function(packet) {
@@ -975,15 +975,15 @@ QUnit.test('Correctly parses multiple PTS rollovers', function() {
 
   QUnit.equal(packets.length, 10, 'built ten packets');
   QUnit.equal(packets[0].pts, 1, 'correctly parsed the pts value');
-  QUnit.equal(packets[1].pts, Math.floor(max_ts * (1 / 3)), 'correctly parsed the pts value');
-  QUnit.equal(packets[2].pts, Math.floor(max_ts * (2 / 3)), 'correctly parsed the pts value');
-  QUnit.equal(packets[3].pts, max_ts + 1, 'correctly parsed the pts value');
-  QUnit.equal(packets[4].pts, max_ts + Math.floor(max_ts * (1 / 3)), 'correctly parsed the pts value');
-  QUnit.equal(packets[5].pts, max_ts + Math.floor(max_ts * (2 / 3)), 'correctly parsed the pts value');
-  QUnit.equal(packets[6].pts, (2 * max_ts) + 1, 'correctly parsed the pts value');
-  QUnit.equal(packets[7].pts, (2 * max_ts) + Math.floor(max_ts * (1 / 3)), 'correctly parsed the pts value');
-  QUnit.equal(packets[8].pts, (2 * max_ts) + Math.floor(max_ts * (2 / 3)), 'correctly parsed the pts value');
-  QUnit.equal(packets[9].pts, (3 * max_ts) + 1, 'correctly parsed the pts value');
+  QUnit.equal(packets[1].pts, Math.floor(maxTS * (1 / 3)), 'correctly parsed the pts value');
+  QUnit.equal(packets[2].pts, Math.floor(maxTS * (2 / 3)), 'correctly parsed the pts value');
+  QUnit.equal(packets[3].pts, maxTS + 1, 'correctly parsed the pts value');
+  QUnit.equal(packets[4].pts, maxTS + Math.floor(maxTS * (1 / 3)), 'correctly parsed the pts value');
+  QUnit.equal(packets[5].pts, maxTS + Math.floor(maxTS * (2 / 3)), 'correctly parsed the pts value');
+  QUnit.equal(packets[6].pts, (2 * maxTS) + 1, 'correctly parsed the pts value');
+  QUnit.equal(packets[7].pts, (2 * maxTS) + Math.floor(maxTS * (1 / 3)), 'correctly parsed the pts value');
+  QUnit.equal(packets[8].pts, (2 * maxTS) + Math.floor(maxTS * (2 / 3)), 'correctly parsed the pts value');
+  QUnit.equal(packets[9].pts, (3 * maxTS) + 1, 'correctly parsed the pts value');
 });
 
 QUnit.module('H264 Stream', {


### PR DESCRIPTION
## Description
Every 26 hours the PTS value resets to 0. We need to detect this condition in the Muxer and add a value to make the PTS values continuous.
* Rollover conditions:
  * Between a single PES packet's DTS and it's PTS
  * Between a PES packet's PTS and the next packet's DTS
* There is a spec for M2TS playback over MSE  https://w3c.github.io/media-source/mp2t-byte-stream-format.html#mpeg2ts-discontinuities

## Specific Changes proposed
* Detect when the PTS OR DTS value rolls over
* Adjust PTS and DTS values to be always increasing by adding `n*2^33` where `n` is the number of rollovers.
* Attach a `TSCorrectionStream` to the end of the `ElementaryStream` or `AacStream` in the pipeline to make these adjustments
* Tests

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors