### PR TITLE
output extra flags on flv tags

### DIFF
--- a/lib/flv/tag-list.js
+++ b/lib/flv/tag-list.js
@@ -9,7 +9,9 @@ var TagList = function() {
     this.list.push({
       bytes: tag.bytes,
       dts: tag.dts,
-      pts: tag.pts
+      pts: tag.pts,
+      keyFrame: tag.keyFrame,
+      metaDataTag: tag.metaDataTag
     });
   };
 

--- a/lib/flv/transmuxer.js
+++ b/lib/flv/transmuxer.js
@@ -197,8 +197,13 @@ VideoSegmentStream = function(track) {
     if (config && track && track.newMetadata &&
         (frame.keyFrame || tags.length === 0)) {
       // Push extra data on every IDR frame in case we did a stream change + seek
-      tags.push(metaDataTag(config, frame.dts).finalize());
-      tags.push(extraDataTag(track, frame.dts).finalize());
+      var metaTag = metaDataTag(config, frame.dts).finalize();
+      var extraTag = extraDataTag(track, frame.dts).finalize();
+
+      metaTag.metaDataTag = extraTag.metaDataTag = true;
+
+      tags.push(metaTag);
+      tags.push(extraTag);
       track.newMetadata = false;
     }
 


### PR DESCRIPTION
some important information wasn't being attached to the tags outputted by the flv transmuxer. 
This adds them on