### PR TITLE
Added support for generating version 1 TFDT boxes

### DIFF
--- a/lib/mp4/mp4-generator.js
+++ b/lib/mp4/mp4-generator.js
@@ -536,8 +536,9 @@ tkhd = function(track) {
  * about tracks in a movie fragment (moof) box.
  */
 traf = function(track) {
-  var trackFragmentHeader, trackFragmentDecodeTime,
-      trackFragmentRun, sampleDependencyTable, dataOffset;
+  var trackFragmentHeader, trackFragmentDecodeTime, trackFragmentRun,
+      sampleDependencyTable, dataOffset, maxWordValue,
+      upperWordBaseMediaDecodeTime, lowerWordBaseMediaDecodeTime;
 
   trackFragmentHeader = box(types.tfhd, new Uint8Array([
     0x00, // version 0
@@ -552,21 +553,29 @@ traf = function(track) {
     0x00, 0x00, 0x00, 0x00  // default_sample_flags
   ]));
 
+  maxWordValue = Math.pow(2, 32);
+  upperWordBaseMediaDecodeTime = Math.floor(track.baseMediaDecodeTime / maxWordValue);
+  lowerWordBaseMediaDecodeTime = Math.floor(track.baseMediaDecodeTime % maxWordValue);
+
   trackFragmentDecodeTime = box(types.tfdt, new Uint8Array([
-    0x00, // version 0
+    0x01, // version 1
     0x00, 0x00, 0x00, // flags
     // baseMediaDecodeTime
-    (track.baseMediaDecodeTime >>> 24) & 0xFF,
-    (track.baseMediaDecodeTime >>> 16) & 0xFF,
-    (track.baseMediaDecodeTime >>> 8) & 0xFF,
-    track.baseMediaDecodeTime & 0xFF
+    (upperWordBaseMediaDecodeTime >>> 24) & 0xFF,
+    (upperWordBaseMediaDecodeTime >>> 16) & 0xFF,
+    (upperWordBaseMediaDecodeTime >>>  8) & 0xFF,
+    upperWordBaseMediaDecodeTime & 0xFF,
+    (lowerWordBaseMediaDecodeTime >>> 24) & 0xFF,
+    (lowerWordBaseMediaDecodeTime >>> 16) & 0xFF,
+    (lowerWordBaseMediaDecodeTime >>>  8) & 0xFF,
+    lowerWordBaseMediaDecodeTime & 0xFF
   ]));
 
   // the data offset specifies the number of bytes from the start of
   // the containing moof to the first payload byte of the associated
   // mdat
   dataOffset = (32 + // tfhd
-                16 + // tfdt
+                20 + // tfdt
                 8 +  // traf header
                 16 + // mfhd
                 8 +  // moof header

--- a/lib/mp4/mp4-generator.js
+++ b/lib/mp4/mp4-generator.js
@@ -9,6 +9,8 @@
  */
 'use strict';
 
+var UINT32_MAX = Math.pow(2, 32) - 1;
+
 var box, dinf, esds, ftyp, mdat, mfhd, minf, moof, moov, mvex, mvhd,
     trak, tkhd, mdia, mdhd, hdlr, sdtp, stbl, stsd, traf, trex,
     trun, types, MAJOR_BRAND, MINOR_VERSION, AVC1_BRAND, VIDEO_HDLR,
@@ -537,7 +539,7 @@ tkhd = function(track) {
  */
 traf = function(track) {
   var trackFragmentHeader, trackFragmentDecodeTime, trackFragmentRun,
-      sampleDependencyTable, dataOffset, maxWordValue,
+      sampleDependencyTable, dataOffset,
       upperWordBaseMediaDecodeTime, lowerWordBaseMediaDecodeTime;
 
   trackFragmentHeader = box(types.tfhd, new Uint8Array([
@@ -553,9 +555,8 @@ traf = function(track) {
     0x00, 0x00, 0x00, 0x00  // default_sample_flags
   ]));
 
-  maxWordValue = Math.pow(2, 32);
-  upperWordBaseMediaDecodeTime = Math.floor(track.baseMediaDecodeTime / maxWordValue);
-  lowerWordBaseMediaDecodeTime = Math.floor(track.baseMediaDecodeTime % maxWordValue);
+  upperWordBaseMediaDecodeTime = Math.floor(track.baseMediaDecodeTime / (UINT32_MAX + 1));
+  lowerWordBaseMediaDecodeTime = Math.floor(track.baseMediaDecodeTime % (UINT32_MAX + 1));
 
   trackFragmentDecodeTime = box(types.tfdt, new Uint8Array([
     0x01, // version 1

--- a/test/mp4-inspector.test.js
+++ b/test/mp4-inspector.test.js
@@ -800,7 +800,7 @@ QUnit.test('can parse an smhd', function() {
             'parsed an smhd');
 });
 
-QUnit.test('can parse a tfdt', function() {
+QUnit.test('can parse a version 0 tfdt', function() {
   var data = box('tfdt',
                  0x00, // version
                  0x00, 0x00, 0x00, // flags
@@ -812,6 +812,22 @@ QUnit.test('can parse a tfdt', function() {
               size: 16,
               flags: new Uint8Array([0, 0, 0]),
               baseMediaDecodeTime: 0x01020304
+            }]);
+});
+
+QUnit.test('can parse a version 1 tfdt', function() {
+  var data = box('tfdt',
+                 0x01, // version
+                 0x00, 0x00, 0x00, // flags
+                 0x01, 0x02, 0x03, 0x04,
+                 0x05, 0x06, 0x07, 0x08); // baseMediaDecodeTime
+  QUnit.deepEqual(mp4.tools.inspect(new Uint8Array(data)),
+            [{
+              type: 'tfdt',
+              version: 1,
+              size: 20,
+              flags: new Uint8Array([0, 0, 0]),
+              baseMediaDecodeTime: 0x0102030405060708
             }]);
 });
 

--- a/test/transmuxer.test.js
+++ b/test/transmuxer.test.js
@@ -1995,11 +1995,14 @@ QUnit.test('calculates baseMediaDecodeTime values from the first DTS ever seen a
 });
 
 QUnit.test('calculates baseMediaDecodeTime values relative to a customizable baseMediaDecodeTime', function() {
-  var segment, boxes, tfdt;
+  var segment, boxes, tfdt, bMDTValue;
+
+  bMDTValue = Math.pow(2, 32) + 100;
+
   videoSegmentStream.track.timelineStartInfo = {
     dts: 10,
     pts: 10,
-    baseMediaDecodeTime: 1234
+    baseMediaDecodeTime: bMDTValue
   };
   videoSegmentStream.on('data', function(data) {
     segment = data.boxes;
@@ -2033,7 +2036,7 @@ QUnit.test('calculates baseMediaDecodeTime values relative to a customizable bas
 
   boxes = mp4.tools.inspect(segment);
   tfdt = boxes[0].boxes[1].boxes[1];
-  QUnit.equal(tfdt.baseMediaDecodeTime, 1324, 'calculated baseMediaDecodeTime');
+  QUnit.equal(tfdt.baseMediaDecodeTime, bMDTValue + 90, 'calculated baseMediaDecodeTime');
 });
 
 QUnit.test('subtract the first frame\'s compositionTimeOffset from baseMediaDecodeTime', function() {

--- a/test/transmuxer.test.js
+++ b/test/transmuxer.test.js
@@ -1995,14 +1995,16 @@ QUnit.test('calculates baseMediaDecodeTime values from the first DTS ever seen a
 });
 
 QUnit.test('calculates baseMediaDecodeTime values relative to a customizable baseMediaDecodeTime', function() {
-  var segment, boxes, tfdt, bMDTValue;
+  var segment, boxes, tfdt, baseMediaDecodeTimeValue;
 
-  bMDTValue = Math.pow(2, 32) + 100;
+  // Set the baseMediaDecodeTime to something over 2^32 to ensure
+  // that the version 1 TFDT box is being created correctly
+  baseMediaDecodeTimeValue = Math.pow(2, 32) + 100;
 
   videoSegmentStream.track.timelineStartInfo = {
     dts: 10,
     pts: 10,
-    baseMediaDecodeTime: bMDTValue
+    baseMediaDecodeTime: baseMediaDecodeTimeValue
   };
   videoSegmentStream.on('data', function(data) {
     segment = data.boxes;
@@ -2036,7 +2038,10 @@ QUnit.test('calculates baseMediaDecodeTime values relative to a customizable bas
 
   boxes = mp4.tools.inspect(segment);
   tfdt = boxes[0].boxes[1].boxes[1];
-  QUnit.equal(tfdt.baseMediaDecodeTime, bMDTValue + 90, 'calculated baseMediaDecodeTime');
+
+  // The timeline begins at 10 and the first sample has a dts of
+  // 100, so the baseMediaDecodeTime should be equal to (100 - 10)
+  QUnit.equal(tfdt.baseMediaDecodeTime, baseMediaDecodeTimeValue + 90, 'calculated baseMediaDecodeTime');
 });
 
 QUnit.test('subtract the first frame\'s compositionTimeOffset from baseMediaDecodeTime', function() {


### PR DESCRIPTION
Switch to using version 1 tfdt boxes to allow up to 64-bits for the baseMediaDecodeTime. 

Since we use a 90kHz clock for the BMDT, we can exceed a 32-bit value after ~13.256 hours of video. This can cause a problem with live-streams or extremely long VODs as the BMDT will wrap around and playback will likely break.

