### PR TITLE
Fixes fixed point calculation of tkhd box's height and width.

### DIFF
--- a/lib/tools/mp4-inspector.js
+++ b/lib/tools/mp4-inspector.js
@@ -594,9 +594,9 @@ var
       i += 2;
       result.matrix = new Uint32Array(data.subarray(i, i + (9 * 4)));
       i += 9 * 4;
-      result.width = view.getUint16(i) + (view.getUint16(i + 2) / 16);
+      result.width = view.getUint16(i) + (view.getUint16(i + 2) / 65536);
       i += 4;
-      result.height = view.getUint16(i) + (view.getUint16(i + 2) / 16);
+      result.height = view.getUint16(i) + (view.getUint16(i + 2) / 65536);
       return result;
     },
     traf: function(data) {

--- a/test/mp4-inspector.test.js
+++ b/test/mp4-inspector.test.js
@@ -63,8 +63,8 @@ var
               0x00, 0x00, // non-audio track volume
               0x00, 0x00, // reserved
               unityMatrix,
-              0x01, 0x2c, 0x00, 0x00, // 300 in 16.16 fixed point
-              0x00, 0x96, 0x00, 0x00), // 150 in 16.16 fixed point
+              0x01, 0x2c, 0x80, 0x00, // 300.5 in 16.16 fixed point
+              0x00, 0x96, 0x80, 0x00), // 150.5 in 16.16 fixed point
   mdhd0 = box('mdhd',
               0x00, // version 0
               0x00, 0x00, 0x00, // flags
@@ -189,8 +189,8 @@ QUnit.test('can parse a version 0 tkhd', function() {
     alternateGroup: 0,
     volume: 0,
     matrix: new Uint32Array(unityMatrix),
-    width: 300,
-    height: 150
+    width: 300.5,
+    height: 150.5
   }]);
 });
 


### PR DESCRIPTION
This is a fix for issue videojs/mux.js#155 ... the fractional portion of the tkhd box's height and width was being calculated incorrectly (divided by 16, instead of shifting right by 16 or divided by 65536). 