### PR TITLE
test: use standard browsers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ addons:
   firefox: latest
 before_install:
   - npm install -g greenkeeper-lockfile@1
-before_script: greenkeeper-lockfile-update
+before_script:
+  - greenkeeper-lockfile-update
+  - export CHROME_BIN=/usr/bin/google-chrome
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
 after_script: greenkeeper-lockfile-upload
-

--- a/test/karma/karma.conf.js
+++ b/test/karma/karma.conf.js
@@ -61,18 +61,7 @@ module.exports = function(config) {
     // enable / disable watching file and executing tests whenever any file changes
     autoWatch: false,
 
-    // start these browsers
-    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    // TODO: This should include firefox for env.TRAVIS. It is currently turned off
-    //       because of https://github.com/travis-ci/travis-ci/issues/8242 When this issue
-    //       is resolved, this should be updated to include firefox
-    customLaunchers: {
-      ChromeHeadlessNoSandbox: {
-        base: 'ChromeHeadless',
-        flags: ['--no-sandbox']
-      }
-    },
-    browsers: ['ChromeHeadlessNoSandbox', 'FirefoxHeadless'],
+    browsers: ['Chrome', 'Firefox'],
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits


### PR DESCRIPTION
The build seems to be failing with headless Chrome, let's switch back to the standard browsers.