### PR TITLE
Support for paint-on, slight rework to roll-up, misc fixes

### DIFF
--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -466,13 +466,13 @@ var Cea608Stream = function(field, dataChannel) {
 
     } else if (data === this.ROLL_UP_2_ROWS_) {
       this.rollUpRows_ = 2;
-      this.setRollUp();
+      this.setRollUp(packet.pts);
     } else if (data === this.ROLL_UP_3_ROWS_) {
       this.rollUpRows_ = 3;
-      this.setRollUp();
+      this.setRollUp(packet.pts);
     } else if (data === this.ROLL_UP_4_ROWS_) {
       this.rollUpRows_ = 4;
-      this.setRollUp();
+      this.setRollUp(packet.pts);
     } else if (data === this.CARRIAGE_RETURN_) {
       this.clearFormatting(packet.pts);
       this.flushDisplayed(packet.pts);
@@ -564,7 +564,7 @@ var Cea608Stream = function(field, dataChannel) {
 
       // Configure the caption window if we're in roll-up mode
       if (this.mode_ === 'rollUp') {
-        this.setRollUp(row);
+        this.setRollUp(packet.pts, row);
       }
 
       if (row !== this.row_) {
@@ -812,15 +812,17 @@ Cea608Stream.prototype.isNormalChar = function(char) {
 /**
  * Configures roll-up
  *
+ * @param  {Integer} pts         Current PTS
  * @param  {Integer} newBaseRow  Used by PACs to slide the current window to
  *                               a new position
  */
-Cea608Stream.prototype.setRollUp = function(newBaseRow) {
+Cea608Stream.prototype.setRollUp = function(pts, newBaseRow) {
   // Reset the base row to the bottom row when switching modes
   if (this.mode_ !== 'rollUp') {
     this.row_ = BOTTOM_ROW;
     this.mode_ = 'rollUp';
     // Spec says to wipe memories when switching to roll-up
+    this.flushDisplayed(pts);
     this.nonDisplayed_ = createDisplayBuffer();
     this.displayed_ = createDisplayBuffer();
   }

--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -451,6 +451,7 @@ var Cea608Stream = function(field, dataChannel) {
       this.mode_ = 'popOn';
 
     } else if (data === this.END_OF_CAPTION_) {
+      this.mode_ = 'popOn';
       this.clearFormatting(packet.pts);
       // if a caption was being displayed, it's gone now
       this.flushDisplayed(packet.pts);
@@ -464,14 +465,14 @@ var Cea608Stream = function(field, dataChannel) {
       this.startPts_ = packet.pts;
 
     } else if (data === this.ROLL_UP_2_ROWS_) {
-      this.topRow_ = BOTTOM_ROW - 1;
-      this.mode_ = 'rollUp';
+      this.rollUpRows_ = 2;
+      this.setRollUp();
     } else if (data === this.ROLL_UP_3_ROWS_) {
-      this.topRow_ = BOTTOM_ROW - 2;
-      this.mode_ = 'rollUp';
+      this.rollUpRows_ = 3;
+      this.setRollUp();
     } else if (data === this.ROLL_UP_4_ROWS_) {
-      this.topRow_ = BOTTOM_ROW - 3;
-      this.mode_ = 'rollUp';
+      this.rollUpRows_ = 4;
+      this.setRollUp();
     } else if (data === this.CARRIAGE_RETURN_) {
       this.clearFormatting(packet.pts);
       this.flushDisplayed(packet.pts);
@@ -480,9 +481,9 @@ var Cea608Stream = function(field, dataChannel) {
 
     } else if (data === this.BACKSPACE_) {
       if (this.mode_ === 'popOn') {
-        this.nonDisplayed_[BOTTOM_ROW] = this.nonDisplayed_[BOTTOM_ROW].slice(0, -1);
+        this.nonDisplayed_[this.row_] = this.nonDisplayed_[this.row_].slice(0, -1);
       } else {
-        this.displayed_[BOTTOM_ROW] = this.displayed_[BOTTOM_ROW].slice(0, -1);
+        this.displayed_[this.row_] = this.displayed_[this.row_].slice(0, -1);
       }
     } else if (data === this.ERASE_DISPLAYED_MEMORY_) {
       this.flushDisplayed(packet.pts);
@@ -492,6 +493,7 @@ var Cea608Stream = function(field, dataChannel) {
 
     } else if (data === this.RESUME_DIRECT_CAPTIONING_) {
       this.mode_ = 'paintOn';
+      this.startPts_ = packet.pts;
 
     // Append special characters to caption text
     } else if (this.isSpecialCharacter(char0, char1)) {
@@ -515,7 +517,7 @@ var Cea608Stream = function(field, dataChannel) {
       if (this.mode_ === 'popOn') {
         this.nonDisplayed_[this.row_] = this.nonDisplayed_[this.row_].slice(0, -1);
       } else {
-        this.displayed_[BOTTOM_ROW] = this.displayed_[BOTTOM_ROW].slice(0, -1);
+        this.displayed_[this.row_] = this.displayed_[this.row_].slice(0, -1);
       }
 
       // Bitmask char0 so that we can apply character transformations
@@ -559,6 +561,11 @@ var Cea608Stream = function(field, dataChannel) {
       // There's no logic for PAC -> row mapping, so we have to just
       // find the row code in an array and use its index :(
       var row = ROWS.indexOf(data & 0x1f20);
+
+      // Configure the caption window if we're in roll-up mode
+      if (this.mode_ === 'rollUp') {
+        this.setRollUp(row);
+      }
 
       if (row !== this.row_) {
         // formatting is only persistent for current row
@@ -645,6 +652,7 @@ Cea608Stream.prototype.reset = function() {
   // Track row and column for proper line-breaking and spacing
   this.column_ = 0;
   this.row_ = BOTTOM_ROW;
+  this.rollUpRows_ = 2;
 
   // This variable holds currently-applied formatting
   this.formatting_ = [];
@@ -691,7 +699,7 @@ Cea608Stream.prototype.setConstants = function() {
   this.ROLL_UP_3_ROWS_             = this.CONTROL_ | 0x26;
   this.ROLL_UP_4_ROWS_             = this.CONTROL_ | 0x27;
   this.CARRIAGE_RETURN_            = this.CONTROL_ | 0x2d;
-  // paint-on mode (not supported)
+  // paint-on mode
   this.RESUME_DIRECT_CAPTIONING_   = this.CONTROL_ | 0x29;
   // Erasure
   this.BACKSPACE_                  = this.CONTROL_ | 0x21;
@@ -801,6 +809,36 @@ Cea608Stream.prototype.isNormalChar = function(char) {
   return (char >= 0x20 && char <= 0x7f);
 };
 
+/**
+ * Configures roll-up
+ *
+ * @param  {Integer} newBaseRow  Used by PACs to slide the current window to
+ *                               a new position
+ */
+Cea608Stream.prototype.setRollUp = function(newBaseRow) {
+  // Reset the base row to the bottom row when switching modes
+  if (this.mode_ !== 'rollUp') {
+    this.row_ = BOTTOM_ROW;
+    this.mode_ = 'rollUp';
+    // Spec says to wipe memories when switching to roll-up
+    this.nonDisplayed_ = createDisplayBuffer();
+    this.displayed_ = createDisplayBuffer();
+  }
+
+  if (newBaseRow !== undefined && newBaseRow !== this.row_) {
+    // slide the window around if we need to
+    for (var i = 0; i < this.rollUpRows_; i++) {
+      this.displayed_[newBaseRow - i] = this.displayed_[this.row_ - i];
+      this.displayed_[this.row_ - i] = '';
+    }
+  }
+
+  if (newBaseRow === undefined) {
+    newBaseRow = this.row_;
+  }
+  this.topRow_ = newBaseRow - this.rollUpRows_ + 1;
+};
+
 // Adds the opening HTML tag for the passed character to the caption text,
 // and keeps track of it for later closing
 Cea608Stream.prototype.addFormatting = function(pts, format) {
@@ -834,10 +872,10 @@ Cea608Stream.prototype.popOn = function(pts, text) {
 };
 
 Cea608Stream.prototype.rollUp = function(pts, text) {
-  var baseRow = this.displayed_[BOTTOM_ROW];
+  var baseRow = this.displayed_[this.row_];
 
   baseRow += text;
-  this.displayed_[BOTTOM_ROW] = baseRow;
+  this.displayed_[this.row_] = baseRow;
 
 };
 
@@ -847,16 +885,24 @@ Cea608Stream.prototype.shiftRowsUp_ = function() {
   for (i = 0; i < this.topRow_; i++) {
     this.displayed_[i] = '';
   }
+  for (i = this.row_ + 1; i < BOTTOM_ROW + 1; i++) {
+    this.displayed_[i] = '';
+  }
   // shift displayed rows up
-  for (i = this.topRow_; i < BOTTOM_ROW; i++) {
+  for (i = this.topRow_; i < this.row_; i++) {
     this.displayed_[i] = this.displayed_[i + 1];
   }
   // clear out the bottom row
-  this.displayed_[BOTTOM_ROW] = '';
+  this.displayed_[this.row_] = '';
 };
 
-// paintOn mode is not implemented
-Cea608Stream.prototype.paintOn = function() {};
+Cea608Stream.prototype.paintOn = function(pts, text) {
+  var baseRow = this.displayed_[this.row_];
+
+  baseRow = baseRow.slice(0, this.column_) + text +
+    baseRow.slice(this.column_ + text.length);
+  this.displayed_[this.row_] = baseRow;
+};
 
 // exports
 module.exports = {

--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -451,6 +451,10 @@ var Cea608Stream = function(field, dataChannel) {
       this.mode_ = 'popOn';
 
     } else if (data === this.END_OF_CAPTION_) {
+      // If an EOC is received while in paint-on mode, the displayed caption
+      // text should be swapped to non-displayed memory as if it was a pop-on
+      // caption. Because of that, we should explicitly switch back to pop-on
+      // mode
       this.mode_ = 'popOn';
       this.clearFormatting(packet.pts);
       // if a caption was being displayed, it's gone now
@@ -834,7 +838,7 @@ Cea608Stream.prototype.setRollUp = function(pts, newBaseRow) {
   }
 
   if (newBaseRow !== undefined && newBaseRow !== this.row_) {
-    // slide the window around if we need to
+    // move currently displayed captions (up or down) to the new base row
     for (var i = 0; i < this.rollUpRows_; i++) {
       this.displayed_[newBaseRow - i] = this.displayed_[this.row_ - i];
       this.displayed_[this.row_ - i] = '';

--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -492,6 +492,12 @@ var Cea608Stream = function(field, dataChannel) {
       this.nonDisplayed_ = createDisplayBuffer();
 
     } else if (data === this.RESUME_DIRECT_CAPTIONING_) {
+      if (this.mode_ !== 'paintOn') {
+        // NOTE: This should be removed when proper caption positioning is
+        // implemented
+        this.flushDisplayed(packet.pts);
+        this.displayed_ = createDisplayBuffer();
+      }
       this.mode_ = 'paintOn';
       this.startPts_ = packet.pts;
 
@@ -901,8 +907,7 @@ Cea608Stream.prototype.shiftRowsUp_ = function() {
 Cea608Stream.prototype.paintOn = function(pts, text) {
   var baseRow = this.displayed_[this.row_];
 
-  baseRow = baseRow.slice(0, this.column_) + text +
-    baseRow.slice(this.column_ + text.length);
+  baseRow += text;
   this.displayed_[this.row_] = baseRow;
 };
 

--- a/test/caption-stream.test.js
+++ b/test/caption-stream.test.js
@@ -1568,8 +1568,8 @@ QUnit.test('switching to roll-up from pop-on wipes memories and flushes captions
   });
 
   QUnit.equal(captions.length, 2, 'both captions flushed');
-  QUnit.equal(displayed, '');
-  QUnit.equal(nonDisplayed, '');
+  QUnit.equal(displayed, '', 'displayed memory is wiped');
+  QUnit.equal(nonDisplayed, '', 'non-displayed memory is wiped');
   QUnit.deepEqual(captions[0], {
     startPts: 1000,
     endPts: 2000,
@@ -1606,8 +1606,8 @@ QUnit.test('switching to roll-up from paint-on wipes memories and flushes captio
   });
 
   QUnit.equal(captions.length, 1, 'flushed caption');
-  QUnit.equal(displayed, '');
-  QUnit.equal(nonDisplayed, '');
+  QUnit.equal(displayed, '', 'displayed memory is wiped');
+  QUnit.equal(nonDisplayed, '', 'non-displayed memory is wiped');
   QUnit.deepEqual(captions[0], {
     startPts: 0,
     endPts: 1000,

--- a/test/caption-stream.test.js
+++ b/test/caption-stream.test.js
@@ -1074,6 +1074,7 @@ QUnit.test('backspaces are applied to non-displayed memory for pop-on mode', fun
     // backspace
     { ccData: 0x1421, type: 0 },
     { ccData: characters('23'), type: 0 },
+    // PAC: row 13, no indent
     { pts: 1 * 1000, ccData: 0x1370, type: 0 },
     { pts: 1 * 1000, ccData: characters('32'), type: 0 },
     // backspace
@@ -1083,7 +1084,7 @@ QUnit.test('backspaces are applied to non-displayed memory for pop-on mode', fun
     { pts: 4 * 1000, ccData: 0x142f, type: 0 },
     // Send another command so that the second EOC isn't ignored
     { ccData: 0x1420, type: 0 },
-    // EOC, End of Caption
+    // EOC, End of Caption, flush caption
     { pts: 5 * 1000, ccData: 0x142f, type: 0 }
   ];
 
@@ -1548,13 +1549,17 @@ QUnit.test('switching to roll-up from pop-on wipes memories and flushes captions
   });
 
   [
+    // RCL (resume caption loading)
     { pts: 0 * 1000, ccData: 0x1420, type: 0 },
     { pts: 0 * 1000, ccData: characters('hi'), type: 0 },
-    // flip memories
+    // EOC (end of caption), mark 1st caption start
     { pts: 1 * 1000, ccData: 0x142f, type: 0 },
+    // RCL, resume caption loading
     { pts: 1 * 1000, ccData: 0x1420, type: 0 },
     { pts: 2 * 1000, ccData: characters('oh'), type: 0 },
+    // EOC, mark 2nd caption start and flush 1st caption
     { pts: 2 * 1000, ccData: 0x142f, type: 0 },
+    // RU2 (roll-up, 2 rows), flush 2nd caption
     { pts: 3 * 1000, ccData: 0x1425, type: 0 }
   ].forEach(cea608Stream.push, cea608Stream);
 
@@ -1591,8 +1596,10 @@ QUnit.test('switching to roll-up from paint-on wipes memories and flushes captio
   });
 
   [
+    // RDC (resume direct captioning)
     { pts: 0 * 1000, ccData: 0x1429, type: 0 },
     { pts: 0 * 1000, ccData: characters('hi'), type: 0 },
+    // RU2 (roll-up, 2 rows), flush displayed caption
     { pts: 1 * 1000, ccData: 0x1425, type: 0 }
   ].forEach(cea608Stream.push, cea608Stream);
 
@@ -1625,16 +1632,23 @@ QUnit.test('switching to paint-on from pop-on flushes display', function() {
   });
 
   [
+    // RCL (resume caption loading)
     { pts: 0 * 1000, ccData: 0x1420, type: 0 },
+    // PAC: row 14, indent 0
     { pts: 0 * 1000, ccData: 0x1450, type: 0 },
     { pts: 0 * 1000, ccData: characters('hi'), type: 0 },
+    // EOC (end of caption), mark caption start
     { pts: 1 * 1000, ccData: 0x142f, type: 0 },
+    // RCL
     { pts: 1 * 1000, ccData: 0x1420, type: 0 },
-    // flip memories
+    // RDC (resume direct captioning), flush caption
     { pts: 2 * 1000, ccData: 0x1429, type: 0 },
+    // PAC: row 14, indent 0
     { pts: 2 * 1000, ccData: 0x1450, type: 0 },
+    // TO1 (tab offset 1 column)
     { pts: 2 * 1000, ccData: 0x1721, type: 0 },
     { pts: 3 * 1000, ccData: characters('io'), type: 0 },
+    // EDM (erase displayed memory), flush paint-on caption
     { pts: 4 * 1000, ccData: 0x142c, type: 0 }
   ].forEach(cea608Stream.push, cea608Stream);
 
@@ -1978,9 +1992,8 @@ QUnit.test('paint-on mode', function() {
   packets = [
     // RDC, resume direct captioning, begin display
     { pts: 1000, ccData: 0x1429, type: 0 },
-    // 'hi'
     { pts: 2000, ccData: characters('hi'), type: 0 },
-    // EDM, erase displayed memory. Finish display
+    // EDM, erase displayed memory. Finish display, flush caption
     { pts: 3000, ccData: 0x142c, type: 0 }
   ];
   captions = [];
@@ -2009,17 +2022,23 @@ QUnit.test('preserves newlines from PACs in paint-on mode', function() {
   [
     // RDC, resume direct captioning
     { pts: 1000, ccData: 0x1429, type: 0 },
+    // PAC: row 12, indent 0
     { pts: 1000, ccData: 0x1350, type: 0 },
+    // text: TEST
     { pts: 2000, ccData: 0x5445, type: 0 },
     { pts: 2000, ccData: 0x5354, type: 0 },
+    // PAC: row 14, indent 0
     { pts: 3000, ccData: 0x1450, type: 0 },
+    // text: STRING
     { pts: 3000, ccData: 0x5354, type: 0 },
     { pts: 4000, ccData: 0x5249, type: 0 },
     { pts: 4000, ccData: 0x4e47, type: 0 },
+    // PAC: row 15, indent 0
     { pts: 5000, ccData: 0x1470, type: 0 },
+    // text: DATA
     { pts: 5000, ccData: 0x4441, type: 0 },
     { pts: 6000, ccData: 0x5441, type: 0 },
-    // EDM, erase displayed memory. Finish display
+    // EDM, erase displayed memory. Finish display, flush caption
     { pts: 6000, ccData: 0x142c, type: 0 }
   ].forEach(cea608Stream.push, cea608Stream);
 
@@ -2040,13 +2059,13 @@ QUnit.test('backspaces are reflected in the generated captions (paint-on)', func
     // backspace
     { pts: 0 * 1000, ccData: 0x1421, type: 0 },
     { pts: 1 * 1000, ccData: characters('23'), type: 0 },
-    // switch to row 13
+    // PAC: row 13, indent 0
     { pts: 2 * 1000, ccData: 0x1370, type: 0 },
     { pts: 2 * 1000, ccData: characters('32'), type: 0 },
     // backspace
     { pts: 3 * 1000, ccData: 0x1421, type: 0 },
     { pts: 4 * 1000, ccData: characters('10'), type: 0 },
-    // EDM, erase displayed memory
+    // EDM, erase displayed memory, flush caption
     { pts: 5 * 1000, ccData: 0x142c, type: 0 }
   ].forEach(cea608Stream.push, cea608Stream);
 
@@ -2061,15 +2080,23 @@ QUnit.test('mix of all modes (extract from CNN)', function() {
   });
 
   [
+    // RU2 (roll-up, 2 rows)
     { pts: 6675, ccData: 0x1425, type: 0 },
+    // CR (carriange return), flush nothing
     { pts: 6675, ccData: 0x142d, type: 0 },
+    // PAC: row 2, indent 0
     { pts: 6675, ccData: 0x1170, type: 0 },
+    // text: YEAR.
     { pts: 6676, ccData: 0x5945, type: 0 },
     { pts: 6676, ccData: 0x4152, type: 0 },
     { pts: 6676, ccData: 0x2e00, type: 0 },
+    // RU2 (roll-up, 2 rows)
     { pts: 6677, ccData: 0x1425, type: 0 },
+    // CR (carriange return), flush 1 row
     { pts: 6677, ccData: 0x142d, type: 0 },
+    // PAC: row 2, indent 0
     { pts: 6677, ccData: 0x1170, type: 0 },
+    // text: GO TO CNNHEROS.COM.
     { pts: 6677, ccData: 0x474f, type: 0 },
     { pts: 6678, ccData: 0x2054, type: 0 },
     { pts: 6678, ccData: 0x4f00, type: 0 },
@@ -2080,9 +2107,13 @@ QUnit.test('mix of all modes (extract from CNN)', function() {
     { pts: 6680, ccData: 0x532e, type: 0 },
     { pts: 6680, ccData: 0x434f, type: 0 },
     { pts: 6680, ccData: 0x4d2e, type: 0 },
+    // EDM (erase displayed memory), flush 2 displayed roll-up rows
     { pts: 6697, ccData: 0x142c, type: 0 },
+    // RDC (resume direct captioning), wipes memories, flushes nothing
     { pts: 6749, ccData: 0x1429, type: 0 },
+    // PAC: row 1, indent 0
     { pts: 6750, ccData: 0x1150, type: 0 },
+    // text: Did your Senator or Congressman
     { pts: 6750, ccData: 0x4469, type: 0 },
     { pts: 6750, ccData: 0x6420, type: 0 },
     { pts: 6750, ccData: 0x796f, type: 0 },
@@ -2099,8 +2130,11 @@ QUnit.test('mix of all modes (extract from CNN)', function() {
     { pts: 6754, ccData: 0x7373, type: 0 },
     { pts: 6754, ccData: 0x6d61, type: 0 },
     { pts: 6754, ccData: 0x6e00, type: 0 },
+    // PAC: row 2, indent 0
     { pts: 6755, ccData: 0x1170, type: 0 },
+    // TO2 (tab offset 2 columns)
     { pts: 6755, ccData: 0x1722, type: 0 },
+    // text: get elected by talking tough
     { pts: 6755, ccData: 0x6765, type: 0 },
     { pts: 6756, ccData: 0x7420, type: 0 },
     { pts: 6756, ccData: 0x656c, type: 0 },
@@ -2115,9 +2149,13 @@ QUnit.test('mix of all modes (extract from CNN)', function() {
     { pts: 6759, ccData: 0x2074, type: 0 },
     { pts: 6759, ccData: 0x6f75, type: 0 },
     { pts: 6759, ccData: 0x6768, type: 0 },
+    // RCL (resume caption loading)
     { pts: 6759, ccData: 0x1420, type: 0 },
+    // PAC: row 1, indent 4
     { pts: 6760, ccData: 0x1152, type: 0 },
+    // TO1 (tab offset 1 column)
     { pts: 6760, ccData: 0x1721, type: 0 },
+    // text: on the national debt?
     { pts: 6760, ccData: 0x6f6e, type: 0 },
     { pts: 6761, ccData: 0x2074, type: 0 },
     { pts: 6761, ccData: 0x6865, type: 0 },
@@ -2129,12 +2167,19 @@ QUnit.test('mix of all modes (extract from CNN)', function() {
     { pts: 6763, ccData: 0x6465, type: 0 },
     { pts: 6763, ccData: 0x6274, type: 0 },
     { pts: 6763, ccData: 0x3f00, type: 0 },
+    // RCL (resume caption loading)
     { pts: 6781, ccData: 0x1420, type: 0 },
+    // EDM (erase displayed memory), flush paint-on caption
     { pts: 6781, ccData: 0x142c, type: 0 },
+    // EOC (end of caption), mark pop-on caption 1 start
     { pts: 6782, ccData: 0x142f, type: 0 },
+    // RCL (resume caption loading)
     { pts: 6782, ccData: 0x1420, type: 0 },
+    // PAC: row 1, indent 4
     { pts: 6782, ccData: 0x1152, type: 0 },
+    // TO2 (tab offset 2 columns)
     { pts: 6783, ccData: 0x1722, type: 0 },
+    // text: Will they stay true
     { pts: 6783, ccData: 0x5769, type: 0 },
     { pts: 6783, ccData: 0x6c6c, type: 0 },
     { pts: 6783, ccData: 0x2074, type: 0 },
@@ -2145,7 +2190,9 @@ QUnit.test('mix of all modes (extract from CNN)', function() {
     { pts: 6785, ccData: 0x2074, type: 0 },
     { pts: 6785, ccData: 0x7275, type: 0 },
     { pts: 6786, ccData: 0x6500, type: 0 },
+    // PAC: row 2, indent 8
     { pts: 6786, ccData: 0x1174, type: 0 },
+    // text: to their words?
     { pts: 6786, ccData: 0x746f, type: 0 },
     { pts: 6786, ccData: 0x2074, type: 0 },
     { pts: 6787, ccData: 0x6865, type: 0 },
@@ -2154,14 +2201,23 @@ QUnit.test('mix of all modes (extract from CNN)', function() {
     { pts: 6788, ccData: 0x6f72, type: 0 },
     { pts: 6788, ccData: 0x6473, type: 0 },
     { pts: 6788, ccData: 0x3f00, type: 0 },
+    // RCL (resume caption loading)
     { pts: 6797, ccData: 0x1420, type: 0 },
+    // EDM (erase displayed memory), mark pop-on caption 1 end and flush
     { pts: 6797, ccData: 0x142c, type: 0 },
+    // EOC (end of caption), mark pop-on caption 2 start, flush nothing
     { pts: 6798, ccData: 0x142f, type: 0 },
+    // RCL
     { pts: 6799, ccData: 0x1420, type: 0 },
+    // EOC, mark pop-on caption 2 end and flush
     { pts: 6838, ccData: 0x142f, type: 0 },
+    // RU2 (roll-up, 2 rows), wipes memories
     { pts: 6841, ccData: 0x1425, type: 0 },
+    // CR (carriage return), flush nothing
     { pts: 6841, ccData: 0x142d, type: 0 },
+    // PAC: row 2, indent 0
     { pts: 6841, ccData: 0x1170, type: 0 },
+    // text: NO MORE SPECULATION, NO MORE
     { pts: 6841, ccData: 0x3e3e, type: 0 },
     { pts: 6841, ccData: 0x3e00, type: 0 },
     { pts: 6842, ccData: 0x204e, type: 0 },
@@ -2181,9 +2237,13 @@ QUnit.test('mix of all modes (extract from CNN)', function() {
     { pts: 6843, ccData: 0x204d, type: 0 },
     { pts: 6844, ccData: 0x4f52, type: 0 },
     { pts: 6844, ccData: 0x4500, type: 0 },
+    // RU2 (roll-up, two rows)
     { pts: 6844, ccData: 0x1425, type: 0 },
+    // CR (carriage return), flush 1 roll-up row
     { pts: 6844, ccData: 0x142d, type: 0 },
+    // PAC: row 2, indent 0
     { pts: 6844, ccData: 0x1170, type: 0 },
+    // text: RUMORS OR GUESSING GAMES.
     { pts: 6844, ccData: 0x5255, type: 0 },
     { pts: 6844, ccData: 0x4d4f, type: 0 },
     { pts: 6844, ccData: 0x5253, type: 0 },
@@ -2198,7 +2258,9 @@ QUnit.test('mix of all modes (extract from CNN)', function() {
     { pts: 6845, ccData: 0x414d, type: 0 },
     { pts: 6845, ccData: 0x4553, type: 0 },
     { pts: 6845, ccData: 0x2e00, type: 0 },
+    // RU2 (roll-up, 2 rows)
     { pts: 6846, ccData: 0x1425, type: 0 },
+    // CR (carriage return), flush 2 roll-up rows
     { pts: 6846, ccData: 0x142d, type: 0 }
   ].forEach(cea608Stream.push, cea608Stream);
 

--- a/test/caption-stream.test.js
+++ b/test/caption-stream.test.js
@@ -1559,11 +1559,11 @@ QUnit.test('switching to roll-up from pop-on wipes memories and flushes captions
   ].forEach(cea608Stream.push, cea608Stream);
 
   var displayed = cea608Stream.displayed_.reduce(function(acc, val) {
-    acc += val.trim();
+    acc += val;
     return acc;
   });
   var nonDisplayed = cea608Stream.nonDisplayed_.reduce(function(acc, val) {
-    acc += val.trim();
+    acc += val;
     return acc;
   });
 
@@ -1597,11 +1597,11 @@ QUnit.test('switching to roll-up from paint-on wipes memories and flushes captio
   ].forEach(cea608Stream.push, cea608Stream);
 
   var displayed = cea608Stream.displayed_.reduce(function(acc, val) {
-    acc += val.trim();
+    acc += val;
     return acc;
   });
   var nonDisplayed = cea608Stream.nonDisplayed_.reduce(function(acc, val) {
-    acc += val.trim();
+    acc += val;
     return acc;
   });
 

--- a/test/caption-stream.test.js
+++ b/test/caption-stream.test.js
@@ -1616,7 +1616,9 @@ QUnit.test('switching to roll-up from paint-on wipes memories and flushes captio
   }, 'caption correct');
 });
 
-QUnit.test('switching to paint-on from pop-on doesn\'t wipe display', function() {
+// NOTE: This should change to not wiping the display when caption
+// positioning is properly implemented
+QUnit.test('switching to paint-on from pop-on flushes display', function() {
   var captions = [];
   cea608Stream.on('data', function(caption) {
     captions.push(caption);
@@ -1636,10 +1638,13 @@ QUnit.test('switching to paint-on from pop-on doesn\'t wipe display', function()
     { pts: 4 * 1000, ccData: 0x142c, type: 0 }
   ].forEach(cea608Stream.push, cea608Stream);
 
-  QUnit.equal(captions.length, 1, 'detected caption');
-  QUnit.equal(captions[0].text, 'hio', 'paint-on overwrote pop-on');
-  QUnit.equal(captions[0].startPts, 2000, 'proper start pts');
-  QUnit.equal(captions[0].endPts, 4000, 'proper end pts');
+  QUnit.equal(captions.length, 2, 'detected 2 captions');
+  QUnit.equal(captions[0].text, 'hi', 'pop-on caption received');
+  QUnit.equal(captions[0].startPts, 1000, 'proper start pts');
+  QUnit.equal(captions[0].endPts, 2000, 'proper end pts');
+  QUnit.equal(captions[1].text, 'io', 'paint-on caption received');
+  QUnit.equal(captions[1].startPts, 2000, 'proper start pts');
+  QUnit.equal(captions[1].endPts, 4000, 'proper end pts');
 });
 
 QUnit.test('backspaces are reflected in the generated captions', function() {

--- a/test/caption-stream.test.js
+++ b/test/caption-stream.test.js
@@ -2035,11 +2035,12 @@ QUnit.test('backspaces are reflected in the generated captions (paint-on)', func
 
   [ // RDC, resume direct captioning
     { ccData: 0x1429, type: 0 },
-    // '01'
+    // '01', default row 15
     { pts: 0 * 1000, ccData: characters('01'), type: 0 },
     // backspace
     { pts: 0 * 1000, ccData: 0x1421, type: 0 },
     { pts: 1 * 1000, ccData: characters('23'), type: 0 },
+    // switch to row 13
     { pts: 2 * 1000, ccData: 0x1370, type: 0 },
     { pts: 2 * 1000, ccData: characters('32'), type: 0 },
     // backspace


### PR DESCRIPTION
I normally like to split up my changes a bit more, but these are kind of interlinked.

As the branch name implies, I started this as a feature for paint-on, but had to cascade some changes to make things compatible, and doing so made me catch a bug.

In essence:
- Paint-on mode is now supported
- Roll-up puts captions in the proper row, rather than always being fixed to the bottom row
- The roll-up window can shift around without deleting contents (as per the spec)
- Switching to roll-up clears displayed and non-displayed memories
- Fixed a bug where backspace wouldn't actually backspace for pop-on captions that weren't in the bottom row

Added/updated relevant tests, including one for testing going between the different modes.