### PR TITLE
always update audio track info in flv transmuxer

### DIFF
--- a/lib/flv/transmuxer.js
+++ b/lib/flv/transmuxer.js
@@ -88,6 +88,7 @@ extraDataTag = function(track, pts) {
 AudioSegmentStream = function(track) {
   var
     adtsFrames = [],
+    videoKeyFrames = [],
     oldExtraData;
 
   AudioSegmentStream.prototype.init.call(this);
@@ -95,7 +96,7 @@ AudioSegmentStream = function(track) {
   this.push = function(data) {
     collectTimelineInfo(track, data);
 
-    if (track && track.channelcount === undefined) {
+    if (track) {
       track.audioobjecttype = data.audioobjecttype;
       track.channelcount = data.channelcount;
       track.samplerate = data.samplerate;
@@ -126,40 +127,21 @@ AudioSegmentStream = function(track) {
     while (adtsFrames.length) {
       currentFrame = adtsFrames.shift();
 
-      // write out metadata tags every 1 second so that the decoder
+      // write out a metadata frame at every video key frame
+      if (videoKeyFrames.length && currentFrame.pts >= videoKeyFrames[0]) {
+        lastMetaPts = videoKeyFrames.shift();
+        this.writeMetaDataTags(tags, lastMetaPts);
+      }
+
+      // also write out metadata tags every 1 second so that the decoder
       // is re-initialized quickly after seeking into a different
-      // audio configuration
+      // audio configuration.
       if (track.extraData !== oldExtraData || currentFrame.pts - lastMetaPts >= 1000) {
-       adtsFrame = new FlvTag(FlvTag.METADATA_TAG);
-        adtsFrame.pts = currentFrame.pts;
-        adtsFrame.dts = currentFrame.dts;
-
-        // AAC is always 10
-        adtsFrame.writeMetaDataDouble('audiocodecid', 10);
-        adtsFrame.writeMetaDataBoolean('stereo', track.channelcount === 2);
-        adtsFrame.writeMetaDataDouble('audiosamplerate', track.samplerate);
-        // Is AAC always 16 bit?
-        adtsFrame.writeMetaDataDouble('audiosamplesize', 16);
-
-        tags.push(adtsFrame.finalize());
-
+        this.writeMetaDataTags(tags, currentFrame.pts);
         oldExtraData = track.extraData;
-
-        adtsFrame = new FlvTag(FlvTag.AUDIO_TAG, true);
-        // For audio, DTS is always the same as PTS. We want to set the DTS
-        // however so we can compare with video DTS to determine approximate
-        // packet order
-        adtsFrame.pts = currentFrame.pts;
-        adtsFrame.dts = currentFrame.dts;
-
-        adtsFrame.view.setUint16(adtsFrame.position, track.extraData);
-        adtsFrame.position += 2;
-        adtsFrame.length = Math.max(adtsFrame.length, adtsFrame.position);
-
-        tags.push(adtsFrame.finalize());
-
         lastMetaPts = currentFrame.pts;
       }
+
       adtsFrame = new FlvTag(FlvTag.AUDIO_TAG);
       adtsFrame.pts = currentFrame.pts;
       adtsFrame.dts = currentFrame.dts;
@@ -169,10 +151,45 @@ AudioSegmentStream = function(track) {
       tags.push(adtsFrame.finalize());
     }
 
+    videoKeyFrames.length = 0;
     oldExtraData = null;
     this.trigger('data', {track: track, tags: tags.list});
 
     this.trigger('done', 'AudioSegmentStream');
+  };
+
+  this.writeMetaDataTags = function(tags, pts) {
+    var adtsFrame;
+
+    adtsFrame = new FlvTag(FlvTag.METADATA_TAG);
+    adtsFrame.pts = pts;
+    adtsFrame.dts = pts;
+
+    // AAC is always 10
+    adtsFrame.writeMetaDataDouble('audiocodecid', 10);
+    adtsFrame.writeMetaDataBoolean('stereo', track.channelcount === 2);
+    adtsFrame.writeMetaDataDouble('audiosamplerate', track.samplerate);
+    // Is AAC always 16 bit?
+    adtsFrame.writeMetaDataDouble('audiosamplesize', 16);
+
+    tags.push(adtsFrame.finalize());
+
+    adtsFrame = new FlvTag(FlvTag.AUDIO_TAG, true);
+    // For audio, DTS is always the same as PTS. We want to set the DTS
+    // however so we can compare with video DTS to determine approximate
+    // packet order
+    adtsFrame.pts = pts;
+    adtsFrame.dts = pts;
+
+    adtsFrame.view.setUint16(adtsFrame.position, track.extraData);
+    adtsFrame.position += 2;
+    adtsFrame.length = Math.max(adtsFrame.length, adtsFrame.position);
+
+    tags.push(adtsFrame.finalize());
+  };
+
+  this.onVideoKeyFrame = function(pts) {
+    videoKeyFrames.push(pts);
   };
 };
 AudioSegmentStream.prototype = new Stream();
@@ -205,6 +222,8 @@ VideoSegmentStream = function(track) {
       tags.push(metaTag);
       tags.push(extraTag);
       track.newMetadata = false;
+
+      this.trigger('keyframe', frame.dts);
     }
 
     frame.endNalUnit();
@@ -385,6 +404,10 @@ Transmuxer = function(options) {
         adtsStream
           .pipe(audioSegmentStream)
           .pipe(coalesceStream);
+
+        if (videoSegmentStream) {
+          videoSegmentStream.on('keyframe', audioSegmentStream.onVideoKeyFrame);
+        }
       }
     }
   });


### PR DESCRIPTION
The flv transmuxer would only update its audio track information if it hasnt yet set it. This causes problems when the audio changes (e.g. sampling rate) because the metadata tags added would still be using the old track info. This changes that to always update track info on pushes.

This also includes a change to add metadata tags to the audio stream at the same time as video key frames so that starting playback on any keyframe will also contain the correct audio track metadata