### PR TITLE
Fill audio gaps at start of segment with silence

### DIFF
--- a/lib/data/silence.js
+++ b/lib/data/silence.js
@@ -1,0 +1,35 @@
+var highPrefix = [33, 16, 5, 32, 164, 27];
+var lowPrefix = [33, 65, 108, 84, 1, 2, 4, 8, 168, 2, 4, 8, 17, 191, 252];
+var zeroFill = function(count) {
+  var a = [];
+  while (count--) {
+    a.push(0);
+  }
+  return a;
+};
+
+var makeTable = function(metaTable) {
+  return Object.keys(metaTable).reduce(function(obj, key) {
+    obj[key] = new Uint8Array(metaTable[key].reduce(function(arr, part) {
+      return arr.concat(part);
+    }, []));
+    return obj;
+  }, {});
+};
+
+// Frames-of-silence to use for filling in missing AAC frames
+var coneOfSilence = {
+  96000: [highPrefix, [227, 64], zeroFill(154), [56]],
+  88200: [highPrefix, [231], zeroFill(170), [56]],
+  64000: [highPrefix, [248, 192], zeroFill(240), [56]],
+  48000: [highPrefix, [255, 192], zeroFill(268), [55, 148, 128], zeroFill(54), [112]],
+  44100: [highPrefix, [255, 192], zeroFill(268), [55, 163, 128], zeroFill(84), [112]],
+  32000: [highPrefix, [255, 192], zeroFill(268), [55, 234], zeroFill(226), [112]],
+  24000: [highPrefix, [255, 192], zeroFill(268), [55, 255, 128], zeroFill(268), [111, 112], zeroFill(126), [224]],
+  16000: [highPrefix, [255, 192], zeroFill(268), [55, 255, 128], zeroFill(268), [111, 255], zeroFill(269), [223, 108], zeroFill(195), [1, 192]],
+  12000: [lowPrefix, zeroFill(268), [3, 127, 248], zeroFill(268), [6, 255, 240], zeroFill(268), [13, 255, 224], zeroFill(268), [27, 253, 128], zeroFill(259), [56]],
+  11025: [lowPrefix, zeroFill(268), [3, 127, 248], zeroFill(268), [6, 255, 240], zeroFill(268), [13, 255, 224], zeroFill(268), [27, 255, 192], zeroFill(268), [55, 175, 128], zeroFill(108), [112]],
+  8000: [lowPrefix, zeroFill(268), [3, 121, 16], zeroFill(47), [7]]
+};
+
+module.exports = makeTable(coneOfSilence);

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -17,6 +17,7 @@ var AdtsStream = require('../codecs/adts.js');
 var H264Stream = require('../codecs/h264').H264Stream;
 var AacStream = require('../aac');
 var coneOfSilence = require('../data/silence');
+var clock = require('../utils/clock');
 
 // constants
 var AUDIO_PROPERTIES = [
@@ -162,7 +163,7 @@ AudioSegmentStream = function(track) {
       mdat,
       boxes,
       baseMediaDecodeTime,
-      baseMediaDecodeTimeClock,
+      baseMediaDecodeTimeTs,
       audioGap,
       silence,
       i,
@@ -177,14 +178,13 @@ AudioSegmentStream = function(track) {
     frames = this.trimAdtsFramesByEarliestDts_(adtsFrames);
 
     baseMediaDecodeTime = calculateTrackBaseMediaDecodeTime(track);
-    baseMediaDecodeTimeClock =
-      Math.floor(baseMediaDecodeTime / (track.samplerate / ONE_SECOND_IN_TS));
+    baseMediaDecodeTimeTs = clock.audioTsToVideoTs(baseMediaDecodeTime, track.samplerate);
 
     if (audioAppendStartTs &&
         videoBaseMediaDecodeTime &&
         // old audio doesn't overlap with new audio
-        audioAppendStartTs < baseMediaDecodeTimeClock) {
-      audioGap = baseMediaDecodeTimeClock - videoBaseMediaDecodeTime;
+        audioAppendStartTs < baseMediaDecodeTimeTs) {
+      audioGap = baseMediaDecodeTimeTs - videoBaseMediaDecodeTime;
       // determine frame clock duration based on sample rate, round up to avoid overfills
       frameDuration = Math.ceil(ONE_SECOND_IN_TS / (track.samplerate / 1024));
       // ensure gap is a whole number of frames
@@ -193,8 +193,15 @@ AudioSegmentStream = function(track) {
 
     if (audioGap >= frameDuration &&
         // smaller than a half second
-        audioGap < ONE_SECOND_IN_TS / 2) {
+        audioGap < ONE_SECOND_IN_TS / 2 &&
+        frames.length) {
       silence = coneOfSilence[track.samplerate];
+
+      if (!silence) {
+        // we don't have a silent frame pregenerated for the sample rate, so use a frame
+        // from the content instead
+        silence = frames[0].data;
+      }
 
       for (i = 0; i * frameDuration < audioGap; i++) {
         frames.splice(i, 0, {
@@ -202,7 +209,8 @@ AudioSegmentStream = function(track) {
         });
       }
 
-      baseMediaDecodeTime -= Math.floor(audioGap * track.samplerate / ONE_SECOND_IN_TS);
+      baseMediaDecodeTime -=
+        Math.floor(clock.videoTsToAudioTs(audioGap, track.samplerate));
     }
 
     track.baseMediaDecodeTime = baseMediaDecodeTime;

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -34,6 +34,8 @@ var VIDEO_PROPERTIES = [
   'profileCompatibility'
 ];
 
+var ONE_SECOND_IN_TS = 90000; // 90kHz clock
+
 // object types
 var VideoSegmentStream, AudioSegmentStream, Transmuxer, CoalesceStream;
 
@@ -45,7 +47,26 @@ var
   clearDtsInfo,
   calculateTrackBaseMediaDecodeTime,
   arrayEquals,
-  sumFrameByteLengths;
+  sumFrameByteLengths,
+  getSilentFrame;
+
+// From hls.js
+getSilentFrame = function(channelCount) {
+  if (channelCount === 1) {
+    return new Uint8Array([0x00, 0xc8, 0x00, 0x80, 0x23, 0x80]);
+  } else if (channelCount === 2) {
+    return new Uint8Array([0x21, 0x00, 0x49, 0x90, 0x02, 0x19, 0x00, 0x23, 0x80]);
+  } else if (channelCount === 3) {
+    return new Uint8Array([0x00, 0xc8, 0x00, 0x80, 0x20, 0x84, 0x01, 0x26, 0x40, 0x08, 0x64, 0x00, 0x8e]);
+  } else if (channelCount === 4) {
+    return new Uint8Array([0x00, 0xc8, 0x00, 0x80, 0x20, 0x84, 0x01, 0x26, 0x40, 0x08, 0x64, 0x00, 0x80, 0x2c, 0x80, 0x08, 0x02, 0x38]);
+  } else if (channelCount === 5) {
+    return new Uint8Array([0x00, 0xc8, 0x00, 0x80, 0x20, 0x84, 0x01, 0x26, 0x40, 0x08, 0x64, 0x00, 0x82, 0x30, 0x04, 0x99, 0x00, 0x21, 0x90, 0x02, 0x38]);
+  } else if (channelCount === 6) {
+    return new Uint8Array([0x00, 0xc8, 0x00, 0x80, 0x20, 0x84, 0x01, 0x26, 0x40, 0x08, 0x64, 0x00, 0x82, 0x30, 0x04, 0x99, 0x00, 0x21, 0x90, 0x02, 0x00, 0xb2, 0x00, 0x20, 0x08, 0xe0]);
+  }
+  return null;
+};
 
 /**
  * Default sample object
@@ -121,7 +142,8 @@ AudioSegmentStream = function(track) {
   var
     adtsFrames = [],
     sequenceNumber = 0,
-    earliestAllowedDts = 0;
+    earliestAllowedDts = 0,
+    audioAppendStartTs = 0;
 
   AudioSegmentStream.prototype.init.call(this);
 
@@ -142,12 +164,21 @@ AudioSegmentStream = function(track) {
     earliestAllowedDts = earliestDts - track.timelineStartInfo.baseMediaDecodeTime;
   };
 
+  this.setAudioAppendStart = function(timestamp) {
+    audioAppendStartTs = timestamp;
+  };
+
   this.flush = function() {
     var
       frames,
       moof,
       mdat,
-      boxes;
+      boxes,
+      baseMediaDecodeTime,
+      baseMediaDecodeTimeClock,
+      audioGap,
+      silence,
+      i;
 
     // return early if no audio data has been observed
     if (adtsFrames.length === 0) {
@@ -156,6 +187,33 @@ AudioSegmentStream = function(track) {
     }
 
     frames = this.trimAdtsFramesByEarliestDts_(adtsFrames);
+
+    baseMediaDecodeTime = calculateTrackBaseMediaDecodeTime(track);
+    baseMediaDecodeTimeClock =
+      Math.floor(baseMediaDecodeTime / (track.samplerate / ONE_SECOND_IN_TS));
+
+    audioGap = baseMediaDecodeTimeClock - audioAppendStartTs;
+
+    // big enough for a frame
+    if (audioGap > 1024 &&
+        // smaller than a half second
+        audioGap < ONE_SECOND_IN_TS / 2) {
+      silence = getSilentFrame(track.channelcount);
+
+      for (i = 0; i * 1024 < audioGap; i++) {
+        frames.splice(i, 0, {
+          data: silence
+        });
+      }
+
+      baseMediaDecodeTime =
+        // normalized audio append start
+        Math.floor(audioAppendStartTs * track.samplerate / ONE_SECOND_IN_TS) +
+        // leave any remaining gap between audio append and start of silence
+        audioGap - i * 1024;
+    }
+
+    track.baseMediaDecodeTime = baseMediaDecodeTime;
 
     // we have to build the index from byte locations to
     // samples (that is, adts frames) in the audio data
@@ -166,7 +224,6 @@ AudioSegmentStream = function(track) {
 
     adtsFrames = [];
 
-    calculateTrackBaseMediaDecodeTime(track);
     moof = mp4.moof(sequenceNumber, [track]);
     boxes = new Uint8Array(moof.byteLength + mdat.byteLength);
 
@@ -374,7 +431,7 @@ VideoSegmentStream = function(track) {
     // Clear nalUnits
     nalUnits = [];
 
-    calculateTrackBaseMediaDecodeTime(track);
+    track.baseMediaDecodeTime = calculateTrackBaseMediaDecodeTime(track);
 
     this.trigger('timelineStartInfo', track.timelineStartInfo);
 
@@ -734,7 +791,7 @@ clearDtsInfo = function(track) {
  */
 calculateTrackBaseMediaDecodeTime = function(track) {
   var
-    oneSecondInTS = 90000, // 90kHz clock
+    baseMediaDecodeTime,
     scale,
     // Calculate the distance, in time, that this segment starts from the start
     // of the timeline (earliest time seen since the transmuxer initialized)
@@ -742,21 +799,23 @@ calculateTrackBaseMediaDecodeTime = function(track) {
 
   // track.timelineStartInfo.baseMediaDecodeTime is the location, in time, where
   // we want the start of the first segment to be placed
-  track.baseMediaDecodeTime = track.timelineStartInfo.baseMediaDecodeTime;
+  baseMediaDecodeTime = track.timelineStartInfo.baseMediaDecodeTime;
 
   // Add to that the distance this segment is from the very first
-  track.baseMediaDecodeTime += timeSinceStartOfTimeline;
+  baseMediaDecodeTime += timeSinceStartOfTimeline;
 
   // baseMediaDecodeTime must not become negative
-  track.baseMediaDecodeTime = Math.max(0, track.baseMediaDecodeTime);
+  baseMediaDecodeTime = Math.max(0, baseMediaDecodeTime);
 
   if (track.type === 'audio') {
     // Audio has a different clock equal to the sampling_rate so we need to
     // scale the PTS values into the clock rate of the track
-    scale = track.samplerate / oneSecondInTS;
-    track.baseMediaDecodeTime *= scale;
-    track.baseMediaDecodeTime = Math.floor(track.baseMediaDecodeTime);
+    scale = track.samplerate / ONE_SECOND_IN_TS;
+    baseMediaDecodeTime *= scale;
+    baseMediaDecodeTime = Math.floor(baseMediaDecodeTime);
   }
+
+  return baseMediaDecodeTime;
 };
 
 /**
@@ -1130,6 +1189,12 @@ Transmuxer = function(options) {
       videoTrack.timelineStartInfo.pts = undefined;
       clearDtsInfo(videoTrack);
       videoTrack.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
+    }
+  };
+
+  this.setAudioAppendStart = function(timestamp) {
+    if (audioTrack) {
+      this.transmuxPipeline_.audioSegmentStream.setAudioAppendStart(timestamp);
     }
   };
 

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -183,7 +183,8 @@ AudioSegmentStream = function(track) {
       baseMediaDecodeTimeClock,
       audioGap,
       silence,
-      i;
+      i,
+      frameDuration;
 
     // return early if no audio data has been observed
     if (adtsFrames.length === 0) {
@@ -202,23 +203,24 @@ AudioSegmentStream = function(track) {
         // old audio doesn't overlap with new audio
         audioAppendStartTs < baseMediaDecodeTimeClock) {
       audioGap = baseMediaDecodeTimeClock - videoBaseMediaDecodeTime;
+      // determine frame clock duration based on sample rate, round up to avoid overfills
+      frameDuration = Math.ceil(ONE_SECOND_IN_TS / (track.samplerate / 1024));
       // ensure gap is an even number of frames
-      audioGap = Math.floor(audioGap / 1024) * 1024;
+      audioGap = Math.floor(audioGap / frameDuration) * frameDuration;
     }
 
-    // big enough for a frame
-    if (audioGap > 1024 &&
+    if (audioGap > frameDuration &&
         // smaller than a half second
         audioGap < ONE_SECOND_IN_TS / 2) {
       silence = getSilentFrame(track.channelcount);
 
-      for (i = 0; i * 1024 < audioGap; i++) {
+      for (i = 0; i * frameDuration < audioGap; i++) {
         frames.splice(i, 0, {
           data: silence
         });
       }
 
-      baseMediaDecodeTime -= audioGap;
+      baseMediaDecodeTime -= Math.floor(audioGap * track.samplerate / ONE_SECOND_IN_TS);
     }
 
     track.baseMediaDecodeTime = baseMediaDecodeTime;

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -143,7 +143,8 @@ AudioSegmentStream = function(track) {
     adtsFrames = [],
     sequenceNumber = 0,
     earliestAllowedDts = 0,
-    audioAppendStartTs = 0;
+    audioAppendStartTs = 0,
+    videoBaseMediaDecodeTime = Infinity;
 
   AudioSegmentStream.prototype.init.call(this);
 
@@ -162,6 +163,10 @@ AudioSegmentStream = function(track) {
 
   this.setEarliestDts = function(earliestDts) {
     earliestAllowedDts = earliestDts - track.timelineStartInfo.baseMediaDecodeTime;
+  };
+
+  this.setVideoBaseMediaDecodeTime = function(baseMediaDecodeTime) {
+    videoBaseMediaDecodeTime = baseMediaDecodeTime;
   };
 
   this.setAudioAppendStart = function(timestamp) {
@@ -192,7 +197,14 @@ AudioSegmentStream = function(track) {
     baseMediaDecodeTimeClock =
       Math.floor(baseMediaDecodeTime / (track.samplerate / ONE_SECOND_IN_TS));
 
-    audioGap = baseMediaDecodeTimeClock - audioAppendStartTs;
+    if (audioAppendStartTs &&
+        videoBaseMediaDecodeTime &&
+        // old audio doesn't overlap with new audio
+        audioAppendStartTs < baseMediaDecodeTimeClock) {
+      audioGap = baseMediaDecodeTimeClock - videoBaseMediaDecodeTime;
+      // ensure gap is an even number of frames
+      audioGap = Math.floor(audioGap / 1024) * 1024;
+    }
 
     // big enough for a frame
     if (audioGap > 1024 &&
@@ -206,11 +218,7 @@ AudioSegmentStream = function(track) {
         });
       }
 
-      baseMediaDecodeTime =
-        // normalized audio append start
-        Math.floor(audioAppendStartTs * track.samplerate / ONE_SECOND_IN_TS) +
-        // leave any remaining gap between audio append and start of silence
-        audioGap - i * 1024;
+      baseMediaDecodeTime -= audioGap;
     }
 
     track.baseMediaDecodeTime = baseMediaDecodeTime;
@@ -433,6 +441,7 @@ VideoSegmentStream = function(track) {
 
     track.baseMediaDecodeTime = calculateTrackBaseMediaDecodeTime(track);
 
+    this.trigger('baseMediaDecodeTime', track.baseMediaDecodeTime);
     this.trigger('timelineStartInfo', track.timelineStartInfo);
 
     moof = mp4.moof(sequenceNumber, [track]);
@@ -1142,6 +1151,12 @@ Transmuxer = function(options) {
               // interpret any video track with a baseMediaDecodeTime that is
               // non-zero as a gap.
               pipeline.audioSegmentStream.setEarliestDts(timelineStartInfo.dts);
+            }
+          });
+
+          pipeline.videoSegmentStream.on('baseMediaDecodeTime', function(baseMediaDecodeTime) {
+            if (audioTrack) {
+              pipeline.audioSegmentStream.setVideoBaseMediaDecodeTime(baseMediaDecodeTime);
             }
           });
 

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -16,6 +16,7 @@ var m2ts = require('../m2ts/m2ts.js');
 var AdtsStream = require('../codecs/adts.js');
 var H264Stream = require('../codecs/h264').H264Stream;
 var AacStream = require('../aac');
+var coneOfSilence = require('../data/silence');
 
 // constants
 var AUDIO_PROPERTIES = [
@@ -47,26 +48,7 @@ var
   clearDtsInfo,
   calculateTrackBaseMediaDecodeTime,
   arrayEquals,
-  sumFrameByteLengths,
-  getSilentFrame;
-
-// From hls.js
-getSilentFrame = function(channelCount) {
-  if (channelCount === 1) {
-    return new Uint8Array([0x00, 0xc8, 0x00, 0x80, 0x23, 0x80]);
-  } else if (channelCount === 2) {
-    return new Uint8Array([0x21, 0x00, 0x49, 0x90, 0x02, 0x19, 0x00, 0x23, 0x80]);
-  } else if (channelCount === 3) {
-    return new Uint8Array([0x00, 0xc8, 0x00, 0x80, 0x20, 0x84, 0x01, 0x26, 0x40, 0x08, 0x64, 0x00, 0x8e]);
-  } else if (channelCount === 4) {
-    return new Uint8Array([0x00, 0xc8, 0x00, 0x80, 0x20, 0x84, 0x01, 0x26, 0x40, 0x08, 0x64, 0x00, 0x80, 0x2c, 0x80, 0x08, 0x02, 0x38]);
-  } else if (channelCount === 5) {
-    return new Uint8Array([0x00, 0xc8, 0x00, 0x80, 0x20, 0x84, 0x01, 0x26, 0x40, 0x08, 0x64, 0x00, 0x82, 0x30, 0x04, 0x99, 0x00, 0x21, 0x90, 0x02, 0x38]);
-  } else if (channelCount === 6) {
-    return new Uint8Array([0x00, 0xc8, 0x00, 0x80, 0x20, 0x84, 0x01, 0x26, 0x40, 0x08, 0x64, 0x00, 0x82, 0x30, 0x04, 0x99, 0x00, 0x21, 0x90, 0x02, 0x00, 0xb2, 0x00, 0x20, 0x08, 0xe0]);
-  }
-  return null;
-};
+  sumFrameByteLengths;
 
 /**
  * Default sample object
@@ -205,14 +187,14 @@ AudioSegmentStream = function(track) {
       audioGap = baseMediaDecodeTimeClock - videoBaseMediaDecodeTime;
       // determine frame clock duration based on sample rate, round up to avoid overfills
       frameDuration = Math.ceil(ONE_SECOND_IN_TS / (track.samplerate / 1024));
-      // ensure gap is an even number of frames
+      // ensure gap is a whole number of frames
       audioGap = Math.floor(audioGap / frameDuration) * frameDuration;
     }
 
-    if (audioGap > frameDuration &&
+    if (audioGap >= frameDuration &&
         // smaller than a half second
         audioGap < ONE_SECOND_IN_TS / 2) {
-      silence = getSilentFrame(track.channelcount);
+      silence = coneOfSilence[track.samplerate];
 
       for (i = 0; i * frameDuration < audioGap; i++) {
         frames.splice(i, 0, {

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -161,13 +161,7 @@ AudioSegmentStream = function(track) {
       frames,
       moof,
       mdat,
-      boxes,
-      baseMediaDecodeTime,
-      baseMediaDecodeTimeTs,
-      audioGap,
-      silence,
-      i,
-      frameDuration;
+      boxes;
 
     // return early if no audio data has been observed
     if (adtsFrames.length === 0) {
@@ -176,44 +170,9 @@ AudioSegmentStream = function(track) {
     }
 
     frames = this.trimAdtsFramesByEarliestDts_(adtsFrames);
+    track.baseMediaDecodeTime = calculateTrackBaseMediaDecodeTime(track);
 
-    baseMediaDecodeTime = calculateTrackBaseMediaDecodeTime(track);
-    baseMediaDecodeTimeTs = clock.audioTsToVideoTs(baseMediaDecodeTime, track.samplerate);
-
-    if (audioAppendStartTs &&
-        videoBaseMediaDecodeTime &&
-        // old audio doesn't overlap with new audio
-        audioAppendStartTs < baseMediaDecodeTimeTs) {
-      audioGap = baseMediaDecodeTimeTs - videoBaseMediaDecodeTime;
-      // determine frame clock duration based on sample rate, round up to avoid overfills
-      frameDuration = Math.ceil(ONE_SECOND_IN_TS / (track.samplerate / 1024));
-      // ensure gap is a whole number of frames
-      audioGap = Math.floor(audioGap / frameDuration) * frameDuration;
-    }
-
-    if (audioGap >= frameDuration &&
-        // smaller than a half second
-        audioGap < ONE_SECOND_IN_TS / 2 &&
-        frames.length) {
-      silence = coneOfSilence[track.samplerate];
-
-      if (!silence) {
-        // we don't have a silent frame pregenerated for the sample rate, so use a frame
-        // from the content instead
-        silence = frames[0].data;
-      }
-
-      for (i = 0; i * frameDuration < audioGap; i++) {
-        frames.splice(i, 0, {
-          data: silence
-        });
-      }
-
-      baseMediaDecodeTime -=
-        Math.floor(clock.videoTsToAudioTs(audioGap, track.samplerate));
-    }
-
-    track.baseMediaDecodeTime = baseMediaDecodeTime;
+    this.prefixWithSilence_(track, frames);
 
     // we have to build the index from byte locations to
     // samples (that is, adts frames) in the audio data
@@ -237,6 +196,61 @@ AudioSegmentStream = function(track) {
 
     this.trigger('data', {track: track, boxes: boxes});
     this.trigger('done', 'AudioSegmentStream');
+  };
+
+  // Possibly pad (prefix) the audio track with silence if appending this track
+  // would lead to the introduction of a gap in the audio buffer
+  this.prefixWithSilence_ = function(track, frames) {
+    var
+      baseMediaDecodeTimeTs,
+      frameDuration = 0,
+      audioGapDuration = 0,
+      audioFillFrameCount = 0,
+      audioFillDuration = 0,
+      silentFrame,
+      i;
+
+    if (!frames.length) {
+      return;
+    }
+
+    baseMediaDecodeTimeTs = clock.audioTsToVideoTs(track.baseMediaDecodeTime, track.samplerate);
+
+    if (audioAppendStartTs &&
+        videoBaseMediaDecodeTime &&
+        // old audio doesn't overlap with new audio
+        audioAppendStartTs < baseMediaDecodeTimeTs) {
+      audioGapDuration = baseMediaDecodeTimeTs - videoBaseMediaDecodeTime;
+      // determine frame clock duration based on sample rate, round up to avoid overfills
+      frameDuration = Math.ceil(ONE_SECOND_IN_TS / (track.samplerate / 1024));
+      // number of full frames in the audio gap
+      audioFillFrameCount = Math.floor(audioGapDuration / frameDuration);
+      // ensure gap is a whole number of frames
+      audioFillDuration = audioFillFrameCount * frameDuration;
+    }
+
+    // don't attempt to fill gaps smaller than a single frame or larger
+    // than a half second
+    if (audioFillFrameCount < 1 || audioFillDuration > ONE_SECOND_IN_TS / 2) {
+      return;
+    }
+
+    silentFrame = coneOfSilence[track.samplerate];
+
+    if (!silentFrame) {
+      // we don't have a silent frame pregenerated for the sample rate, so use a frame
+      // from the content instead
+      silentFrame = frames[0].data;
+    }
+
+    for (i = 0; i < audioFillFrameCount; i++) {
+      frames.splice(i, 0, {
+        data: silentFrame
+      });
+    }
+
+    track.baseMediaDecodeTime -=
+      Math.floor(clock.videoTsToAudioTs(audioFillDuration, track.samplerate));
   };
 
   // If the audio segment extends before the earliest allowed dts

--- a/lib/utils/clock.js
+++ b/lib/utils/clock.js
@@ -1,0 +1,41 @@
+var
+  ONE_SECOND_IN_TS = 90000, // 90kHz clock
+  secondsToVideoTs,
+  secondsToAudioTs,
+  videoTsToSeconds,
+  audioTsToSeconds,
+  audioTsToVideoTs,
+  videoTsToAudioTs;
+
+secondsToVideoTs = function(seconds) {
+  return seconds * ONE_SECOND_IN_TS;
+};
+
+secondsToAudioTs = function(seconds, sampleRate) {
+  return seconds * sampleRate;
+};
+
+videoTsToSeconds = function(timestamp) {
+  return timestamp / ONE_SECOND_IN_TS;
+};
+
+audioTsToSeconds = function(timestamp, sampleRate) {
+  return timestamp / sampleRate;
+};
+
+audioTsToVideoTs = function(timestamp, sampleRate) {
+  return secondsToVideoTs(audioTsToSeconds(timestamp, sampleRate));
+};
+
+videoTsToAudioTs = function(timestamp, sampleRate) {
+  return secondsToAudioTs(videoTsToSeconds(timestamp), sampleRate);
+};
+
+module.exports = {
+  secondsToVideoTs: secondsToVideoTs,
+  secondsToAudioTs: secondsToAudioTs,
+  videoTsToSeconds: videoTsToSeconds,
+  audioTsToSeconds: audioTsToSeconds,
+  audioTsToVideoTs: audioTsToVideoTs,
+  videoTsToAudioTs: videoTsToAudioTs
+};

--- a/test/transmuxer.test.js
+++ b/test/transmuxer.test.js
@@ -2354,6 +2354,63 @@ QUnit.test('fills audio gaps taking into account audio sample rate', function() 
                'filled all but frame remainder between video start and audio start');
 });
 
+QUnit.test('fills audio gaps with existing frame if odd sample rate', function() {
+  var
+    events = [],
+    boxes,
+    numSilentFrames,
+    videoGap = 0.29,
+    audioGap = 0.49,
+    expectedFillSeconds = audioGap - videoGap,
+    sampleRate = 90e3, // we don't have matching silent frames
+    frameDuration = Math.ceil(90e3 / (sampleRate / 1024)),
+    frameSeconds = clock.videoTsToSeconds(frameDuration),
+    audioBMDT,
+    offsetSeconds = clock.videoTsToSeconds(111),
+    startingAudioBMDT = clock.secondsToAudioTs(10 + audioGap - offsetSeconds, sampleRate);
+
+  audioSegmentStream.on('data', function(event) {
+    events.push(event);
+  });
+
+  audioSegmentStream.setAudioAppendStart(clock.secondsToVideoTs(10));
+  audioSegmentStream.setVideoBaseMediaDecodeTime(clock.secondsToVideoTs(10 + videoGap));
+
+  audioSegmentStream.push({
+    channelcount: 2,
+    samplerate: sampleRate,
+    pts: clock.secondsToVideoTs(10 + audioGap),
+    dts: clock.secondsToVideoTs(10 + audioGap),
+    data: new Uint8Array([1])
+  });
+
+  audioSegmentStream.flush();
+
+  numSilentFrames = Math.floor(expectedFillSeconds / frameSeconds);
+
+  QUnit.equal(events.length, 1, 'a data event fired');
+  QUnit.equal(events[0].track.samples.length, 1 + numSilentFrames, 'generated samples');
+  QUnit.equal(events[0].track.samples[0].size, 1, 'copied sample');
+  QUnit.equal(events[0].track.samples[7].size, 1, 'copied sample');
+  QUnit.equal(events[0].track.samples[8].size, 1, 'normal sample');
+  boxes = mp4.tools.inspect(events[0].boxes);
+
+  audioBMDT = boxes[0].boxes[1].boxes[1].baseMediaDecodeTime;
+
+  QUnit.equal(
+    audioBMDT,
+    // should always be rounded up so as not to overfill
+    Math.ceil(startingAudioBMDT -
+              clock.secondsToAudioTs(numSilentFrames * frameSeconds, sampleRate)),
+    'filled the gap to the nearest frame');
+  QUnit.equal(
+    Math.floor(clock.audioTsToVideoTs(audioBMDT, sampleRate) -
+               clock.secondsToVideoTs(10 + videoGap)),
+    Math.floor(clock.secondsToVideoTs(expectedFillSeconds) % frameDuration -
+               clock.secondsToVideoTs(offsetSeconds)),
+               'filled all but frame remainder between video start and audio start');
+});
+
 QUnit.test('does not fill audio gaps if no audio append start time', function() {
   var
     events = [],

--- a/test/transmuxer.test.js
+++ b/test/transmuxer.test.js
@@ -2342,6 +2342,62 @@ QUnit.test('fills audio gaps from video start if video is later than audio', fun
     'filled all but frame remainder between video start and audio start');
 });
 
+QUnit.test('fills audio gaps taking into account audio sample rate', function() {
+  var
+    events = [],
+    boxes,
+    numSilentFrames,
+    expectedFillLength,
+    videoGap = 0.29,
+    audioGap = 0.49,
+    videoBaseMediaDecodeTime = (10 + videoGap) * 90e3,
+    expectedFillSeconds = audioGap - videoGap,
+    sampleRate = 44100,
+    frameDuration = Math.ceil(90e3 / (sampleRate / 1024)),
+    frameSeconds = frameDuration / 90e3,
+    scale = sampleRate / 90e3,
+    audioBMDT,
+    startingAudioBMDT = (10 + audioGap) * sampleRate - (111 * scale);
+
+  audioSegmentStream.on('data', function(event) {
+    events.push(event);
+  });
+
+  audioSegmentStream.setAudioAppendStart(10 * 90e3);
+  audioSegmentStream.setVideoBaseMediaDecodeTime(videoBaseMediaDecodeTime);
+
+  audioSegmentStream.push({
+    channelcount: 2,
+    samplerate: sampleRate,
+    pts: (10 + audioGap) * 90e3,
+    dts: (10 + audioGap) * 90e3,
+    data: new Uint8Array([1])
+  });
+
+  audioSegmentStream.flush();
+
+  numSilentFrames = Math.floor(expectedFillSeconds / frameSeconds);
+
+  QUnit.equal(events.length, 1, 'a data event fired');
+  QUnit.equal(events[0].track.samples.length, 1 + numSilentFrames, 'generated samples');
+  QUnit.equal(events[0].track.samples[0].size, 9, 'silent sample');
+  QUnit.equal(events[0].track.samples[7].size, 9, 'silent sample');
+  QUnit.equal(events[0].track.samples[8].size, 1, 'normal sample');
+  boxes = mp4.tools.inspect(events[0].boxes);
+
+  audioBMDT = boxes[0].boxes[1].boxes[1].baseMediaDecodeTime;
+  expectedFillLength = (numSilentFrames * frameSeconds) * sampleRate;
+  QUnit.equal(audioBMDT,
+              // should always be rounded up so as not to overfill
+              Math.ceil(startingAudioBMDT - expectedFillLength),
+              'filled the gap to the nearest frame');
+  QUnit.equal(
+    // difference in video clock
+    Math.floor(audioBMDT / scale - videoBaseMediaDecodeTime),
+    Math.floor((expectedFillSeconds * 90e3) % frameDuration) - 111,
+    'filled all but frame remainder between video start and audio start');
+});
+
 QUnit.test('does not fill audio gaps if no audio append start time', function() {
   var
     events = [],

--- a/test/utils.clock.test.js
+++ b/test/utils.clock.test.js
@@ -1,0 +1,163 @@
+'use strict';
+
+var
+  QUnit = require('qunit'),
+  clock = require('../lib/utils/clock');
+
+QUnit.module('Clock Utils');
+
+QUnit.test('converts from seconds to video timestamps', function() {
+  QUnit.equal(clock.secondsToVideoTs(0), 0, 'converts seconds to video timestamp');
+  QUnit.equal(clock.secondsToVideoTs(1), 90000, 'converts seconds to video timestamp');
+  QUnit.equal(clock.secondsToVideoTs(10), 900000, 'converts seconds to video timestamp');
+  QUnit.equal(clock.secondsToVideoTs(-1), -90000, 'converts seconds to video timestamp');
+  QUnit.equal(clock.secondsToVideoTs(3), 270000, 'converts seconds to video timestamp');
+  QUnit.equal(clock.secondsToVideoTs(0.1), 9000, 'converts seconds to video timestamp');
+});
+
+QUnit.test('converts from seconds to audio timestamps', function() {
+  QUnit.equal(clock.secondsToAudioTs(0, 90000),
+              0,
+              'converts seconds to audio timestamp');
+  QUnit.equal(clock.secondsToAudioTs(1, 90000),
+              90000,
+              'converts seconds to audio timestamp');
+  QUnit.equal(clock.secondsToAudioTs(-1, 90000),
+              -90000,
+              'converts seconds to audio timestamp');
+  QUnit.equal(clock.secondsToAudioTs(3, 90000),
+              270000,
+              'converts seconds to audio timestamp');
+  QUnit.equal(clock.secondsToAudioTs(0, 44100),
+              0,
+              'converts seconds to audio timestamp');
+  QUnit.equal(clock.secondsToAudioTs(1, 44100),
+              44100,
+              'converts seconds to audio timestamp');
+  QUnit.equal(clock.secondsToAudioTs(3, 44100),
+              132300,
+              'converts seconds to audio timestamp');
+  QUnit.equal(clock.secondsToAudioTs(-1, 44100),
+              -44100,
+              'converts seconds to audio timestamp');
+  QUnit.equal(clock.secondsToAudioTs(0.1, 44100),
+              4410,
+              'converts seconds to audio timestamp');
+});
+
+QUnit.test('converts from video timestamp to seconds', function() {
+  QUnit.equal(clock.videoTsToSeconds(0), 0, 'converts video timestamp to seconds');
+  QUnit.equal(clock.videoTsToSeconds(90000), 1, 'converts video timestamp to seconds');
+  QUnit.equal(clock.videoTsToSeconds(900000), 10, 'converts video timestamp to seconds');
+  QUnit.equal(clock.videoTsToSeconds(-90000), -1, 'converts video timestamp to seconds');
+  QUnit.equal(clock.videoTsToSeconds(270000), 3, 'converts video timestamp to seconds');
+  QUnit.equal(clock.videoTsToSeconds(9000), 0.1, 'converts video timestamp to seconds');
+});
+
+QUnit.test('converts from audio timestamp to seconds', function() {
+  QUnit.equal(clock.audioTsToSeconds(0, 90000),
+              0,
+              'converts seconds to audio timestamp');
+  QUnit.equal(clock.audioTsToSeconds(90000, 90000),
+              1,
+              'converts seconds to audio timestamp');
+  QUnit.equal(clock.audioTsToSeconds(-90000, 90000),
+              -1,
+              'converts seconds to audio timestamp');
+  QUnit.equal(clock.audioTsToSeconds(270000, 90000),
+              3,
+              'converts seconds to audio timestamp');
+  QUnit.equal(clock.audioTsToSeconds(0, 44100),
+              0,
+              'converts seconds to audio timestamp');
+  QUnit.equal(clock.audioTsToSeconds(44100, 44100),
+              1,
+              'converts seconds to audio timestamp');
+  QUnit.equal(clock.audioTsToSeconds(132300, 44100),
+              3,
+              'converts seconds to audio timestamp');
+  QUnit.equal(clock.audioTsToSeconds(-44100, 44100),
+              -1,
+              'converts seconds to audio timestamp');
+  QUnit.equal(clock.audioTsToSeconds(4410, 44100),
+              0.1,
+              'converts seconds to audio timestamp');
+});
+
+QUnit.test('converts from audio timestamp to video timestamp', function() {
+  QUnit.equal(clock.audioTsToVideoTs(0, 90000),
+              0,
+              'converts audio timestamp to video timestamp');
+  QUnit.equal(clock.audioTsToVideoTs(90000, 90000),
+              90000,
+              'converts audio timestamp to video timestamp');
+  QUnit.equal(clock.audioTsToVideoTs(900000, 90000),
+              900000,
+              'converts audio timestamp to video timestamp');
+  QUnit.equal(clock.audioTsToVideoTs(-90000, 90000),
+              -90000,
+              'converts audio timestamp to video timestamp');
+  QUnit.equal(clock.audioTsToVideoTs(270000, 90000),
+              270000,
+              'converts audio timestamp to video timestamp');
+  QUnit.equal(clock.audioTsToVideoTs(9000, 90000),
+              9000,
+              'converts audio timestamp to video timestamp');
+  QUnit.equal(clock.audioTsToVideoTs(0, 44100),
+              0,
+              'converts audio timestamp to video timestamp');
+  QUnit.equal(clock.audioTsToVideoTs(44100, 44100),
+              90000,
+              'converts audio timestamp to video timestamp');
+  QUnit.equal(clock.audioTsToVideoTs(441000, 44100),
+              900000,
+              'converts audio timestamp to video timestamp');
+  QUnit.equal(clock.audioTsToVideoTs(-44100, 44100),
+              -90000,
+              'converts audio timestamp to video timestamp');
+  QUnit.equal(clock.audioTsToVideoTs(132300, 44100),
+              270000,
+              'converts audio timestamp to video timestamp');
+  QUnit.equal(clock.audioTsToVideoTs(4410, 44100),
+              9000,
+              'converts audio timestamp to video timestamp');
+});
+
+QUnit.test('converts from video timestamp to audio timestamp', function() {
+  QUnit.equal(clock.videoTsToAudioTs(0, 90000),
+              0,
+              'converts video timestamp to audio timestamp');
+  QUnit.equal(clock.videoTsToAudioTs(90000, 90000),
+              90000,
+              'converts video timestamp to audio timestamp');
+  QUnit.equal(clock.videoTsToAudioTs(900000, 90000),
+              900000,
+              'converts video timestamp to audio timestamp');
+  QUnit.equal(clock.videoTsToAudioTs(-90000, 90000),
+              -90000,
+              'converts video timestamp to audio timestamp');
+  QUnit.equal(clock.videoTsToAudioTs(270000, 90000),
+              270000,
+              'converts video timestamp to audio timestamp');
+  QUnit.equal(clock.videoTsToAudioTs(9000, 90000),
+              9000,
+              'converts video timestamp to audio timestamp');
+  QUnit.equal(clock.videoTsToAudioTs(0, 44100),
+              0,
+              'converts video timestamp to audio timestamp');
+  QUnit.equal(clock.videoTsToAudioTs(90000, 44100),
+              44100,
+              'converts video timestamp to audio timestamp');
+  QUnit.equal(clock.videoTsToAudioTs(900000, 44100),
+              441000,
+              'converts video timestamp to audio timestamp');
+  QUnit.equal(clock.videoTsToAudioTs(-90000, 44100),
+              -44100,
+              'converts video timestamp to audio timestamp');
+  QUnit.equal(clock.videoTsToAudioTs(270000, 44100),
+              132300,
+              'converts video timestamp to audio timestamp');
+  QUnit.equal(clock.videoTsToAudioTs(9000, 44100),
+              4410,
+              'converts video timestamp to audio timestamp');
+});


### PR DESCRIPTION
# Description

If an audio append start time is provided, and the next audio segment starts greater than a frame's duration from that time, but is within a half second from that time, fill the gap (up to the nearest whole frame) with silence.