### PR TITLE
reset TimestampRolloverStream on discontinuities

### DIFF
--- a/lib/m2ts/timestamp-rollover-stream.js
+++ b/lib/m2ts/timestamp-rollover-stream.js
@@ -69,6 +69,11 @@ var TimestampRolloverStream = function(type) {
     this.trigger('done');
   };
 
+  this.discontinuity = function() {
+    referenceDTS = void 0;
+    lastDTS = void 0;
+  };
+
 };
 
 TimestampRolloverStream.prototype = new Stream();

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -1199,15 +1199,23 @@ Transmuxer = function(options) {
       audioTrack.timelineStartInfo.pts = undefined;
       clearDtsInfo(audioTrack);
       audioTrack.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
+      if (pipeline.audioTimestampRolloverStream) {
+        pipeline.audioTimestampRolloverStream.discontinuity();
+      }
     }
     if (videoTrack) {
       if (pipeline.videoSegmentStream) {
         pipeline.videoSegmentStream.gopCache_ = [];
+        pipeline.videoTimestampRolloverStream.discontinuity();
       }
       videoTrack.timelineStartInfo.dts = undefined;
       videoTrack.timelineStartInfo.pts = undefined;
       clearDtsInfo(videoTrack);
       videoTrack.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
+    }
+
+    if (pipeline.timedMetadataTimestampRolloverStream) {
+      pipeline.timedMetadataTimestampRolloverStream.discontinuity();
     }
   };
 


### PR DESCRIPTION
https://github.com/videojs/videojs-contrib-hls/issues/1056

The above issue stems from two key things. 

 * the `TimestampRolloverStream` doesn't reset its `referenceDTS` value on discontinuities. This wasn't really an issue because of the way we use `baseMediaDecodeTime` to shift segments to the correct time on discontinuities, so it didn't matter if the transmuxer treated a segment on a discontinuity as a rollover since `baseMediaDecodeTime` would shift it correctly regardless.

 * each `type` (`video`, `audio`, `timed-metadata`) has its own independent `referenceDTS`. This is important because the rollover for video may be in a different segment than the rollover in audio if it is near segment boundaries. However, in the case of the issue linked above, because only the ads have ID3 tags, and the main content doesn't, and because `referenceDTS` wasn't reset on discontinuities, the `videoTimestampRolloverStream` was detecting a rollover in video, but the `timedMetadataTimestampRolloverStream` never had `referenceDTS` set, so it did not detect a rollover, giving the ID3 tags a different PTS value than the video. When `baseMediaDecodeTime` was being used to shift the times later on in the pipeline, the ID3 tags were being shifted too much into the negative values.

By resetting all the `TimestampRolloverStream`s on discontinuities, we can avoid this edge case 