### PR TITLE
docs: removing maintainers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 
 Lightweight utilities for inspecting and manipulating video container formats.
 
-Lead Maintainer: Jon-Carlos Rivera [@imbcmdth](https://github.com/imbcmdth)
-
 Maintenance Status: Stable
 
 ## Diagram


### PR DESCRIPTION
Removing the maintainers section since the video.js playback team maintains this repo