### PR TITLE
Use the first audio and video tracks in the PMT

### DIFF
--- a/lib/m2ts/m2ts.js
+++ b/lib/m2ts/m2ts.js
@@ -156,7 +156,11 @@ TransportParseStream = function() {
     }
 
     // overwrite any existing program map table
-    self.programMapTable = {};
+    self.programMapTable = {
+      video: null,
+      audio: null,
+      'timed-metadata': {}
+    };
 
     // the mapping table ends at the end of the current section
     sectionLength = (payload[1] & 0x0f) << 8 | payload[2];
@@ -169,8 +173,22 @@ TransportParseStream = function() {
     // advance the offset to the first entry in the mapping table
     offset = 12 + programInfoLength;
     while (offset < tableEnd) {
-      // add an entry that maps the elementary_pid to the stream_type
-      self.programMapTable[(payload[offset + 1] & 0x1F) << 8 | payload[offset + 2]] = payload[offset];
+      var streamType = payload[offset];
+      var pid = (payload[offset + 1] & 0x1F) << 8 | payload[offset + 2];
+
+      // only map a single elementary_pid for audio and video stream types
+      // TODO: should this be done for metadata too? for now maintain behavior of
+      //       multiple metadata streams
+      if (streamType === StreamTypes.H264_STREAM_TYPE &&
+          self.programMapTable.video === null) {
+        self.programMapTable.video = pid;
+      } else if (streamType === StreamTypes.ADTS_STREAM_TYPE &&
+                 self.programMapTable.audio === null) {
+        self.programMapTable.audio = pid;
+      } else if (streamType === StreamTypes.METADATA_STREAM_TYPE) {
+        // map pid to stream type for metadata streams
+        self.programMapTable['timed-metadata'][pid] = streamType;
+      }
 
       // move to the next table entry
       // skip past the elementary stream descriptors, if present
@@ -229,7 +247,17 @@ TransportParseStream = function() {
   };
 
   this.processPes_ = function(packet, offset, result) {
-    result.streamType = this.programMapTable[result.pid];
+    // set the appropriate stream type
+    if (result.pid === this.programMapTable.video) {
+      result.streamType = StreamTypes.H264_STREAM_TYPE;
+    } else if (result.pid === this.programMapTable.audio) {
+      result.streamType = StreamTypes.ADTS_STREAM_TYPE;
+    } else {
+      // if not video or audio, it is timed-metadata or unknown
+      // if unknown, streamType will be undefined
+      result.streamType = this.programMapTable['timed-metadata'][result.pid];
+    }
+
     result.type = 'pes';
     result.data = packet.subarray(offset);
 
@@ -408,29 +436,30 @@ ElementaryStream = function() {
             type: 'metadata',
             tracks: []
           },
-          programMapTable = data.programMapTable,
-          k,
-          track;
+          programMapTable = data.programMapTable;
 
-        // translate streams to tracks
-        for (k in programMapTable) {
-          if (programMapTable.hasOwnProperty(k)) {
-            track = {
-              timelineStartInfo: {
-                baseMediaDecodeTime: 0
-              }
-            };
-            track.id = +k;
-            if (programMapTable[k] === m2tsStreamTypes.H264_STREAM_TYPE) {
-              track.codec = 'avc';
-              track.type = 'video';
-            } else if (programMapTable[k] === m2tsStreamTypes.ADTS_STREAM_TYPE) {
-              track.codec = 'adts';
-              track.type = 'audio';
-            }
-            event.tracks.push(track);
-          }
+        // translate audio and video streams to tracks
+        if (programMapTable.video !== null) {
+          event.tracks.push({
+            timelineStartInfo: {
+              baseMediaDecodeTime: 0
+            },
+            id: +programMapTable.video,
+            codec: 'avc',
+            type: 'video'
+          });
         }
+        if (programMapTable.audio !== null) {
+          event.tracks.push({
+            timelineStartInfo: {
+              baseMediaDecodeTime: 0
+            },
+            id: +programMapTable.audio,
+            codec: 'adts',
+            type: 'audio'
+          });
+        }
+
         self.trigger('data', event);
       }
     })[data.type]();

--- a/test/transmuxer.test.js
+++ b/test/transmuxer.test.js
@@ -238,7 +238,8 @@ QUnit.test('parses a PES packet', function() {
 
   // setup a program map table
   transportParseStream.programMapTable = {
-    0x0010: mp2t.H264_STREAM_TYPE
+    video: 0x0010,
+    'timed-metadata': {}
   };
 
   transportParseStream.push(new Uint8Array([
@@ -257,7 +258,8 @@ QUnit.test('parses packets with variable length adaptation fields and a payload'
 
   // setup a program map table
   transportParseStream.programMapTable = {
-    0x0010: mp2t.H264_STREAM_TYPE
+    video: 0x0010,
+    'timed-metadata': {}
   };
 
   transportParseStream.push(new Uint8Array([
@@ -418,9 +420,8 @@ QUnit.test('parse the elementary streams from a program map table', function() {
 
   QUnit.ok(packet, 'parsed a packet');
   QUnit.ok(transportParseStream.programMapTable, 'parsed a program map');
-  QUnit.strictEqual(0x1b, transportParseStream.programMapTable[0x11], 'associated h264 with pid 0x11');
-  QUnit.strictEqual(0x0f, transportParseStream.programMapTable[0x12], 'associated adts with pid 0x12');
-  QUnit.strictEqual(transportParseStream.programMapTable[0], undefined, 'ignored trailing stuffing bytes');
+  QUnit.strictEqual(transportParseStream.programMapTable.video, 0x11, 'associated h264 with pid 0x11');
+  QUnit.strictEqual(transportParseStream.programMapTable.audio, 0x12, 'associated adts with pid 0x12');
   QUnit.deepEqual(transportParseStream.programMapTable, packet.programMapTable, 'recorded the PMT');
 });
 
@@ -592,8 +593,9 @@ QUnit.test('parses metadata events from PSI packets', function() {
   elementaryStream.push({
     type: 'pmt',
     programMapTable: {
-      1: 0x1b,
-      2: 0x0f
+      video: 1,
+      audio: 2,
+      'timed-metadata': {}
     }
   });
 


### PR DESCRIPTION
Segments can contain multiple audio and video tracks. Currently mux.js does not take this into account, so when there are multiple, they get combined into a single stream. This can cause playback issues or distorted audio. 
https://github.com/videojs/videojs-contrib-hls/issues/994
https://github.com/videojs/mux.js/issues/106
https://github.com/videojs/videojs-contrib-hls/issues/1247

This change makes sure the transmuxer uses the track with the lowest identifier, ignoring extra tracks.

I'm not quite sure if it is common for streams to have multiple timed-metadata tracks, and we have not gotten any reports around multiple timed-metadata tracks, so I have kept the functionality of combining all timed-metadata tracks into a single stream.