### PR TITLE
fix mp4 probe bitwise operations

### DIFF
--- a/lib/mp4/probe.js
+++ b/lib/mp4/probe.js
@@ -8,6 +8,7 @@
  */
 'use strict';
 
+var toUnsigned = require('../utils/bin').toUnsigned;
 var findBox, parseType, timescale, startTime;
 
 // Find the data for a box specified by its path
@@ -21,10 +22,10 @@ findBox = function(data, path) {
   }
 
   for (i = 0; i < data.byteLength;) {
-    size  = data[i]     << 24;
-    size |= data[i + 1] << 16;
-    size |= data[i + 2] << 8;
-    size |= data[i + 3];
+    size  = toUnsigned(data[i]     << 24 |
+                       data[i + 1] << 16 |
+                       data[i + 2] <<  8 |
+                       data[i + 3]);
 
     type = parseType(data.subarray(i + 4, i + 8));
 
@@ -97,10 +98,10 @@ timescale = function(init) {
     }
     version = tkhd[0];
     index = version === 0 ? 12 : 20;
-    id = tkhd[index]     << 24 |
-         tkhd[index + 1] << 16 |
-         tkhd[index + 2] <<  8 |
-         tkhd[index + 3];
+    id = toUnsigned(tkhd[index]     << 24 |
+                    tkhd[index + 1] << 16 |
+                    tkhd[index + 2] <<  8 |
+                    tkhd[index + 3]);
 
     mdhd = findBox(trak, ['mdia', 'mdhd'])[0];
     if (!mdhd) {
@@ -108,10 +109,10 @@ timescale = function(init) {
     }
     version = mdhd[0];
     index = version === 0 ? 12 : 20;
-    result[id] = mdhd[index]     << 24 |
-                 mdhd[index + 1] << 16 |
-                 mdhd[index + 2] <<  8 |
-                 mdhd[index + 3];
+    result[id] = toUnsigned(mdhd[index]     << 24 |
+                            mdhd[index + 1] << 16 |
+                            mdhd[index + 2] <<  8 |
+                            mdhd[index + 3]);
     return result;
   }, result);
 };
@@ -144,10 +145,10 @@ startTime = function(timescale, fragment) {
       var id, scale, baseTime;
 
       // get the track id from the tfhd
-      id = tfhd[4] << 24 |
-           tfhd[5] << 16 |
-           tfhd[6] << 8 |
-           tfhd[7];
+      id = toUnsigned(tfhd[4] << 24 |
+                      tfhd[5] << 16 |
+                      tfhd[6] <<  8 |
+                      tfhd[7]);
       // assume a 90kHz clock if no timescale was specified
       scale = timescale[id] || 90e3;
 
@@ -156,16 +157,16 @@ startTime = function(timescale, fragment) {
         var version, result;
 
         version = tfdt[0];
-        result = tfdt[4] << 24 |
-                 tfdt[5] << 16 |
-                 tfdt[6] <<  8 |
-                 tfdt[7];
+        result = toUnsigned(tfdt[4] << 24 |
+                            tfdt[5] << 16 |
+                            tfdt[6] <<  8 |
+                            tfdt[7]);
         if (version ===  1) {
           result *= Math.pow(2, 32);
-          result += tfdt[8]  << 24 |
-                    tfdt[9]  << 16 |
-                    tfdt[10] <<  8 |
-                    tfdt[11];
+          result += toUnsigned(tfdt[8]  << 24 |
+                               tfdt[9]  << 16 |
+                               tfdt[10] <<  8 |
+                               tfdt[11]);
         }
         return result;
       })[0];

--- a/lib/utils/bin.js
+++ b/lib/utils/bin.js
@@ -1,0 +1,7 @@
+var toUnsigned = function(value) {
+  return value >>> 0;
+};
+
+module.exports = {
+  toUnsigned: toUnsigned
+};

--- a/test/utils.bin.test.js
+++ b/test/utils.bin.test.js
@@ -1,0 +1,26 @@
+var
+  QUnit = require('qunit'),
+  toUnsigned = require('../lib/utils/bin').toUnsigned;
+
+QUnit.module('Binary Utils');
+
+QUnit.test('converts values to unsigned integers after bitwise operations', function() {
+var bytes;
+
+bytes = [0, 0, 124, 129];
+
+QUnit.equal(toUnsigned(bytes[0] << 24 |
+                       bytes[1] << 16 |
+                       bytes[2] <<  8 |
+                       bytes[3]),
+            31873, 'positive signed result stays positive');
+
+bytes = [150, 234, 221, 192];
+
+// The following bitwise operation would normally result in -1762992704
+QUnit.equal(toUnsigned(bytes[0] << 24 |
+                       bytes[1] << 16 |
+                       bytes[2] <<  8 |
+                       bytes[3]),
+            2531974592, 'negative signed result becomes unsigned positive');
+});

--- a/test/utils.bin.test.js
+++ b/test/utils.bin.test.js
@@ -5,22 +5,28 @@ var
 QUnit.module('Binary Utils');
 
 QUnit.test('converts values to unsigned integers after bitwise operations', function() {
-var bytes;
+  var bytes;
 
-bytes = [0, 0, 124, 129];
+  bytes = [0, 0, 124, 129];
 
-QUnit.equal(toUnsigned(bytes[0] << 24 |
-                       bytes[1] << 16 |
-                       bytes[2] <<  8 |
-                       bytes[3]),
-            31873, 'positive signed result stays positive');
+  QUnit.equal(toUnsigned(bytes[0] << 24 |
+                         bytes[1] << 16 |
+                         bytes[2] <<  8 |
+                         bytes[3]),
+              31873, 'positive signed result stays positive');
 
-bytes = [150, 234, 221, 192];
+  bytes = [150, 234, 221, 192];
 
-// The following bitwise operation would normally result in -1762992704
-QUnit.equal(toUnsigned(bytes[0] << 24 |
-                       bytes[1] << 16 |
-                       bytes[2] <<  8 |
-                       bytes[3]),
-            2531974592, 'negative signed result becomes unsigned positive');
+  // sanity check
+  QUnit.equal(bytes[0] << 24 |
+              bytes[1] << 16 |
+              bytes[2] <<  8 |
+              bytes[3],
+              -1762992704, 'bitwise operation produces negative signed result');
+
+  QUnit.equal(toUnsigned(bytes[0] << 24 |
+                         bytes[1] << 16 |
+                         bytes[2] <<  8 |
+                         bytes[3]),
+              2531974592, 'negative signed result becomes unsigned positive');
 });


### PR DESCRIPTION
javascript bitwise operations convert operands to signed 32 bit integers, this, the output of bitwise ops will be signed 32bit ints, however, we want them to be unsigned. `>>> 0` ensures the value will be unsigned