### PR TITLE
Move browserify-shim to the devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   ],
   "devDependencies": {
     "browserify": "^12.0.1",
+    "browserify-shim": "^3.8.12",
     "bundle-collapser": "^1.2.1",
     "eslint": "^2.10.2",
     "express": "^4.13.3",
@@ -84,8 +85,5 @@
     "uglify-js": "^2.6.2",
     "watchify": "^3.6.1",
     "webworkify": "^1.0.2"
-  },
-  "dependencies": {
-    "browserify-shim": "^3.8.12"
   }
 }


### PR DESCRIPTION
The browserify-shim doc says it should be at the devDependencies instead of the dependencies section ([ref](https://github.com/thlorenz/browserify-shim#1-install-browserify-shim-dependency)).

When you require mux.js from a project, it will pull the shim, and will complain for missing browserify peer dependency. See:

```
├─┬ videojs-contrib-hls@3.6.5
│ ├─┬ aes-decrypter@1.0.3 
│ │ └── pkcs7@0.2.3 
│ ├── m3u8-parser@1.2.0 
│ ├─┬ mux.js@3.0.2 
│ │ ├── UNMET PEER DEPENDENCY browserify@>= 2.3.0 < 14
│ │ └─┬ browserify-shim@3.8.12 
```