### PR TITLE
fix(captions): handle case where invalid base row is selected with roll-up mode

### DIFF
--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -515,6 +515,13 @@ Cea608Stream.prototype.flushDisplayed = function(pts) {
   var content = this.displayed_
     // remove spaces from the start and end of the string
     .map(function(row) {
+      // if (!row) {
+      //   // Ordinarily, this shouldn't happen. However, caption
+      //   // parsing errors should not throw exceptions and
+      //   // break playback.
+      //   console.error('There was a problem parsing captions.');
+      //   return '';
+      // }
       return row.trim();
     })
     // combine all text rows to display in one cue
@@ -727,7 +734,7 @@ Cea608Stream.prototype.setRollUp = function(pts, newBaseRow) {
 
   if (newBaseRow !== undefined && newBaseRow !== this.row_) {
     // move currently displayed captions (up or down) to the new base row
-    for (var i = 0; i < this.rollUpRows_; i++) {
+    for (var i = 0; i < this.rollUpRows_ && this.row_ - i >= 0; i++) {
       this.displayed_[newBaseRow - i] = this.displayed_[this.row_ - i];
       this.displayed_[this.row_ - i] = '';
     }
@@ -736,7 +743,16 @@ Cea608Stream.prototype.setRollUp = function(pts, newBaseRow) {
   if (newBaseRow === undefined) {
     newBaseRow = this.row_;
   }
+
   this.topRow_ = newBaseRow - this.rollUpRows_ + 1;
+
+  // This implies that the base row is incorrectly set.
+  // As per the recommendation in CTA-608, defer to the number
+  // of roll-up rows set.
+  if (this.topRow_ < 0) {
+    this.topRow_ = 0;
+    newBaseRow = this.rollUpRows_ - 1;
+  }
 };
 
 // Adds the opening HTML tag for the passed character to the caption text,

--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -743,7 +743,7 @@ Cea608Stream.prototype.setRollUp = function(pts, newBaseRow) {
 
   if (newBaseRow !== undefined && newBaseRow !== this.row_) {
     // move currently displayed captions (up or down) to the new base row
-    for (var i = 0; i < this.rollUpRows_ && this.row_ - i >= 0; i++) {
+    for (var i = 0; i < this.rollUpRows_; i++) {
       this.displayed_[newBaseRow - i] = this.displayed_[this.row_ - i];
       this.displayed_[this.row_ - i] = '';
     }

--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -515,13 +515,14 @@ Cea608Stream.prototype.flushDisplayed = function(pts) {
   var content = this.displayed_
     // remove spaces from the start and end of the string
     .map(function(row) {
-      // if (!row) {
-      //   // Ordinarily, this shouldn't happen. However, caption
-      //   // parsing errors should not throw exceptions and
-      //   // break playback.
-      //   console.error('There was a problem parsing captions.');
-      //   return '';
-      // }
+      if (row === undefined || row === null) {
+        // Ordinarily, this shouldn't happen. However, caption
+        // parsing errors should not throw exceptions and
+        // break playback.
+        // eslint-disable-next-line no-console
+        console.log('Skipping malformed caption.');
+        return '';
+      }
       return row.trim();
     })
     // combine all text rows to display in one cue

--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -515,15 +515,16 @@ Cea608Stream.prototype.flushDisplayed = function(pts) {
   var content = this.displayed_
     // remove spaces from the start and end of the string
     .map(function(row) {
-      if (row === undefined || row === null) {
+      try {
+        return row.trim();
+      } catch (e) {
         // Ordinarily, this shouldn't happen. However, caption
         // parsing errors should not throw exceptions and
         // break playback.
         // eslint-disable-next-line no-console
-        console.log('Skipping malformed caption.');
+        console.error('Skipping malformed caption.');
         return '';
       }
-      return row.trim();
     })
     // combine all text rows to display in one cue
     .join('\n')
@@ -748,7 +749,7 @@ Cea608Stream.prototype.setRollUp = function(pts, newBaseRow) {
   this.topRow_ = newBaseRow - this.rollUpRows_ + 1;
 
   // This implies that the base row is incorrectly set.
-  // As per the recommendation in CTA-608, defer to the number
+  // As per the recommendation in CEA-608(Base Row Implementation), defer to the number
   // of roll-up rows set.
   if (this.topRow_ < 0) {
     this.topRow_ = 0;

--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -462,6 +462,13 @@ var Cea608Stream = function(field, dataChannel) {
 
       // Configure the caption window if we're in roll-up mode
       if (this.mode_ === 'rollUp') {
+        // This implies that the base row is incorrectly set.
+        // As per the recommendation in CEA-608(Base Row Implementation), defer to the number
+        // of roll-up rows set.
+        if (row - this.rollUpRows_ + 1 < 0) {
+          row = this.rollUpRows_ - 1;
+        }
+
         this.setRollUp(packet.pts, row);
       }
 
@@ -747,14 +754,6 @@ Cea608Stream.prototype.setRollUp = function(pts, newBaseRow) {
   }
 
   this.topRow_ = newBaseRow - this.rollUpRows_ + 1;
-
-  // This implies that the base row is incorrectly set.
-  // As per the recommendation in CEA-608(Base Row Implementation), defer to the number
-  // of roll-up rows set.
-  if (this.topRow_ < 0) {
-    this.topRow_ = 0;
-    newBaseRow = this.rollUpRows_ - 1;
-  }
 };
 
 // Adds the opening HTML tag for the passed character to the caption text,

--- a/test/caption-stream.test.js
+++ b/test/caption-stream.test.js
@@ -847,14 +847,7 @@ QUnit.test('special and extended character codes work regardless of field and da
 QUnit.test('number of roll up rows takes precedence over base row command', function(assert) {
   var captions = [];
   var packets = [
-    // RCL
-    { type: 0, ccData: 0x1420 },
-    // RCL
-    { type: 0, ccData: 0x1420 },
-    // EDM
-    { type: 0, ccData: 0x142c },
-    // EDM
-    { type: 0, ccData: 0x142c },
+
     // RU2 (roll-up, 2 rows), CC1
     { type: 0, ccData: 0x1425 },
     // RU2, CC1
@@ -897,6 +890,24 @@ QUnit.test('number of roll up rows takes precedence over base row command', func
 
   QUnit.deepEqual(captions[0].text, '-', 'RU2 caption is correct');
   QUnit.deepEqual(captions[1].text, '-\nso', 'RU3 caption is correct');
+
+  packets = [
+    // switching from row 11 to 0
+    // PAC: row 0 (sets base row to row 0)
+    { type: 0, ccData: 0x1140 },
+    // PAC: row 0
+    { type: 0, ccData: 0x1140 },
+    // CR
+    { type: 0, ccData: 0x14ad },
+    // CR
+    { type: 0, ccData: 0x14ad }
+  ];
+
+  seis = packets.map(makeSeiFromCaptionPacket);
+  seis.forEach(captionStream.push, captionStream);
+  captionStream.flush();
+
+  QUnit.deepEqual(captions[2].text, '-\nso', 'RU3 caption is correct');
 });
 
 var cea608Stream;

--- a/test/caption-stream.test.js
+++ b/test/caption-stream.test.js
@@ -855,11 +855,11 @@ QUnit.test('number of roll up rows takes precedence over base row command', func
     { type: 0, ccData: 0x142c },
     // EDM
     { type: 0, ccData: 0x142c },
-    // RU2, CC1
+    // RU2 (roll-up, 2 rows), CC1
     { type: 0, ccData: 0x1425 },
     // RU2, CC1
     { type: 0, ccData: 0x1425 },
-    // PAC: row 1
+    // PAC: row 1 (sets base row to row 1)
     { type: 0, ccData: 0x1170 },
     // PAC: row 1
     { type: 0, ccData: 0x1170 },
@@ -869,7 +869,7 @@ QUnit.test('number of roll up rows takes precedence over base row command', func
     { type: 0, ccData: 0x14ad },
     // CR
     { type: 0, ccData: 0x14ad },
-    // RU3, CC1
+    // RU3 (roll-up, 3 rows), CC1
     { type: 0, ccData: 0x1426 },
     // RU3, CC1
     { type: 0, ccData: 0x1426 },
@@ -2429,15 +2429,15 @@ QUnit.test('mix of all modes (extract from CNN)', function() {
 
 QUnit.test('Cea608Stream will log errors, not throw an exception', function(assert) {
   var result;
-  var originalConsole = window.console.log;
+  var originalConsole = window.console.error;
   var logs = [];
 
-  window.console.log = function(msg) {
+  window.console.error = function(msg) {
     logs.push(msg);
   };
 
+  // this will force an exception to happen in flushDisplayed
   cea608Stream.displayed_[0] = undefined;
-  cea608Stream.displayed_[1] = null;
 
   try {
     cea608Stream.flushDisplayed();
@@ -2453,11 +2453,10 @@ QUnit.test('Cea608Stream will log errors, not throw an exception', function(asse
   QUnit.deepEqual(
     logs,
     [
-      'Skipping malformed caption.',
       'Skipping malformed caption.'
     ],
     'warnings were logged to the console'
   );
 
-  window.console.log = originalConsole;
+  window.console.error = originalConsole;
 });

--- a/test/caption-stream.test.js
+++ b/test/caption-stream.test.js
@@ -896,7 +896,7 @@ QUnit.only('number of roll up rows takes precedence over base row command', func
   captionStream.flush();
 
   QUnit.deepEqual(captions[0].text, '-', 'RU2 caption is correct');
-  QUnit.deepEqual(captions[1].text, 'so', 'RU3 caption is correct');
+  QUnit.deepEqual(captions[1].text, '-\nso', 'RU3 caption is correct');
 });
 
 var cea608Stream;

--- a/test/caption-stream.test.js
+++ b/test/caption-stream.test.js
@@ -844,6 +844,61 @@ QUnit.test('special and extended character codes work regardless of field and da
   QUnit.deepEqual(captions[2].text, String.fromCharCode(0xbb), 'CC4 extended character correct');
 });
 
+QUnit.only('number of roll up rows takes precedence over base row command', function(assert) {
+  var captions = [];
+  var packets = [
+    // RCL
+    { type: 0, ccData: 0x1420 },
+    // RCL
+    { type: 0, ccData: 0x1420 },
+    // EDM
+    { type: 0, ccData: 0x142c },
+    // EDM
+    { type: 0, ccData: 0x142c },
+    // RU2, CC1
+    { type: 0, ccData: 0x1425 },
+    // RU2, CC1
+    { type: 0, ccData: 0x1425 },
+    // PAC: row 1
+    { type: 0, ccData: 0x1170 },
+    // PAC: row 1
+    { type: 0, ccData: 0x1170 },
+    // -
+    { type: 0, ccData: 0x2d00 },
+    // CR
+    { type: 0, ccData: 0x14ad },
+    // CR
+    { type: 0, ccData: 0x14ad },
+    // RU3, CC1
+    { type: 0, ccData: 0x1426 },
+    // RU3, CC1
+    { type: 0, ccData: 0x1426 },
+    // PAC, row 11
+    { type: 0, ccData: 0x13d0 },
+    // PAC, row 11
+    { type: 0, ccData: 0x13d0 },
+    // so
+    { type: 0, ccData: 0x736f },
+    // CR
+    { type: 0, ccData: 0x14ad },
+    // CR
+    { type: 0, ccData: 0x14ad }
+  ];
+  var seis;
+
+  captionStream.on('data', function(caption) {
+    captions.push(caption);
+  });
+
+  seis = packets.map(makeSeiFromCaptionPacket);
+
+  seis.forEach(captionStream.push, captionStream);
+  captionStream.flush();
+
+  QUnit.deepEqual(captions[0].text, '-', 'RU2 caption is correct');
+  QUnit.deepEqual(captions[1].text, 'so', 'RU3 caption is correct');
+});
+
 var cea608Stream;
 
 QUnit.module('CEA 608 Stream', {

--- a/test/caption-stream.test.js
+++ b/test/caption-stream.test.js
@@ -844,7 +844,7 @@ QUnit.test('special and extended character codes work regardless of field and da
   QUnit.deepEqual(captions[2].text, String.fromCharCode(0xbb), 'CC4 extended character correct');
 });
 
-QUnit.only('number of roll up rows takes precedence over base row command', function(assert) {
+QUnit.test('number of roll up rows takes precedence over base row command', function(assert) {
   var captions = [];
   var packets = [
     // RCL
@@ -2425,4 +2425,39 @@ QUnit.test('mix of all modes (extract from CNN)', function() {
     stream: 'CC1'
   }, 'parsed the 4th roll-up caption');
 
+});
+
+QUnit.test('Cea608Stream will log errors, not throw an exception', function(assert) {
+  var result;
+  var originalConsole = window.console.log;
+  var logs = [];
+
+  window.console.log = function(msg) {
+    logs.push(msg);
+  };
+
+  cea608Stream.displayed_[0] = undefined;
+  cea608Stream.displayed_[1] = null;
+
+  try {
+    cea608Stream.flushDisplayed();
+    result = true;
+  } catch (e) {
+    result = false;
+  }
+
+  QUnit.ok(
+    result,
+    'the function does not throw an exception'
+  );
+  QUnit.deepEqual(
+    logs,
+    [
+      'Skipping malformed caption.',
+      'Skipping malformed caption.'
+    ],
+    'warnings were logged to the console'
+  );
+
+  window.console.log = originalConsole;
 });


### PR DESCRIPTION
It's possible for a base row to be selected with a number of roll up rows that would be invalid. e.g:
base row: 1
number of roll-up rows: 3

This should do two things:
- set a correct base row and `topRow_` in the parsing code
- avoid throwing exceptions from the caption parsing code, and logs a message instead