### PR TITLE
Only flush PES packets from TS parsing front end when they are complete

### DIFF
--- a/lib/m2ts/m2ts.js
+++ b/lib/m2ts/m2ts.js
@@ -321,7 +321,7 @@ ElementaryStream = function() {
         event = {
           type: type
         },
-        i = stream.data.length,
+        i = 0,
         offset = 0,
         packetFlushable = false,
         fragment;

--- a/lib/m2ts/m2ts.js
+++ b/lib/m2ts/m2ts.js
@@ -270,6 +270,9 @@ ElementaryStream = function() {
     parsePes = function(payload, pes) {
       var ptsDtsFlags;
 
+      // get the packet length, this will be 0 for video
+      pes.packetLength = 6 + ((payload[4] << 8) | payload[5]);
+
       // find out if this packets starts a new keyframe
       pes.dataAlignmentIndicator = (payload[6] & 0x04) !== 0;
       // PES packets may be annotated with a PTS value, or a PTS value
@@ -312,35 +315,50 @@ ElementaryStream = function() {
       // that follow the last byte of the field.
       pes.data = payload.subarray(9 + payload[8]);
     },
-    flushStream = function(stream, type) {
+    flushStream = function(stream, type, forceFlush) {
       var
         packetData = new Uint8Array(stream.size),
         event = {
           type: type
         },
-        i = 0,
+        i = stream.data.length,
+        offset = 0,
+        packetFlushable = false,
         fragment;
 
-      // do nothing if there is no buffered data
-      if (!stream.data.length) {
+      // do nothing if there is not enough buffered data for a complete
+      // PES header
+      if (!stream.data.length || stream.size < 9) {
         return;
       }
       event.trackId = stream.data[0].pid;
 
       // reassemble the packet
-      while (stream.data.length) {
-        fragment = stream.data.shift();
+      for (i = 0; i < stream.data.length; i++) {
+        fragment = stream.data[i];
 
-        packetData.set(fragment.data, i);
-        i += fragment.data.byteLength;
+        packetData.set(fragment.data, offset);
+        offset += fragment.data.byteLength;
       }
 
       // parse assembled packet's PES header
       parsePes(packetData, event);
 
-      stream.size = 0;
+      // non-video PES packets MUST have a non-zero PES_packet_length
+      // check that tthey match before we do a flush
+      packetFlushable = type === 'video' || event.packetLength === stream.size;
 
-      self.trigger('data', event);
+      // flush pending packets if the conditions are right
+      if (forceFlush || packetFlushable) {
+        stream.size = 0;
+        stream.data.length = 0;
+      }
+
+      // only emit packets that are complete. this is to avoid assembling
+      // incomplete PES packets due to poor segmentation
+      if (packetFlushable) {
+        self.trigger('data', event);
+      }
     };
 
   ElementaryStream.prototype.init.call(this);
@@ -376,7 +394,7 @@ ElementaryStream = function() {
         // if a new packet is starting, we can flush the completed
         // packet
         if (data.payloadUnitStartIndicator) {
-          flushStream(stream, streamType);
+          flushStream(stream, streamType, true);
         }
 
         // buffer this fragment until we are sure we've received the

--- a/lib/m2ts/m2ts.js
+++ b/lib/m2ts/m2ts.js
@@ -345,7 +345,7 @@ ElementaryStream = function() {
       parsePes(packetData, event);
 
       // non-video PES packets MUST have a non-zero PES_packet_length
-      // check that tthey match before we do a flush
+      // check that they match before we do a flush
       packetFlushable = type === 'video' || event.packetLength === stream.size;
 
       // flush pending packets if the conditions are right

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "serve": "node scripts/server.js",
     "watch": "npm run mkdirs && npm-run-all -p watch:*",
     "watch:js": "watchify -s muxjs -p bundle-collapser/plugin lib/index.js -v -o dist/mux.js",
-    "watch:test": "watchify test/*.test.js -p bundle-collapser/plugin -v -o dist-test/mux.js",
+    "watch:test": "watchify test/*.test.js -g browserify-shim -p bundle-collapser/plugin -v -o dist-test/mux.js",
     "mkdirs": "mkdir -p dist dist-test",
     "build": "npm run mkdirs && npm-run-all -p build:* && npm run collapse && npm run uglify",
     "build:mp4": "browserify -s muxjs lib/mp4/index.js -o dist/mux-mp4.js",


### PR DESCRIPTION
Where `complete` is defined as any time `PES_packet_length` matches the data’s length OR is a video packet.

Works around an issue with incomplete packets getting sent down the pipeline when the source has audio PES packets split between segments.