### PR TITLE
Parse captions from tracks with trackId of zero

### DIFF
--- a/lib/mp4/caption-parser.js
+++ b/lib/mp4/caption-parser.js
@@ -231,7 +231,7 @@ var parseCaptionNals = function(segment, videoTrackId) {
 var parseEmbeddedCaptions = function(segment, trackId, timescale) {
   var seiNals;
 
-  if (!trackId) {
+  if (trackId === null) {
     return null;
   }
 
@@ -330,7 +330,7 @@ var CaptionParser = function() {
 
     // If an init segment has not been seen yet, hold onto segment
     // data until we have one
-    } else if (!trackId || !timescale) {
+    } else if (trackId === null || !timescale) {
       segmentCache.push(segment);
       return null;
     }

--- a/lib/mp4/caption-parser.js
+++ b/lib/mp4/caption-parser.js
@@ -231,6 +231,7 @@ var parseCaptionNals = function(segment, videoTrackId) {
 var parseEmbeddedCaptions = function(segment, trackId, timescale) {
   var seiNals;
 
+  // the ISO-BMFF spec says that trackId can't be zero, but there's some broken content out there
   if (trackId === null) {
     return null;
   }
@@ -329,7 +330,8 @@ var CaptionParser = function() {
       timescale = timescales[trackId];
 
     // If an init segment has not been seen yet, hold onto segment
-    // data until we have one
+    // data until we have one.
+    // the ISO-BMFF spec says that trackId can't be zero, but there's some broken content out there
     } else if (trackId === null || !timescale) {
       segmentCache.push(segment);
       return null;


### PR DESCRIPTION
Currently, if the `trackId` is zero, the CaptionParser thinks it hasn't found an init segment yet and stores the segment for later inspection.  This PR changes the `trackId` checks in CaptionParser to allow for a `trackId` of zero, and thus the captions can then be parsed.