### PR TITLE
Set active data channel per-field instead of globally

### DIFF
--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -260,9 +260,9 @@ CaptionStream.prototype.reset = function() {
 
 CaptionStream.prototype.dispatchCea608Packet = function(packet) {
   // NOTE: packet.type is the CEA608 field
-  if (this.setsChannel1Active(packet) && this.activeCea608Channel_[packet.type] !== 0) {
+  if (this.setsChannel1Active(packet)) {
     this.activeCea608Channel_[packet.type] = 0;
-  } else if (this.setsChannel2Active(packet) && this.activeCea608Channel_[packet.type] !== 1) {
+  } else if (this.setsChannel2Active(packet)) {
     this.activeCea608Channel_[packet.type] = 1;
   }
   if (this.activeCea608Channel_[packet.type] === null) {

--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -140,10 +140,6 @@ var parseCaptionPackets = function(pts, userData) {
   return results;
 };
 
-var packetDropper = {
-  push: function() {}
-};
-
 var CaptionStream = function() {
 
   CaptionStream.prototype.init.call(this);
@@ -256,30 +252,25 @@ CaptionStream.prototype.flush = function() {
 CaptionStream.prototype.reset = function() {
   this.latestDts_ = null;
   this.ignoreNextEqualDts_ = false;
-  this.activeCea608Channel_ = null;
-  // Since we don't know which channel is active until we get a control
-  // code that sets it, we start off with CEA608 handlers that just drop
-  // all the packets.
-  this.activeCea608Streams_ = [
-    packetDropper,
-    packetDropper
-  ];
+  this.activeCea608Channel_ = [null, null];
   this.ccStreams_.forEach(function(ccStream) {
     ccStream.reset();
   });
 };
 
 CaptionStream.prototype.dispatchCea608Packet = function(packet) {
-  if (this.setsChannel1Active(packet) && this.activeCea608Channel_ !== 1) {
-    this.activeCea608Channel_ = 1;
-    this.activeCea608Streams_ = [this.ccStreams_[0], this.ccStreams_[2]]; // CC1, CC3
-  } else if (this.setsChannel2Active(packet) && this.activeCea608Channel_ !== 2) {
-    this.activeCea608Channel_ = 2;
-    this.activeCea608Streams_ = [this.ccStreams_[1], this.ccStreams_[3]]; // CC2, CC4
+  // NOTE: packet.type is the CEA608 field
+  if (this.setsChannel1Active(packet) && this.activeCea608Channel_[packet.type] !== 0) {
+    this.activeCea608Channel_[packet.type] = 0;
+  } else if (this.setsChannel2Active(packet) && this.activeCea608Channel_[packet.type] !== 1) {
+    this.activeCea608Channel_[packet.type] = 1;
   }
-  // If we haven't set the active streams yet, this next call just returns
-  // immediately.
-  this.activeCea608Streams_[packet.type].push(packet);
+  if (this.activeCea608Channel_[packet.type] === null) {
+    // If we haven't received anything to set the active channel, discard the
+    // data; we don't want jumbled captions
+    return;
+  }
+  this.ccStreams_[(packet.type << 1) + this.activeCea608Channel_[packet.type]].push(packet);
 };
 
 CaptionStream.prototype.setsChannel1Active = function(packet) {


### PR DESCRIPTION
According to some real-world caption data for CC4, the currently active data channel is tracked on a per-field basis, not globally for all captions.

Comments about the efficiency of my solution would be particularly appreciated.