### PR TITLE
Expose parseSidx in mp4-inspector

### DIFF
--- a/lib/tools/mp4-inspector.js
+++ b/lib/tools/mp4-inspector.js
@@ -842,5 +842,6 @@ module.exports = {
   parseTfdt: parse.tfdt,
   parseHdlr: parse.hdlr,
   parseTfhd: parse.tfhd,
-  parseTrun: parse.trun
+  parseTrun: parse.trun,
+  parseSidx: parse.sidx
 };


### PR DESCRIPTION
Needed for videojs/http-streaming#207.
Exposes `parseSidx` in addition to the other box types.