### PR TITLE
Create mp4 init segment only for first segment of timeline

### DIFF
--- a/debug/index.html
+++ b/debug/index.html
@@ -302,11 +302,14 @@ mp4fragment --track audio --fragment-duration 11000 movie-audio.mp4 movie-audio.
             outputType = document.querySelector('input[name="output"]:checked').value,
             resetTransmuxer = $('#reset-tranmsuxer').checked,
             remuxedSegments = [],
+            remuxedInitSegment = null,
             remuxedBytesLength = 0,
+            createInitSegment = false,
             bytes,
             i, j;
 
         if (resetTransmuxer || !transmuxer) {
+          createInitSegment = true;
           if (combined) {
               outputType = 'combined';
               transmuxer = new muxjs.mp4.Transmuxer();
@@ -318,13 +321,22 @@ mp4fragment --track audio --fragment-duration 11000 movie-audio.mp4 movie-audio.
             if (event.type === outputType) {
               remuxedSegments.push(event);
               remuxedBytesLength += event.data.byteLength;
+              remuxedInitSegment = event.initSegment;
             }
           });
 
           transmuxer.on('done', function () {
-            bytes = new Uint8Array(remuxedBytesLength);
+            var offset = 0;
+            if (createInitSegment) {
+              bytes = new Uint8Array(remuxedInitSegment.byteLength + remuxedBytesLength)
+              bytes.set(remuxedInitSegment, offset);
+              offset += remuxedInitSegment.byteLength;
+              createInitSegment = false;
+            } else {
+              bytes = new Uint8Array(remuxedBytesLength);
+            }
 
-            for (j = 0, i = 0; j < remuxedSegments.length; j++) {
+            for (j = 0, i = offset; j < remuxedSegments.length; j++) {
               bytes.set(remuxedSegments[j].data, i);
               i += remuxedSegments[j].byteLength;
             }

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -791,10 +791,6 @@ CoalesceStream = function(options, metadataStream) {
   this.pendingMetadata = [];
   this.pendingBytes = 0;
   this.emittedTracks = 0;
-  this.createInitSegment = {
-    VideoSegmentStream: true,
-    AudioSegmentStream: true
-  };
 
   CoalesceStream.prototype.init.call(this);
 
@@ -889,22 +885,17 @@ CoalesceStream.prototype.flush = function(flushSource) {
 
   this.emittedTracks += this.pendingTracks.length;
 
-  if (this.createInitSegment[flushSource]) {
-    initSegment = mp4.initSegment(this.pendingTracks);
+  initSegment = mp4.initSegment(this.pendingTracks);
 
-    // Create a new typed array large enough to hold the init
-    // segment and all tracks
-    event.data = new Uint8Array(initSegment.byteLength +
-                                this.pendingBytes);
+  // Create a new typed array to hold the init segment
+  event.initSegment = new Uint8Array(initSegment.byteLength);
 
-    // Create an init segment containing a moov
-    // and track definitions
-    event.data.set(initSegment);
-    offset += initSegment.byteLength;
-    this.createInitSegment[flushSource] = false;
-  } else {
-    event.data = new Uint8Array(this.pendingBytes);
-  }
+  // Create an init segment containing a moov
+  // and track definitions
+  event.initSegment.set(initSegment);
+
+  // Create a new typed array to hold the moof+mdat
+  event.data = new Uint8Array(this.pendingBytes);
 
   // Append each moof+mdat (one per track) after the init segment
   for (i = 0; i < this.pendingBoxes.length; i++) {
@@ -1137,9 +1128,6 @@ Transmuxer = function(options) {
       audioTrack.timelineStartInfo.pts = undefined;
       clearDtsInfo(audioTrack);
       audioTrack.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
-      if (pipeline.coalesceStream) {
-        pipeline.coalesceStream.createInitSegment.AudioSegmentStream = true;
-      }
     }
     if (videoTrack) {
       if (pipeline.videoSegmentStream) {
@@ -1149,9 +1137,6 @@ Transmuxer = function(options) {
       videoTrack.timelineStartInfo.pts = undefined;
       clearDtsInfo(videoTrack);
       videoTrack.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
-      if (pipeline.coalesceStream) {
-        pipeline.coalesceStream.createInitSegment.VideoSegmentStream = true;
-      }
     }
   };
 

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -894,10 +894,10 @@ CoalesceStream.prototype.flush = function(flushSource) {
   // and track definitions
   event.initSegment.set(initSegment);
 
-  // Create a new typed array to hold the moof+mdat
+  // Create a new typed array to hold the moof+mdats
   event.data = new Uint8Array(this.pendingBytes);
 
-  // Append each moof+mdat (one per track) after the init segment
+  // Append each moof+mdat (one per track) together
   for (i = 0; i < this.pendingBoxes.length; i++) {
     event.data.set(this.pendingBoxes[i], offset);
     offset += this.pendingBoxes[i].byteLength;

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -791,6 +791,10 @@ CoalesceStream = function(options, metadataStream) {
   this.pendingMetadata = [];
   this.pendingBytes = 0;
   this.emittedTracks = 0;
+  this.createInitSegment = {
+    VideoSegmentStream: true,
+    AudioSegmentStream: true
+  };
 
   CoalesceStream.prototype.init.call(this);
 
@@ -885,17 +889,22 @@ CoalesceStream.prototype.flush = function(flushSource) {
 
   this.emittedTracks += this.pendingTracks.length;
 
-  initSegment = mp4.initSegment(this.pendingTracks);
+  if (this.createInitSegment[flushSource]) {
+    initSegment = mp4.initSegment(this.pendingTracks);
 
-  // Create a new typed array large enough to hold the init
-  // segment and all tracks
-  event.data = new Uint8Array(initSegment.byteLength +
-                              this.pendingBytes);
+    // Create a new typed array large enough to hold the init
+    // segment and all tracks
+    event.data = new Uint8Array(initSegment.byteLength +
+                                this.pendingBytes);
 
-  // Create an init segment containing a moov
-  // and track definitions
-  event.data.set(initSegment);
-  offset += initSegment.byteLength;
+    // Create an init segment containing a moov
+    // and track definitions
+    event.data.set(initSegment);
+    offset += initSegment.byteLength;
+    this.createInitSegment[flushSource] = false;
+  } else {
+    event.data = new Uint8Array(this.pendingBytes);
+  }
 
   // Append each moof+mdat (one per track) after the init segment
   for (i = 0; i < this.pendingBoxes.length; i++) {
@@ -1128,6 +1137,9 @@ Transmuxer = function(options) {
       audioTrack.timelineStartInfo.pts = undefined;
       clearDtsInfo(audioTrack);
       audioTrack.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
+      if (pipeline.coalesceStream) {
+        pipeline.coalesceStream.createInitSegment.AudioSegmentStream = true;
+      }
     }
     if (videoTrack) {
       if (pipeline.videoSegmentStream) {
@@ -1137,6 +1149,9 @@ Transmuxer = function(options) {
       videoTrack.timelineStartInfo.pts = undefined;
       clearDtsInfo(videoTrack);
       videoTrack.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
+      if (pipeline.coalesceStream) {
+        pipeline.coalesceStream.createInitSegment.VideoSegmentStream = true;
+      }
     }
   };
 

--- a/test/transmuxer.test.js
+++ b/test/transmuxer.test.js
@@ -2884,6 +2884,35 @@ QUnit.test('can be reused for multiple TS segments', function() {
   QUnit.deepEqual(segments[0][5],
             segments[1][3],
             'generated identical audio mdats');
+
+  transmuxer.setBaseMediaDecodeTime(0);
+  transmuxer.push(testSegment);
+  transmuxer.flush();
+
+  QUnit.equal(segments.length, 3, 'generated third segment');
+
+  QUnit.deepEqual(segments[0][0], segments[2][0], 'generated identical ftyp');
+  QUnit.deepEqual(segments[0][1], segments[2][1], 'generated identical moov');
+
+  QUnit.deepEqual(segments[0][2].boxes[1],
+            segments[2][2].boxes[1],
+            'generated identical video trafs');
+  QUnit.equal(segments[2][2].boxes[0].sequenceNumber,
+        2,
+        'set the correct video sequence number');
+  QUnit.deepEqual(segments[0][3],
+            segments[2][3],
+            'generated identical video mdats');
+
+  QUnit.deepEqual(segments[0][4].boxes[3],
+            segments[2][4].boxes[3],
+            'generated identical audio trafs');
+  QUnit.equal(segments[2][4].boxes[0].sequenceNumber,
+        2,
+        'set the correct audio sequence number');
+  QUnit.deepEqual(segments[0][5],
+            segments[2][5],
+            'generated identical audio mdats');
 });
 
 QUnit.module('NalByteStream', {

--- a/test/transmuxer.test.js
+++ b/test/transmuxer.test.js
@@ -2852,36 +2852,37 @@ QUnit.test('can be reused for multiple TS segments', function() {
   transmuxer.flush();
 
   QUnit.equal(segments.length, 2, 'generated two combined segments');
-  QUnit.deepEqual(segments[0][0],
-            segments[1][0],
-            'generated identical ftyps');
-  QUnit.deepEqual(segments[0][1],
-            segments[1][1],
-            'generated identical moovs');
+
+  QUnit.equal(segments[0][0].type, 'ftyp', 'generated ftyp for first segment');
+  QUnit.equal(segments[0][1].type, 'moov', 'generated moov for first segment');
+
+  QUnit.notEqual(segments[1][0].type, 'ftyp', 'did not generate ftyp for first segment');
+  QUnit.notEqual(segments[1][1].type, 'moov', 'did not generate moov for first segment');
+
   QUnit.deepEqual(segments[0][2].boxes[1],
-            segments[1][2].boxes[1],
+            segments[1][0].boxes[1],
             'generated identical video trafs');
   QUnit.equal(segments[0][2].boxes[0].sequenceNumber,
         0,
         'set the correct video sequence number');
-  QUnit.equal(segments[1][2].boxes[0].sequenceNumber,
+  QUnit.equal(segments[1][0].boxes[0].sequenceNumber,
         1,
         'set the correct video sequence number');
   QUnit.deepEqual(segments[0][3],
-            segments[1][3],
+            segments[1][1],
             'generated identical video mdats');
 
   QUnit.deepEqual(segments[0][4].boxes[3],
-            segments[1][4].boxes[3],
+            segments[1][2].boxes[3],
             'generated identical audio trafs');
   QUnit.equal(segments[0][4].boxes[0].sequenceNumber,
         0,
-        'set the correct video sequence number');
-  QUnit.equal(segments[1][4].boxes[0].sequenceNumber,
+        'set the correct audio sequence number');
+  QUnit.equal(segments[1][2].boxes[0].sequenceNumber,
         1,
-        'set the correct video sequence number');
+        'set the correct audio sequence number');
   QUnit.deepEqual(segments[0][5],
-            segments[1][5],
+            segments[1][3],
             'generated identical audio mdats');
 });
 


### PR DESCRIPTION
## Description
Currently we generate and attach an initialization segment (`ftyp` and `moov` boxes) to the mp4 we generate for every ts segment. Adding this init segment for each segment causes a noticeable hiccup in the audio along segment boundaries. Only attaching an init segment on timeline changes when `baseMediaDecodeTime` is set resolves this issue.

Requires [pull request](https://github.com/videojs/videojs-contrib-media-sources/pull/104)

## Specific Changes proposed
Only create a single mp4 init segment whenever `setBaseMediaDecodeTime` is called, otherwise just create the `moof` and `mdat`.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] Unit Tests updated or fixed
- [ ] Reviewed by Two Core Contributors
