### PR TITLE
fix(mp4/Transmuxer): respect keepOriginalTimestamps for captions and ID3 in mp4

### DIFF
--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -716,6 +716,9 @@ VideoSegmentStream.prototype = new Stream();
  * A Stream that can combine multiple streams (ie. audio & video)
  * into a single output segment for MSE. Also supports audio-only
  * and video-only streams.
+ * @param options {object} transmuxer options object
+ * @param options.keepOriginalTimestamps {boolean} If true, keep the timestamps
+ *        in the source; false to adjust the first segment to start at media timeline start.
  */
 CoalesceStream = function(options, metadataStream) {
   // Number of Tracks per output segment
@@ -724,10 +727,16 @@ CoalesceStream = function(options, metadataStream) {
   this.numberOfTracks = 0;
   this.metadataStream = metadataStream;
 
+  options = options || {};
+
   if (typeof options.remux !== 'undefined') {
     this.remuxTracks = !!options.remux;
   } else {
     this.remuxTracks = true;
+  }
+
+  if (typeof options.keepOriginalTimestamps === 'boolean') {
+    this.keepOriginalTimestamps = options.keepOriginalTimestamps;
   }
 
   this.pendingTracks = [];
@@ -850,26 +859,41 @@ CoalesceStream.prototype.flush = function(flushSource) {
     offset += this.pendingBoxes[i].byteLength;
   }
 
-  // Translate caption PTS times into second offsets into the
+  // Translate caption PTS times into second offsets to match the
   // video timeline for the segment, and add track info
   for (i = 0; i < this.pendingCaptions.length; i++) {
     caption = this.pendingCaptions[i];
-    caption.startTime = (caption.startPts - timelineStartPts);
+
+    caption.startTime = caption.startPts;
+    if (!this.keepOriginalTimestamps) {
+      caption.startTime -= timelineStartPts;
+    }
     caption.startTime /= 90e3;
-    caption.endTime = (caption.endPts - timelineStartPts);
+
+    caption.endTime = caption.endPts;
+    if (!this.keepOriginalTimestamps) {
+      caption.endTime -= timelineStartPts;
+    }
     caption.endTime /= 90e3;
+
     event.captionStreams[caption.stream] = true;
     event.captions.push(caption);
   }
 
-  // Translate ID3 frame PTS times into second offsets into the
+  // Translate ID3 frame PTS times into second offsets to match the
   // video timeline for the segment
   for (i = 0; i < this.pendingMetadata.length; i++) {
     id3 = this.pendingMetadata[i];
-    id3.cueTime = (id3.pts - timelineStartPts);
+
+    id3.cueTime = id3.pts;
+    if (!this.keepOriginalTimestamps) {
+      id3.cueTime -= timelineStartPts;
+    }
     id3.cueTime /= 90e3;
+
     event.metadata.push(id3);
   }
+
   // We add this to every single emitted segment even though we only need
   // it for the first
   event.metadata.dispatchType = this.metadataStream.dispatchType;
@@ -1079,12 +1103,17 @@ Transmuxer = function(options) {
   this.setBaseMediaDecodeTime = function(baseMediaDecodeTime) {
     var pipeline = this.transmuxPipeline_;
 
-    this.baseMediaDecodeTime = baseMediaDecodeTime;
+    if (!options.keepOriginalTimestamps) {
+      this.baseMediaDecodeTime = baseMediaDecodeTime;
+    }
+
     if (audioTrack) {
       audioTrack.timelineStartInfo.dts = undefined;
       audioTrack.timelineStartInfo.pts = undefined;
       trackDecodeInfo.clearDtsInfo(audioTrack);
-      audioTrack.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
+      if (!options.keepOriginalTimestamps) {
+        audioTrack.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
+      }
       if (pipeline.audioTimestampRolloverStream) {
         pipeline.audioTimestampRolloverStream.discontinuity();
       }
@@ -1098,7 +1127,9 @@ Transmuxer = function(options) {
       videoTrack.timelineStartInfo.pts = undefined;
       trackDecodeInfo.clearDtsInfo(videoTrack);
       pipeline.captionStream.reset();
-      videoTrack.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
+      if (!options.keepOriginalTimestamps) {
+        videoTrack.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
+      }
     }
 
     if (pipeline.timedMetadataTimestampRolloverStream) {

--- a/test/transmuxer.test.js
+++ b/test/transmuxer.test.js
@@ -3324,6 +3324,130 @@ QUnit.test('can specify that we want to generate separate audio and video segmen
   QUnit.equal('mdat', boxes[1].type, 'generated a mdat box');
 });
 
+QUnit.test("doesn't adjust caption and ID3 times when configured to adjust timestamps", function() {
+  var transmuxer = new Transmuxer({ keepOriginalTimestamps: false });
+
+  var
+    segments = [],
+    captions = [];
+
+  transmuxer.on('data', function(segment) {
+    captions = captions.concat(segment.captions);
+    segments.push(segment);
+  });
+  transmuxer.push(packetize(PAT));
+  transmuxer.push(packetize(generatePMT({
+    hasVideo: true,
+    hasAudio: true
+  })));
+
+  transmuxer.push(packetize(audioPes([
+    0x19, 0x47
+  ], true, 90000)));
+  transmuxer.push(packetize(videoPes([
+      0x09, 0x01 // access_unit_delimiter_rbsp
+  ], true, 90000)));
+  transmuxer.push(packetize(videoPes([
+      0x08, 0x01 // pic_parameter_set_rbsp
+  ], true, 90002)));
+  transmuxer.push(packetize(videoPes([
+    0x07, // seq_parameter_set_rbsp
+    0x27, 0x42, 0xe0, 0x0b,
+    0xa9, 0x18, 0x60, 0x9d,
+    0x80, 0x53, 0x06, 0x01,
+    0x06, 0xb6, 0xc2, 0xb5,
+    0xef, 0x7c, 0x04
+  ], false, 90002)));
+  transmuxer.push(packetize(videoPes([
+      0x06, // sei_rbsp
+      0x04, 0x29, 0xb5, 0x00,
+      0x31, 0x47, 0x41, 0x39,
+      0x34, 0x03, 0x52, 0xff,
+      0xfc, 0x94, 0xae, 0xfc,
+      0x94, 0x20, 0xfc, 0x91,
+      0x40, 0xfc, 0xb0, 0xb0,
+      0xfc, 0xba, 0xb0, 0xfc,
+      0xb0, 0xba, 0xfc, 0xb0,
+      0xb0, 0xfc, 0x94, 0x2f,
+      0xfc, 0x94, 0x2f, 0xfc,
+      0x94, 0x2f, 0xff, 0x80,
+      0x00 // has an extra End Of Caption, so start and end times will be the same
+  ], true, 90002)));
+  transmuxer.push(packetize(videoPes([
+      0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
+  ], true, 90004)));
+  transmuxer.flush();
+
+  QUnit.equal(segments.length, 1, 'generated a combined video and audio segment');
+  QUnit.equal(segments[0].type, 'combined', 'combined is the segment type');
+  QUnit.equal(captions.length, 1, 'got one caption');
+  QUnit.equal(captions[0].startPts, 90004, 'original pts value intact');
+  QUnit.equal(captions[0].startTime, (90004 - 90002) / 90e3, 'caption start time are based on original timeline');
+  QUnit.equal(captions[0].endTime, (90004 - 90002) / 90e3, 'caption end time are based on original timeline');
+});
+
+QUnit.test("doesn't adjust caption and ID3 times when configured to keep original timestamps", function() {
+  var transmuxer = new Transmuxer({ keepOriginalTimestamps: true });
+
+  var
+    segments = [],
+    captions = [];
+
+  transmuxer.on('data', function(segment) {
+    captions = captions.concat(segment.captions);
+    segments.push(segment);
+  });
+  transmuxer.push(packetize(PAT));
+  transmuxer.push(packetize(generatePMT({
+    hasVideo: true,
+    hasAudio: true
+  })));
+
+  transmuxer.push(packetize(audioPes([
+    0x19, 0x47
+  ], true, 90000)));
+  transmuxer.push(packetize(videoPes([
+      0x09, 0x01 // access_unit_delimiter_rbsp
+  ], true, 90000)));
+  transmuxer.push(packetize(videoPes([
+      0x08, 0x01 // pic_parameter_set_rbsp
+  ], true, 90002)));
+  transmuxer.push(packetize(videoPes([
+    0x07, // seq_parameter_set_rbsp
+    0x27, 0x42, 0xe0, 0x0b,
+    0xa9, 0x18, 0x60, 0x9d,
+    0x80, 0x53, 0x06, 0x01,
+    0x06, 0xb6, 0xc2, 0xb5,
+    0xef, 0x7c, 0x04
+  ], false, 90002)));
+  transmuxer.push(packetize(videoPes([
+      0x06, // sei_rbsp
+      0x04, 0x29, 0xb5, 0x00,
+      0x31, 0x47, 0x41, 0x39,
+      0x34, 0x03, 0x52, 0xff,
+      0xfc, 0x94, 0xae, 0xfc,
+      0x94, 0x20, 0xfc, 0x91,
+      0x40, 0xfc, 0xb0, 0xb0,
+      0xfc, 0xba, 0xb0, 0xfc,
+      0xb0, 0xba, 0xfc, 0xb0,
+      0xb0, 0xfc, 0x94, 0x2f,
+      0xfc, 0x94, 0x2f, 0xfc,
+      0x94, 0x2f, 0xff, 0x80,
+      0x00 // has an extra End Of Caption, so start and end times will be the same
+  ], true, 90002)));
+  transmuxer.push(packetize(videoPes([
+      0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
+  ], true, 90004)));
+  transmuxer.flush();
+
+  QUnit.equal(segments.length, 1, 'generated a combined video and audio segment');
+  QUnit.equal(segments[0].type, 'combined', 'combined is the segment type');
+  QUnit.equal(captions.length, 1, 'got one caption');
+  QUnit.equal(captions[0].startPts, 90004, 'original pts value intact');
+  QUnit.equal(captions[0].startTime, 90004 / 90e3, 'caption start time are based on original timeline');
+  QUnit.equal(captions[0].endTime, 90004 / 90e3, 'caption end time are based on original timeline');
+});
+
 QUnit.module('MP4 - Transmuxer', {
   setup: function() {
     transmuxer = new Transmuxer();


### PR DESCRIPTION
There is a `keepOriginalTimestamps` flag which is intended to avoid adjusting timestamps when transmuxing from TS -> MP4. However, we do not respect this flag when returning captions and ID3 tags parsed out of the video data, leading to the captions and ID3 cues being out-of-sync with the video data.

Releasing this might be tricky as users may be depending on this behavior. A couple of ways we could do this:
- release as a major version, with captions and ID3 cues respecting the flag
- make a new flag to avoid adjusting the timing for captions and ID3 cues specifically

The downsides of the first is that any users relying on the current behavior with `keepOriginalTimestamps` would have to adjust caption times to start at zero if the TS segments do not start at zero.