### PR TITLE
Transmuxing can fail if there are less than two GOPs

### DIFF
--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -535,7 +535,7 @@ VideoSegmentStream = function(track) {
   this.extendFirstKeyFrame_ = function(gops) {
     var currentGop;
 
-    if (!gops[0][0].keyFrame) {
+    if (!gops[0][0].keyFrame && gops.length > 1) {
       // Remove the first GOP
       currentGop = gops.shift();
 


### PR DESCRIPTION
`this.extendFirstKeyFrame_` should not throw an exception if there is only one GOP and should become a NOOP in that case.