### PR TITLE
Selection multiply fragments in one segment when findBox return 0

### DIFF
--- a/lib/mp4/probe.js
+++ b/lib/mp4/probe.js
@@ -142,8 +142,8 @@ startTime = function(timescale, fragment) {
   // determine the start times for each track
   baseTimes = [].concat.apply([], trafs.map(function(traf) {
     return findBox(traf, ['tfhd']).map(function(tfhd) {
-      var id, scale, baseTime;
-
+      var id, scale, baseTime, tfdt;
+      var baseTimeArray = [];
       // get the track id from the tfhd
       id = toUnsigned(tfhd[4] << 24 |
                       tfhd[5] << 16 |
@@ -153,24 +153,30 @@ startTime = function(timescale, fragment) {
       scale = timescale[id] || 90e3;
 
       // get the base media decode time from the tfdt
-      baseTime = findBox(traf, ['tfdt']).map(function(tfdt) {
-        var version, result;
+      tfdt = findBox(traf, ['tfdt']);
+      if (tfdt !== null) {
+        baseTimeArray = tfdt.map(function(tfdt) {
+          var version, result;
 
-        version = tfdt[0];
-        result = toUnsigned(tfdt[4] << 24 |
-                            tfdt[5] << 16 |
-                            tfdt[6] <<  8 |
-                            tfdt[7]);
-        if (version ===  1) {
-          result *= Math.pow(2, 32);
-          result += toUnsigned(tfdt[8]  << 24 |
-                               tfdt[9]  << 16 |
-                               tfdt[10] <<  8 |
-                               tfdt[11]);
-        }
-        return result;
-      })[0];
-      baseTime = baseTime || Infinity;
+          version = tfdt[0];
+          result = toUnsigned(tfdt[4] << 24 |
+              tfdt[5] << 16 |
+              tfdt[6] << 8 |
+              tfdt[7]);
+          if (version === 1) {
+            result *= Math.pow(2, 32);
+            result += toUnsigned(tfdt[8] << 24 |
+                tfdt[9] << 16 |
+                tfdt[10] << 8 |
+                tfdt[11]);
+          }
+          return result;
+        });
+      }
+      if (baseTimeArray.length === 0) {
+        return Infinity;
+      }
+      baseTime = baseTimeArray[0];
 
       // convert base time to seconds
       return baseTime / scale;

--- a/test/mp4-probe.test.js
+++ b/test/mp4-probe.test.js
@@ -15,6 +15,7 @@ var
   moovWithoutTkhd,
   moofWithTfdt,
   multiMoof,
+  multiMoofWithZero,
   v1boxes;
 
 QUnit.module('MP4 Probe');
@@ -41,6 +42,15 @@ test('reads the base decode time from a tfdt', function() {
   }, new Uint8Array(moofWithTfdt)),
         0x01020304 / 2,
         'calculated base decode time');
+});
+
+test('returns the earliest base decode time with zero 0', function() {
+    equal(probe.startTime({
+            4: 2,
+            6: 1
+        }, new Uint8Array(multiMoofWithZero)),
+        0x00,
+        'returned 0');
 });
 
 test('returns the earliest base decode time', function() {
@@ -187,3 +197,26 @@ v1boxes =
               0x00, 0x00, 0x00, // flags
               0x00, 0x00, 0x00, 0x01,
               0x01, 0x02, 0x03, 0x04))); // baseMediaDecodeTime
+
+multiMoofWithZero =
+    box('moof',
+        box('mfhd',
+            0x00, // version
+            0x00, 0x00, 0x00, // flags
+            0x00, 0x00, 0x00, 0x04), // sequence_number
+        box('traf',
+            box('tfhd',
+                0x00, // version
+                0x00, 0x00, 0x3b, // flags
+                0x00, 0x00, 0x00, 0x04, // track_ID = 4
+                0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x01, // base_data_offset
+                0x00, 0x00, 0x00, 0x02, // sample_description_index
+                0x00, 0x00, 0x00, 0x03, // default_sample_duration,
+                0x00, 0x00, 0x00, 0x04, // default_sample_size
+                0x00, 0x00, 0x00, 0x05),
+            box('tfdt',
+                0x00, // version
+                0x00, 0x00, 0x00, // flags
+                0x00, 0x00, 0x00, 0x00))) // baseMediaDecodeTime
+        .concat(moofWithTfdt);


### PR DESCRIPTION
Hello, guys.
Recently I discovered an issue with byteranges and fragments in mp4.
This pull request fixes bug in `lib/mp4/probe.js`.
Brief description of the problem:
Construction `baseTime = baseTime || Infinity;` returns `Infinity` when  `baseTime === 0` so in can affect streams, that contains `tfhd` and function `findBox` return `0` as a valid number from mp4 file.

I add a test for this case as well