### PR TITLE
Trigger videoTimingInfo on transmuxer with relevant timing info and prepended GOP duration

### DIFF
--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -62,6 +62,25 @@ var arrayEquals = function(a, b) {
   return true;
 };
 
+var generateVideoTimingInfo = function(firstGop, lastGop, startPts, prependedGops) {
+  var timingInfo = {
+    start: {
+      dts: firstGop.dts,
+      pts: firstGop.pts
+    },
+    end: {
+      dts: lastGop.dts + lastGop.duration,
+      pts: lastGop.pts + lastGop.duration
+    }
+  };
+
+  if (prependedGops) {
+    timingInfo.prependedGopDuration = startPts - prependedGops[0].pts;
+  }
+
+  return timingInfo;
+};
+
 /**
  * Constructs a single-track, ISO BMFF media segment from AAC data
  * events. The output of this stream can be fed to a SourceBuffer
@@ -226,8 +245,7 @@ VideoSegmentStream = function(track, options) {
       moof,
       mdat,
       boxes,
-      segmentStartPts,
-      timingInfo;
+      segmentStartPts;
 
     // Throw away nalUnits at the start of the byte stream until
     // we find the first AUD
@@ -347,22 +365,13 @@ VideoSegmentStream = function(track, options) {
       };
     }));
 
-    timingInfo = {
-      start: {
-        dts: gops[0].dts,
-        pts: gops[0].pts
-      },
-      end: {
-        dts: gops[gops.length - 1].dts + gops[gops.length - 1].duration,
-        pts: gops[gops.length - 1].pts + gops[gops.length - 1].duration
-      },
-    };
-
-    if (alignedGops) {
-      timingInfo.prependedGopDuration = segmentStartPts - alignedGops[0].pts;
-    }
-
-    this.trigger('timingInfo', timingInfo);
+    this.trigger(
+      'timingInfo',
+      generateVideoTimingInfo(
+        gops[0],
+        gops[gops.length - 1],
+        segmentStartPts,
+        alignedGops));
 
     // save all the nals in the last GOP into the gop cache
     this.gopCache_.unshift({
@@ -1065,5 +1074,7 @@ module.exports = {
   VideoSegmentStream: VideoSegmentStream,
   AudioSegmentStream: AudioSegmentStream,
   AUDIO_PROPERTIES: AUDIO_PROPERTIES,
-  VIDEO_PROPERTIES: VIDEO_PROPERTIES
+  VIDEO_PROPERTIES: VIDEO_PROPERTIES,
+  // exported for testing
+  generateVideoTimingInfo: generateVideoTimingInfo
 };

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -62,23 +62,32 @@ var arrayEquals = function(a, b) {
   return true;
 };
 
-var generateVideoTimingInfo = function(firstGop, lastGop, startPts, prependedGops) {
-  var timingInfo = {
+var generateVideoSegmentTimingInfo = function(
+  startDts,
+  startPts,
+  endDts,
+  endPts,
+  originalStartPts,
+  prependedGops
+) {
+  var segmentTimingInfo = {
     start: {
-      dts: firstGop.dts,
-      pts: firstGop.pts
+      dts: startDts,
+      pts: startPts
     },
     end: {
-      dts: lastGop.dts + lastGop.duration,
-      pts: lastGop.pts + lastGop.duration
+      dts: endDts,
+      pts: endPts
     }
   };
 
   if (prependedGops) {
-    timingInfo.prependedGopDuration = startPts - prependedGops[0].pts;
+    // Use presentation timestamp as calculations are based on showing frames, rather than
+    // the underlying decoding frames.
+    segmentTimingInfo.prependedContentDuration = originalStartPts - prependedGops[0].pts;
   }
 
-  return timingInfo;
+  return segmentTimingInfo;
 };
 
 /**
@@ -245,7 +254,9 @@ VideoSegmentStream = function(track, options) {
       moof,
       mdat,
       boxes,
-      segmentStartPts;
+      originalSegmentStartPts,
+      firstGop,
+      lastGop;
 
     // Throw away nalUnits at the start of the byte stream until
     // we find the first AUD
@@ -310,7 +321,7 @@ VideoSegmentStream = function(track, options) {
     if (gopsToAlignWith.length) {
       var alignedGops;
 
-      segmentStartPts = gops[0].pts;
+      originalSegmentStartPts = gops[0].pts;
 
       if (options.alignGopsAtEnd) {
         alignedGops = this.alignGopsAtEnd_(gops);
@@ -365,12 +376,17 @@ VideoSegmentStream = function(track, options) {
       };
     }));
 
+    firstGop = gops[0];
+    lastGop = gops[gops.length - 1];
+
     this.trigger(
-      'timingInfo',
-      generateVideoTimingInfo(
-        gops[0],
-        gops[gops.length - 1],
-        segmentStartPts,
+      'segmentTimingInfo',
+      generateVideoSegmentTimingInfo(
+        firstGop.dts,
+        firstGop.pts,
+        lastGop.dts + lastGop.duration,
+        lastGop.pts + lastGop.duration,
+        originalSegmentStartPts,
         alignedGops));
 
     // save all the nals in the last GOP into the gop cache
@@ -953,8 +969,8 @@ Transmuxer = function(options) {
 
           pipeline.videoSegmentStream.on('processedGopsInfo',
             self.trigger.bind(self, 'gopInfo'));
-          pipeline.videoSegmentStream.on('timingInfo',
-            self.trigger.bind(self, 'videoTimingInfo'));
+          pipeline.videoSegmentStream.on('segmentTimingInfo',
+            self.trigger.bind(self, 'videoSegmentTimingInfo'));
 
           pipeline.videoSegmentStream.on('baseMediaDecodeTime', function(baseMediaDecodeTime) {
             if (audioTrack) {
@@ -1076,5 +1092,5 @@ module.exports = {
   AUDIO_PROPERTIES: AUDIO_PROPERTIES,
   VIDEO_PROPERTIES: VIDEO_PROPERTIES,
   // exported for testing
-  generateVideoTimingInfo: generateVideoTimingInfo
+  generateVideoSegmentTimingInfo: generateVideoSegmentTimingInfo
 };

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -67,10 +67,9 @@ var generateVideoSegmentTimingInfo = function(
   startPts,
   endDts,
   endPts,
-  originalStartPts,
-  prependedGops
+  prependedContentDuration
 ) {
-  var segmentTimingInfo = {
+  return {
     start: {
       dts: startDts,
       pts: startPts
@@ -78,16 +77,9 @@ var generateVideoSegmentTimingInfo = function(
     end: {
       dts: endDts,
       pts: endPts
-    }
+    },
+    prependedContentDuration: prependedContentDuration
   };
-
-  if (prependedGops) {
-    // Use presentation timestamp as calculations are based on showing frames, rather than
-    // the underlying decoding frames.
-    segmentTimingInfo.prependedContentDuration = originalStartPts - prependedGops[0].pts;
-  }
-
-  return segmentTimingInfo;
 };
 
 /**
@@ -254,7 +246,7 @@ VideoSegmentStream = function(track, options) {
       moof,
       mdat,
       boxes,
-      originalSegmentStartPts,
+      prependedContentDuration = 0,
       firstGop,
       lastGop;
 
@@ -303,6 +295,10 @@ VideoSegmentStream = function(track, options) {
       gopForFusion = this.getGopForFusion_(nalUnits[0], track);
 
       if (gopForFusion) {
+        // in order to provide more accurate timing information about the segment, save
+        // the number of seconds prepended to the original segment due to GOP fusion
+        prependedContentDuration = gopForFusion.duration;
+
         gops.unshift(gopForFusion);
         // Adjust Gops' metadata to account for the inclusion of the
         // new gop at the beginning
@@ -320,8 +316,6 @@ VideoSegmentStream = function(track, options) {
     // Trim gops to align with gopsToAlignWith
     if (gopsToAlignWith.length) {
       var alignedGops;
-
-      originalSegmentStartPts = gops[0].pts;
 
       if (options.alignGopsAtEnd) {
         alignedGops = this.alignGopsAtEnd_(gops);
@@ -386,8 +380,7 @@ VideoSegmentStream = function(track, options) {
         firstGop.pts,
         lastGop.dts + lastGop.duration,
         lastGop.pts + lastGop.duration,
-        originalSegmentStartPts,
-        alignedGops));
+        prependedContentDuration));
 
     // save all the nals in the last GOP into the gop cache
     this.gopCache_.unshift({

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -225,7 +225,9 @@ VideoSegmentStream = function(track, options) {
       gops,
       moof,
       mdat,
-      boxes;
+      boxes,
+      segmentStartPts,
+      timingInfo;
 
     // Throw away nalUnits at the start of the byte stream until
     // we find the first AUD
@@ -290,6 +292,8 @@ VideoSegmentStream = function(track, options) {
     if (gopsToAlignWith.length) {
       var alignedGops;
 
+      segmentStartPts = gops[0].pts;
+
       if (options.alignGopsAtEnd) {
         alignedGops = this.alignGopsAtEnd_(gops);
       } else {
@@ -342,6 +346,23 @@ VideoSegmentStream = function(track, options) {
         byteLength: gop.byteLength
       };
     }));
+
+    timingInfo = {
+      start: {
+        dts: gops[0].dts,
+        pts: gops[0].pts
+      },
+      end: {
+        dts: gops[gops.length - 1].dts + gops[gops.length - 1].duration,
+        pts: gops[gops.length - 1].pts + gops[gops.length - 1].duration
+      },
+    };
+
+    if (alignedGops) {
+      timingInfo.prependedGopDuration = segmentStartPts - alignedGops[0].pts;
+    }
+
+    this.trigger('timingInfo', timingInfo);
 
     // save all the nals in the last GOP into the gop cache
     this.gopCache_.unshift({
@@ -923,6 +944,8 @@ Transmuxer = function(options) {
 
           pipeline.videoSegmentStream.on('processedGopsInfo',
             self.trigger.bind(self, 'gopInfo'));
+          pipeline.videoSegmentStream.on('timingInfo',
+            self.trigger.bind(self, 'videoTimingInfo'));
 
           pipeline.videoSegmentStream.on('baseMediaDecodeTime', function(baseMediaDecodeTime) {
             if (audioTrack) {

--- a/test/transmuxer.test.js
+++ b/test/transmuxer.test.js
@@ -1981,7 +1981,8 @@ function() {
     end: {
       dts: 200,
       pts: 210
-    }
+    },
+    prependedContentDuration: 0
   }, 'triggered correct segment timing info');
 });
 
@@ -2424,8 +2425,7 @@ function() {
       pts: 140,
       duration: 4
     },
-    // should have no impact as there wasn't any prepended content
-    originalSegmentStartPts = 10;
+    prependedContentDuration = 0;
 
   QUnit.deepEqual(
     generateVideoSegmentTimingInfo(
@@ -2433,7 +2433,7 @@ function() {
       firstFrame.pts,
       lastFrame.dts + lastFrame.duration,
       lastFrame.pts + lastFrame.duration,
-      originalSegmentStartPts
+      prependedContentDuration
     ), {
       start: {
         dts: 12,
@@ -2442,7 +2442,8 @@ function() {
       end: {
         dts: 124,
         pts: 144
-      }
+      },
+      prependedContentDuration: 0
     }, 'generated correct timing info object');
 });
 
@@ -2458,13 +2459,7 @@ QUnit.test('generateVideoSegmentTimingInfo accounts for prepended GOPs', functio
       pts: 140,
       duration: 4
     },
-    originalSegmentStartPts = 10,
-    // two GOPs were prepended
-    prependedGops = [{
-      pts: 4
-    }, {
-      pts: 8
-    }];
+    prependedContentDuration = 7;
 
   QUnit.deepEqual(
     generateVideoSegmentTimingInfo(
@@ -2472,8 +2467,7 @@ QUnit.test('generateVideoSegmentTimingInfo accounts for prepended GOPs', functio
       firstFrame.pts,
       lastFrame.dts + lastFrame.duration,
       lastFrame.pts + lastFrame.duration,
-      originalSegmentStartPts,
-      prependedGops
+      prependedContentDuration
     ), {
       start: {
         dts: 12,
@@ -2483,9 +2477,7 @@ QUnit.test('generateVideoSegmentTimingInfo accounts for prepended GOPs', functio
         dts: 124,
         pts: 144
       },
-      // original segment start - new segment start (first prepended GOP)
-      // = 10 - 4 = 6
-      prependedContentDuration: 6
+      prependedContentDuration: 7
     },
     'included prepended content duration in timing info');
 });


### PR DESCRIPTION
The video timing info can be useful for determining the duration of a segment (both presentation and decode), as well as any time prepended due to the addition of GOPs for alignment.