### PR TITLE
fix(caption-parser): do not fail when first sei sample is null

### DIFF
--- a/lib/mp4/caption-parser.js
+++ b/lib/mp4/caption-parser.js
@@ -89,11 +89,13 @@ var findSeiNals = function(avcStream, samples, trackId) {
         seiNal.pts = matchingSample.pts;
         seiNal.dts = matchingSample.dts;
         lastMatchedSample = matchingSample;
-      } else {
+      } else if (lastMatchedSample !== undefined) {
         // If a matching sample cannot be found, use the last
         // sample's values as they should be as close as possible
         seiNal.pts = lastMatchedSample.pts;
         seiNal.dts = lastMatchedSample.dts;
+      } else {
+        break;
       }
 
       result.push(seiNal);


### PR DESCRIPTION
By following up on <a href="https://github.com/videojs/mux.js/issues/223">that discussion</a>, maybe this small fix will be enough?