### PR TITLE
flush pes packets when there is enough data

### DIFF
--- a/lib/m2ts/m2ts.js
+++ b/lib/m2ts/m2ts.js
@@ -373,8 +373,8 @@ ElementaryStream = function() {
       parsePes(packetData, event);
 
       // non-video PES packets MUST have a non-zero PES_packet_length
-      // check that they match before we do a flush
-      packetFlushable = type === 'video' || event.packetLength === stream.size;
+      // check that there is enough stream data to fill the packet
+      packetFlushable = type === 'video' || event.packetLength <= stream.size;
 
       // flush pending packets if the conditions are right
       if (forceFlush || packetFlushable) {

--- a/test/transmuxer.test.js
+++ b/test/transmuxer.test.js
@@ -812,8 +812,9 @@ QUnit.test('won\'t emit non-video packets if the PES_packet_length is larger tha
     payloadUnitStartIndicator: true,
     streamType: METADATA_STREAM_TYPE,
     // data larger than 5 byte dataLength, should still emit event
-    data: new Uint8Array(pesHead.concat([1,1,1,1,1,1,1,1,1]))
-  })
+    data: new Uint8Array(pesHead.concat([1, 1, 1, 1, 1, 1, 1, 1, 1]))
+  });
+
   QUnit.equal(0, events.length, 'buffers partial packets');
 
   elementaryStream.flush();


### PR DESCRIPTION
PES packets can be poorly formatted to have padding bytes at the end, but not include those padding bytes in the PES_packet_length value. This would cause the length match comparison to make sure we've gotten the compete packet to fail. The change here will allow flushing a packet if we have exactly or more than enough data to meet the PES_packet_length. 