### PR TITLE
Set the PTS and DTS for TS timestamp ID3 tags

### DIFF
--- a/lib/m2ts/metadata-stream.js
+++ b/lib/m2ts/metadata-stream.js
@@ -209,6 +209,9 @@ MetadataStream = function(options) {
       frame.key = frame.id;
       if (tagParsers[frame.id]) {
         tagParsers[frame.id](frame);
+
+        // handle the special PRIV frame used to indicate the start
+        // time for raw AAC data
         if (frame.owner === 'com.apple.streaming.transportStreamTimestamp') {
           var
             d = frame.data,
@@ -221,6 +224,14 @@ MetadataStream = function(options) {
           size *= 4;
           size += d[7] & 0x03;
           frame.timeStamp = size;
+          // in raw AAC, all subsequent data will be timestamped based
+          // on the value of this frame
+          // we couldn't have known the appropriate pts and dts before
+          // parsing this ID3 tag so set those values now
+          if (tag.pts === undefined && tag.dts === undefined) {
+            tag.pts = frame.timeStamp;
+            tag.dts = frame.timeStamp;
+          }
           this.trigger('timestamp', frame);
         }
       }


### PR DESCRIPTION
The special PRIV frame that specifies the timestamp in raw AAC data would not itself receive a timestamp since it was already parsed when the base timestamp was set. Add special case handling for that ID3 tag so that it does not end up with a cueTime of NaN when picked up by the CoalesceStream in the MP4 transmuxer.