### PR TITLE
fix: remuxed video corruption fix at ie, edge

### DIFF
--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -63,7 +63,8 @@ createDefaultSample = function() {
       dependsOn: 1,
       isDependedOn: 0,
       hasRedundancy: 0,
-      degradationPriority: 0
+      degradationPriority: 0,
+      isNonSyncSample: 1
     }
   };
 };
@@ -756,6 +757,7 @@ VideoSegmentStream = function(track, options) {
 
         if (currentFrame.keyFrame) {
           sample.flags.dependsOn = 2;
+          sample.flags.isNonSyncSample = 0;
         }
 
         dataOffset += sample.size;

--- a/test/transmuxer.test.js
+++ b/test/transmuxer.test.js
@@ -3615,6 +3615,12 @@ validateTrackFragment = function(track, segment, metadata, type) {
       QUnit.equal(sample.flags.isDependedOn, 0, 'dependency of other samples is unknown');
       QUnit.equal(sample.flags.hasRedundancy, 0, 'sample redundancy is unknown');
       QUnit.equal(sample.flags.degradationPriority, 0, 'sample degradation priority is zero');
+      // If current sample is Key frame
+      if (sample.flags.dependsOn === 2) {
+        QUnit.equal(sample.flags.isNonSyncSample, 0, 'samples_is_non_sync_sample flag is zero');
+      } else {
+        QUnit.equal(sample.flags.isNonSyncSample, 1, 'samples_is_non_sync_sample flag is one');
+      }
     } else {
       QUnit.equal(sample.duration, 1024,
             'aac sample duration is always 1024');


### PR DESCRIPTION
I registered the issue #187 .

Fixed code in transmuxer.js file.
I added ```isNonSyncSample``` property at the createDefaultSample function used by ```VideoSegmentStream```.

```isNonSyncSample``` property semantics by MP4_spec;
"The flag sample_is_non_sync_sample provides the same information as the sync sample table [8.6.2].
When this value is set 0 for a sample, it is the same as if the sample were not in a movie fragment and
marked with an entry in the sync sample table (or, if all samples are sync samples, the sync sample table
were absent)."

```isNonSyncSample``` property is already used by the mp4-generator.js file.
```js
  videoTrun = function(track, offset) {
    var bytes, samples, sample, i;

    samples = track.samples || [];
    offset += 8 + 12 + (16 * samples.length);

    bytes = trunHeader(samples, offset);

    for (i = 0; i < samples.length; i++) {
      sample = samples[i];
      bytes = bytes.concat([
         ...
        (sample.flags.isLeading << 2) | sample.flags.dependsOn,
        (sample.flags.isDependedOn << 6) |
          (sample.flags.hasRedundancy << 4) |
          (sample.flags.paddingValue << 1) |
          sample.flags.isNonSyncSample,
        sample.flags.degradationPriority & 0xF0 << 8,
        sample.flags.degradationPriority & 0x0F, // sample_flags
         ...
      ]);
    }
    return box(types.trun, new Uint8Array(bytes));
  };
```