### PR TITLE
Include raw packet in TransportParseStream data event

### DIFF
--- a/lib/m2ts/m2ts.js
+++ b/lib/m2ts/m2ts.js
@@ -193,7 +193,7 @@ TransportParseStream = function() {
     var
       result = {},
       offset = 4;
-    
+
     result.packet = packet;
     result.payloadUnitStartIndicator = !!(packet[1] & 0x40);
 

--- a/lib/m2ts/m2ts.js
+++ b/lib/m2ts/m2ts.js
@@ -193,7 +193,8 @@ TransportParseStream = function() {
     var
       result = {},
       offset = 4;
-
+    
+    result.packet = packet;
     result.payloadUnitStartIndicator = !!(packet[1] & 0x40);
 
     // pid is a 13-bit field starting at the last bit of packet[1]


### PR DESCRIPTION
Adds a reference to the original raw TS packet in TransportParseStream data event object.
This is very useful in my case where I want to re-use the original packet based on the parsing information.