### PR TITLE
Stop applying the compositionTimestamp of the first frame to the baseMediaDecodeTime…

### DIFF
--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -734,13 +734,11 @@ clearDtsInfo = function(track) {
  */
 calculateTrackBaseMediaDecodeTime = function(track) {
   var
-    oneSecondInPTS = 90000, // 90kHz clock
+    oneSecondInTS = 90000, // 90kHz clock
     scale,
     // Calculate the distance, in time, that this segment starts from the start
     // of the timeline (earliest time seen since the transmuxer initialized)
-    timeSinceStartOfTimeline = track.minSegmentDts - track.timelineStartInfo.dts,
-    // Calculate the first sample's effective compositionTimeOffset
-    firstSampleCompositionOffset = track.minSegmentPts - track.minSegmentDts;
+    timeSinceStartOfTimeline = track.minSegmentDts - track.timelineStartInfo.dts;
 
   // track.timelineStartInfo.baseMediaDecodeTime is the location, in time, where
   // we want the start of the first segment to be placed
@@ -749,18 +747,13 @@ calculateTrackBaseMediaDecodeTime = function(track) {
   // Add to that the distance this segment is from the very first
   track.baseMediaDecodeTime += timeSinceStartOfTimeline;
 
-  // Subtract this segment's "compositionTimeOffset" so that the first frame of
-  // this segment is displayed exactly at the `baseMediaDecodeTime` or at the
-  // end of the previous segment
-  track.baseMediaDecodeTime -= firstSampleCompositionOffset;
-
   // baseMediaDecodeTime must not become negative
   track.baseMediaDecodeTime = Math.max(0, track.baseMediaDecodeTime);
 
   if (track.type === 'audio') {
     // Audio has a different clock equal to the sampling_rate so we need to
     // scale the PTS values into the clock rate of the track
-    scale = track.samplerate / oneSecondInPTS;
+    scale = track.samplerate / oneSecondInTS;
     track.baseMediaDecodeTime *= scale;
     track.baseMediaDecodeTime = Math.floor(track.baseMediaDecodeTime);
   }

--- a/test/transmuxer.test.js
+++ b/test/transmuxer.test.js
@@ -2036,7 +2036,7 @@ QUnit.test('calculates baseMediaDecodeTime values relative to a customizable bas
   QUnit.equal(tfdt.baseMediaDecodeTime, 1324, 'calculated baseMediaDecodeTime');
 });
 
-QUnit.test('subtract the first frame\'s compositionTimeOffset from baseMediaDecodeTime', function() {
+QUnit.test('do not subtract the first frame\'s compositionTimeOffset from baseMediaDecodeTime', function() {
   var segment, boxes, tfdt;
   videoSegmentStream.track.timelineStartInfo = {
     dts: 10,
@@ -2078,9 +2078,7 @@ QUnit.test('subtract the first frame\'s compositionTimeOffset from baseMediaDeco
 
   // The timelineStartInfo's bMDT is 100 and that corresponds to a dts/pts of 10
   // The first frame has a dts 50 so the bMDT is calculated as: (50 - 10) + 100 = 140
-  // The first frame has a compositionTimeOffset of: 60 - 50 = 10
-  // The final track's bMDT is therefore: 140 - 10 = 130
-  QUnit.equal(tfdt.baseMediaDecodeTime, 130, 'calculated baseMediaDecodeTime');
+  QUnit.equal(tfdt.baseMediaDecodeTime, 140, 'calculated baseMediaDecodeTime');
 });
 
 QUnit.module('ADTS Stream', {


### PR DESCRIPTION
...Because that makes no sense.

This was causing problems when switching between different renditions. It created a situation where entire GoPs could be removed (mostly by Chrome) after an append or result in gaps between segments of different renditions.
