### PR TITLE
Set h264Frame to null after we finish the frame

### DIFF
--- a/lib/flv/transmuxer.js
+++ b/lib/flv/transmuxer.js
@@ -196,13 +196,14 @@ VideoSegmentStream = function(track) {
     if (config && track && track.newMetadata &&
         (frame.keyFrame || tags.length === 0)) {
       // Push extra data on every IDR frame in case we did a stream change + seek
-      tags.push(metaDataTag(config, frame.pts));
-      tags.push(extraDataTag(track, frame.pts));
+      tags.push(metaDataTag(config, frame.dts));
+      tags.push(extraDataTag(track, frame.dts));
       track.newMetadata = false;
     }
 
     frame.endNalUnit();
     tags.push(frame);
+    h264Frame = null;
   };
 
   this.push = function(data) {

--- a/test/transmuxer.test.js
+++ b/test/transmuxer.test.js
@@ -3158,6 +3158,54 @@ QUnit.test('buffers video samples until flushed', function() {
   QUnit.equal(segments[0].tags.videoTags.length, 2, 'generated two video tags');
 });
 
+QUnit.test('does not buffer a duplicate video sample on subsequent flushes', function() {
+  var segments = [];
+  transmuxer.on('data', function(data) {
+    segments.push(data);
+  });
+  transmuxer.push(packetize(PAT));
+  transmuxer.push(packetize(generatePMT({
+    hasVideo: true
+  })));
+
+  // buffer a NAL
+  transmuxer.push(packetize(videoPes([0x09, 0x01], true)));
+  transmuxer.push(packetize(videoPes([0x00, 0x02])));
+
+  // add an access_unit_delimiter_rbsp
+  transmuxer.push(packetize(videoPes([0x09, 0x03])));
+  transmuxer.push(packetize(videoPes([0x00, 0x04])));
+  transmuxer.push(packetize(videoPes([0x00, 0x05])));
+
+  // flush everything
+  transmuxer.flush();
+
+  QUnit.equal(segments[0].tags.audioTags.length, 0, 'generated no audio tags');
+  QUnit.equal(segments[0].tags.videoTags.length, 2, 'generated two video tags');
+
+  segments = [];
+
+  transmuxer.push(packetize(PAT));
+  transmuxer.push(packetize(generatePMT({
+    hasVideo: true
+  })));
+
+  // buffer a NAL
+  transmuxer.push(packetize(videoPes([0x09, 0x01], true)));
+  transmuxer.push(packetize(videoPes([0x00, 0x02])));
+
+  // add an access_unit_delimiter_rbsp
+  transmuxer.push(packetize(videoPes([0x09, 0x03])));
+  transmuxer.push(packetize(videoPes([0x00, 0x04])));
+  transmuxer.push(packetize(videoPes([0x00, 0x05])));
+
+  // flush everything
+  transmuxer.flush();
+
+  QUnit.equal(segments[0].tags.audioTags.length, 0, 'generated no audio tags');
+  QUnit.equal(segments[0].tags.videoTags.length, 2, 'generated two video tags');
+});
+
 QUnit.module('AAC Stream');
 QUnit.test('parses correct ID3 tag size', function() {
   var packetStream = new Uint8Array(10),


### PR DESCRIPTION
Currently, the `VideoSegmentStream` in the FLV transmuxer holds a reference to an `h264Frame` object across segment boundaries even though it always finishes the frame at the end of every flush. This means that on the next flush, that same frame will be finished a second time, causing a duplicate frame append. This also happens on replays where the last frame of the last segment will be added to the tags in the first segment.

This change sets `h264Frame = null` after every call to `finishFrame`. Also changed the metadata and extra data tags to have timestamps based on dts instead of pts to make sure tags are ordered correctly.