### PR TITLE
Better fix for ignoring of duplicate segments

### DIFF
--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -191,22 +191,30 @@ CaptionStream.prototype.push = function(event) {
   // Sometimes, the same segment # will be downloaded twice. To stop the
   // caption data from being processed twice, we track the latest dts we've
   // received and ignore everything with a dts before that. However, since
-  // data for a specific dts can be split across 2 packets on either side of
-  // a segment boundary, we need to make sure we *don't* ignore the second
-  // dts packet we receive that has dts === this.latestDts_. And thus, the
-  // ignoreNextEqualDts_ flag was born.
+  // data for a specific dts can be split across packets on either side of
+  // a segment boundary, we need to make sure we *don't* ignore the packets
+  // from the *next* segment that have dts === this.latestDts_. By constantly
+  // tracking the number of packets received with dts === this.latestDts_, we
+  // know how many should be ignored once we start receiving duplicates.
   if (event.dts < this.latestDts_) {
     // We've started getting older data, so set the flag.
     this.ignoreNextEqualDts_ = true;
     return;
   } else if ((event.dts === this.latestDts_) && (this.ignoreNextEqualDts_)) {
-    // We've received the last duplicate packet, time to start processing again
-    this.ignoreNextEqualDts_ = false;
+    this.numSameDts_--;
+    if (!this.numSameDts_) {
+      // We've received the last duplicate packet, time to start processing again
+      this.ignoreNextEqualDts_ = false;
+    }
     return;
   }
 
   // parse out CC data packets and save them for later
   this.captionPackets_ = this.captionPackets_.concat(parseCaptionPackets(event.pts, userData));
+  if (this.latestDts_ !== event.dts) {
+    this.numSameDts_ = 0;
+  }
+  this.numSameDts_++;
   this.latestDts_ = event.dts;
 };
 
@@ -252,6 +260,7 @@ CaptionStream.prototype.flush = function() {
 CaptionStream.prototype.reset = function() {
   this.latestDts_ = null;
   this.ignoreNextEqualDts_ = false;
+  this.numSameDts_ = 0;
   this.activeCea608Channel_ = [null, null];
   this.ccStreams_.forEach(function(ccStream) {
     ccStream.reset();

--- a/test/caption-stream.test.js
+++ b/test/caption-stream.test.js
@@ -428,6 +428,81 @@ QUnit.test('drops duplicate segments with multi-segment DTS values', function() 
     {
       pts: 4000, dts: 4000, captions: [
         {ccData: 0x142f, type: 0 },
+        {ccData: 0x1420, type: 0 }
+      ]
+    },
+    {
+      pts: 5000, dts: 5000, captions: [
+        {ccData: 0x1420, type: 0 },
+        {ccData: characters(' a'), type: 0 },
+        {ccData: characters('nd'), type: 0 }
+      ]
+    },
+    {
+      pts: 6000, dts: 6000, captions: [
+        {ccData: characters(' e'), type: 0 },
+        {ccData: characters('ve'), type: 0 }
+      ]
+    },
+    {
+      pts: 6000, dts: 6000, captions: [
+        {ccData: characters('n '), type: 0 },
+        {ccData: characters('mo'), type: 0 }
+      ]
+    },
+    {
+      pts: 6000, dts: 6000, captions: [
+        {ccData: characters('re'), type: 0 },
+        {ccData: characters(' t'), type: 0 }
+      ]
+    },
+    {
+      pts: 5000, dts: 5000, captions: [
+        {ccData: 0x1420, type: 0 },
+        {ccData: characters(' a'), type: 0 },
+        {ccData: characters('nd'), type: 0 }
+      ]
+    },
+    {
+      pts: 6000, dts: 6000, captions: [
+        {ccData: characters(' e'), type: 0 },
+        {ccData: characters('ve'), type: 0 }
+      ]
+    },
+    {
+      pts: 6000, dts: 6000, captions: [
+        {ccData: characters('n '), type: 0 },
+        {ccData: characters('mo'), type: 0 }
+      ]
+    },
+    {
+      pts: 6000, dts: 6000, captions: [
+        {ccData: characters('re'), type: 0 },
+        {ccData: characters(' t'), type: 0 }
+      ]
+    },
+    {
+      pts: 6000, dts: 6000, captions: [
+        {ccData: characters('ex'), type: 0 },
+        {ccData: characters('t '), type: 0 }
+      ]
+    },
+    {
+      pts: 6000, dts: 6000, captions: [
+        {ccData: characters('da'), type: 0 },
+        {ccData: characters('ta'), type: 0 }
+      ]
+    },
+    {
+      pts: 7000, dts: 7000, captions: [
+        {ccData: characters(' h'), type: 0 },
+        {ccData: characters('er'), type: 0 }
+      ]
+    },
+    {
+      pts: 8000, dts: 8000, captions: [
+        {ccData: characters('e!'), type: 0 },
+        {ccData: 0x142f, type: 0 },
         {ccData: 0x142f, type: 0 },
         {ccData: 0x1420, type: 0 },
         {ccData: 0x142f, type: 0 }
@@ -445,8 +520,9 @@ QUnit.test('drops duplicate segments with multi-segment DTS values', function() 
   seiNals.forEach(captionStream.push, captionStream);
   captionStream.flush();
 
-  QUnit.equal(captions.length, 1, 'detected one caption');
+  QUnit.equal(captions.length, 2, 'detected two captions');
   QUnit.equal(captions[0].text, 'test string data stuff', 'parsed caption properly');
+  QUnit.equal(captions[1].text, 'and even more text data here!', 'parsed caption properly');
 });
 
 QUnit.test("doesn't ignore older segments if reset", function() {


### PR DESCRIPTION
I found a source feed which broke the fix I made in #158 :sob: 

Thankfully, a fix wasn't too hard. It was just receiving packets with the same dts before the segment switch, so now it keeps track of how many packets it should ignore (i.e. it better infers where the segment boundary is).

Updated the relevant test to account for such a situation.