### PR TITLE
add ptsTime to ts inspector output

### DIFF
--- a/lib/tools/ts-inspector.js
+++ b/lib/tools/ts-inspector.js
@@ -306,8 +306,11 @@ var adjustTimestamp_ = function(segmentInfo, baseTimestamp) {
       audioBaseTimestamp = segmentInfo.audio[0].dts;
     }
     segmentInfo.audio.forEach(function(info) {
-      info.dts = handleRollover(info.dts, audioBaseTimestamp) / PES_TIMESCALE;
-      info.pts = handleRollover(info.pts, audioBaseTimestamp) / PES_TIMESCALE;
+      info.dts = handleRollover(info.dts, audioBaseTimestamp);
+      info.pts = handleRollover(info.pts, audioBaseTimestamp);
+      // time in seconds
+      info.dtsTime = info.dts / PES_TIMESCALE;
+      info.ptsTime = info.pts / PES_TIMESCALE;
     });
   }
 
@@ -317,13 +320,19 @@ var adjustTimestamp_ = function(segmentInfo, baseTimestamp) {
       videoBaseTimestamp = segmentInfo.video[0].dts;
     }
     segmentInfo.video.forEach(function(info) {
-      info.dts = handleRollover(info.dts, videoBaseTimestamp) / PES_TIMESCALE;
-      info.pts = handleRollover(info.pts, videoBaseTimestamp) / PES_TIMESCALE;
+      info.dts = handleRollover(info.dts, videoBaseTimestamp);
+      info.pts = handleRollover(info.pts, videoBaseTimestamp);
+      // time in seconds
+      info.dtsTime = info.dts / PES_TIMESCALE;
+      info.ptsTime = info.pts / PES_TIMESCALE;
     });
     if (segmentInfo.firstKeyFrame) {
       var frame = segmentInfo.firstKeyFrame;
-      frame.dts = handleRollover(frame.dts, videoBaseTimestamp) / PES_TIMESCALE;
-      frame.pts = handleRollover(frame.pts, videoBaseTimestamp) / PES_TIMESCALE;
+      frame.dts = handleRollover(frame.dts, videoBaseTimestamp);
+      frame.pts = handleRollover(frame.pts, videoBaseTimestamp);
+      // time in seconds
+      frame.dtsTime = frame.dts / PES_TIMESCALE;
+      frame.ptsTime = frame.dts / PES_TIMESCALE;
     }
   }
 };
@@ -462,6 +471,14 @@ var inspectTs_ = function(bytes) {
   return result;
 };
 
+/**
+ * Inspects segment byte data and returns an object with start and end timing information
+ *
+ * @param {Uint8Array} bytes The segment byte data
+ * @param {Number} baseTimestamp Relative reference timestamp used when adjusting frame
+ *  timestamps for rollover. This value must be in 90khz clock.
+ * @return {Object} Object containing start and end frame timing info of segment.
+ */
 var inspect = function(bytes, baseTimestamp) {
   var isAacData = isLikelyAacData(bytes);
 

--- a/test/ts-inspector.test.js
+++ b/test/ts-inspector.test.js
@@ -19,30 +19,40 @@ QUnit.test('can parse a ts segment', function() {
     video: [
       {
         type: 'video',
-        pts: 126000 / PES_TIMESCALE,
-        dts: 126000 / PES_TIMESCALE
+        pts: 126000,
+        dts: 126000,
+        ptsTime: 126000 / PES_TIMESCALE,
+        dtsTime: 126000 / PES_TIMESCALE
       },
       {
         type: 'video',
-        pts: 924000 / PES_TIMESCALE,
-        dts: 924000 / PES_TIMESCALE
+        pts: 924000,
+        dts: 924000,
+        ptsTime: 924000 / PES_TIMESCALE,
+        dtsTime: 924000 / PES_TIMESCALE
       }
     ],
     firstKeyFrame: {
       type: 'video',
-      pts: 126000 / PES_TIMESCALE,
-      dts: 126000 / PES_TIMESCALE
+      pts: 126000,
+      dts: 126000,
+      ptsTime: 126000 / PES_TIMESCALE,
+      dtsTime: 126000 / PES_TIMESCALE
     },
     audio: [
       {
         type: 'audio',
-        pts: 126000 / PES_TIMESCALE,
-        dts: 126000 / PES_TIMESCALE
+        pts: 126000,
+        dts: 126000,
+        ptsTime: 126000 / PES_TIMESCALE,
+        dtsTime: 126000 / PES_TIMESCALE
       },
       {
         type: 'audio',
-        pts: 859518 / PES_TIMESCALE,
-        dts: 859518 / PES_TIMESCALE
+        pts: 859518,
+        dts: 859518,
+        ptsTime: 859518 / PES_TIMESCALE,
+        dtsTime: 859518 / PES_TIMESCALE
       }
     ]
   };
@@ -57,30 +67,40 @@ QUnit.test('adjusts timestamp values based on provided reference', function() {
     video: [
       {
         type: 'video',
-        pts: (126000 + rollover) / PES_TIMESCALE,
-        dts: (126000 + rollover) / PES_TIMESCALE
+        pts: (126000 + rollover),
+        dts: (126000 + rollover),
+        ptsTime: (126000 + rollover) / PES_TIMESCALE,
+        dtsTime: (126000 + rollover) / PES_TIMESCALE
       },
       {
         type: 'video',
-        pts: (924000 + rollover) / PES_TIMESCALE,
-        dts: (924000 + rollover) / PES_TIMESCALE
+        pts: (924000 + rollover),
+        dts: (924000 + rollover),
+        ptsTime: (924000 + rollover) / PES_TIMESCALE,
+        dtsTime: (924000 + rollover) / PES_TIMESCALE
       }
     ],
     firstKeyFrame: {
       type: 'video',
-      pts: (126000 + rollover) / PES_TIMESCALE,
-      dts: (126000 + rollover) / PES_TIMESCALE
+      pts: (126000 + rollover),
+      dts: (126000 + rollover),
+      ptsTime: (126000 + rollover) / PES_TIMESCALE,
+      dtsTime: (126000 + rollover) / PES_TIMESCALE
     },
     audio: [
       {
         type: 'audio',
-        pts: (126000 + rollover) / PES_TIMESCALE,
-        dts: (126000 + rollover) / PES_TIMESCALE
+        pts: (126000 + rollover),
+        dts: (126000 + rollover),
+        ptsTime: (126000 + rollover) / PES_TIMESCALE,
+        dtsTime: (126000 + rollover) / PES_TIMESCALE
       },
       {
         type: 'audio',
-        pts: (859518 + rollover) / PES_TIMESCALE,
-        dts: (859518 + rollover) / PES_TIMESCALE
+        pts: (859518 + rollover),
+        dts: (859518 + rollover),
+        ptsTime: (859518 + rollover) / PES_TIMESCALE,
+        dtsTime: (859518 + rollover) / PES_TIMESCALE
       }
     ]
   };
@@ -94,13 +114,17 @@ QUnit.test('can parse an aac segment', function() {
     audio: [
       {
         type: 'audio',
-        pts: 895690 / PES_TIMESCALE,
-        dts: 895690 / PES_TIMESCALE
+        pts: 895690,
+        dts: 895690,
+        ptsTime: 895690 / PES_TIMESCALE,
+        dtsTime: 895690 / PES_TIMESCALE
       },
       {
         type: 'audio',
-        pts: (895690 + (430 * 1024 * PES_TIMESCALE / 44100)) / PES_TIMESCALE,
-        dts: (895690 + (430 * 1024 * PES_TIMESCALE / 44100)) / PES_TIMESCALE
+        pts: (895690 + (430 * 1024 * PES_TIMESCALE / 44100)),
+        dts: (895690 + (430 * 1024 * PES_TIMESCALE / 44100)),
+        ptsTime: (895690 + (430 * 1024 * PES_TIMESCALE / 44100)) / PES_TIMESCALE,
+        dtsTime: (895690 + (430 * 1024 * PES_TIMESCALE / 44100)) / PES_TIMESCALE
       }
     ]
   };
@@ -113,19 +137,25 @@ QUnit.test('can parse ts segment with no audio muxed in', function() {
     video: [
       {
         type: 'video',
-        pts: 126000 / PES_TIMESCALE,
-        dts: 126000 / PES_TIMESCALE
+        pts: 126000,
+        dts: 126000,
+        ptsTime: 126000 / PES_TIMESCALE,
+        dtsTime: 126000 / PES_TIMESCALE
       },
       {
         type: 'video',
-        pts: 924000 / PES_TIMESCALE,
-        dts: 924000 / PES_TIMESCALE
+        pts: 924000,
+        dts: 924000,
+        ptsTime: 924000 / PES_TIMESCALE,
+        dtsTime: 924000 / PES_TIMESCALE
       }
     ],
     firstKeyFrame: {
       type: 'video',
-      pts: 126000 / PES_TIMESCALE,
-      dts: 126000 / PES_TIMESCALE
+      pts: 126000,
+      dts: 126000,
+      ptsTime: 126000 / PES_TIMESCALE,
+      dtsTime: 126000 / PES_TIMESCALE
     }
   };
 


### PR DESCRIPTION
This changes the output of the ts inspector to include both `pts` and `ptsTime`. `pts` is the timestamp value on the 90khz clock and `ptsTime` is the timestamp value converted into seconds.