### PR TITLE
Fix: Force stable sort of cea608 captions

### DIFF
--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -186,9 +186,14 @@ CaptionStream.prototype.flush = function() {
     return;
   }
 
+  // map the presort index so we can use it to disambiguate the sort()
+  // in order to ensure we get a stable sort()
+  this.captionPackets_.map(function(elem, idx) {
+    elem.presortIndex = idx;
+  });
   // sort caption byte-pairs based on their PTS values
   this.captionPackets_.sort(function(a, b) {
-    return a.pts - b.pts;
+    return (a.pts - b.pts === 0) ? a.presortIndex - b.presortIndex : a.pts - b.pts;
   });
 
   // Push each caption into Cea608Stream


### PR DESCRIPTION
Add a presortIndex property to cea608 caption objects in order to disambiguate the sort so that we get a stable sort
See issue: https://github.com/videojs/mux.js/issues/100