### PR TITLE
Ignore XDS and Text packets

### DIFF
--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -148,16 +148,30 @@ CaptionStream.prototype.reset = function() {
   });
 };
 
+// From the CEA-608 spec:
+/*
+ * When XDS sub-packets are interleaved with other services, the end of each sub-packet shall be followed
+ * by a control pair to change to a different service. When any of the control codes from 0x10 to 0x1F is
+ * used to begin a control code pair, it indicates the return to captioning or Text data. The control code pair
+ * and subsequent data should then be processed according to the FCC rules. It may be necessary for the
+ * line 21 data encoder to automatically insert a control code pair (i.e. RCL, RU2, RU3, RU4, RDC, or RTD)
+ * to switch to captioning or Text.
+*/
+// With that in mind, we ignore any data between an XDS control code and a
+// subsequent closed-captioning control code.
 CaptionStream.prototype.dispatchCea608Packet = function(packet) {
   // NOTE: packet.type is the CEA608 field
-  if (this.setsChannel1Active(packet)) {
+  if (this.setsTextOrXDSActive(packet)) {
+    this.activeCea608Channel_[packet.type] = null;
+  } else if (this.setsChannel1Active(packet)) {
     this.activeCea608Channel_[packet.type] = 0;
   } else if (this.setsChannel2Active(packet)) {
     this.activeCea608Channel_[packet.type] = 1;
   }
   if (this.activeCea608Channel_[packet.type] === null) {
-    // If we haven't received anything to set the active channel, discard the
-    // data; we don't want jumbled captions
+    // If we haven't received anything to set the active channel, or the
+    // packets are Text/XDS data, discard the data; we don't want jumbled
+    // captions
     return;
   }
   this.ccStreams_[(packet.type << 1) + this.activeCea608Channel_[packet.type]].push(packet);
@@ -168,6 +182,11 @@ CaptionStream.prototype.setsChannel1Active = function(packet) {
 };
 CaptionStream.prototype.setsChannel2Active = function(packet) {
   return ((packet.ccData & 0x7800) === 0x1800);
+};
+CaptionStream.prototype.setsTextOrXDSActive = function(packet) {
+  return ((packet.ccData & 0x7100) === 0x0100) ||
+    ((packet.ccData & 0x78fe) === 0x102a) ||
+    ((packet.ccData & 0x78fe) === 0x182a);
 };
 
 // ----------------------


### PR DESCRIPTION
I noticed that XDS and Text packets aren't being ignored, and those may interfere with captions.

To ignore the packets, I do similar to what's done before any active channel is set -- I set the `activeCea608Channel` for the field to `null` so that packets are dropped.

Note: I've never seen Text packets in real life, so if anyone has any sources, please share!