### PR TITLE
chore: fix License inconsitencies

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,14 +1,202 @@
-Copyright 2015 Brightcove
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-    http://www.apache.org/licenses/LICENSE-2.0
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+   1. Definitions.
 
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright Brightcove, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/lib/aac/index.js
+++ b/lib/aac/index.js
@@ -1,4 +1,9 @@
 /**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ *
  * A stream-based aac to mp4 converter. This utility can be used to
  * deliver mp4s to a SourceBuffer on platforms that support native
  * Media Source Extensions.

--- a/lib/aac/index.js
+++ b/lib/aac/index.js
@@ -1,9 +1,4 @@
 /**
- * mux.js
- *
- * Copyright (c) 2016 Brightcove
- * All rights reserved.
- *
  * A stream-based aac to mp4 converter. This utility can be used to
  * deliver mp4s to a SourceBuffer on platforms that support native
  * Media Source Extensions.

--- a/lib/aac/utils.js
+++ b/lib/aac/utils.js
@@ -1,9 +1,4 @@
 /**
- * mux.js
- *
- * Copyright (c) 2016 Brightcove
- * All rights reserved.
- *
  * Utilities to detect basic properties and metadata about Aac data.
  */
 'use strict';

--- a/lib/aac/utils.js
+++ b/lib/aac/utils.js
@@ -1,4 +1,9 @@
 /**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ *
  * Utilities to detect basic properties and metadata about Aac data.
  */
 'use strict';

--- a/lib/codecs/adts.js
+++ b/lib/codecs/adts.js
@@ -1,3 +1,9 @@
+/**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ */
 'use strict';
 
 var Stream = require('../utils/stream.js');

--- a/lib/codecs/h264.js
+++ b/lib/codecs/h264.js
@@ -1,3 +1,9 @@
+/**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ */
 'use strict';
 
 var Stream = require('../utils/stream.js');

--- a/lib/codecs/index.js
+++ b/lib/codecs/index.js
@@ -1,3 +1,9 @@
+/**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ */
 module.exports = {
   adts: require('./adts'),
   h264: require('./h264')

--- a/lib/data/silence.js
+++ b/lib/data/silence.js
@@ -1,3 +1,9 @@
+/**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ */
 var highPrefix = [33, 16, 5, 32, 164, 27];
 var lowPrefix = [33, 65, 108, 84, 1, 2, 4, 8, 168, 2, 4, 8, 17, 191, 252];
 var zeroFill = function(count) {

--- a/lib/flv/coalesce-stream.js
+++ b/lib/flv/coalesce-stream.js
@@ -1,3 +1,9 @@
+/**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ */
 'use strict';
 
 var Stream = require('../utils/stream.js');

--- a/lib/flv/flv-header.js
+++ b/lib/flv/flv-header.js
@@ -1,3 +1,9 @@
+/**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ */
 'use strict';
 
 var FlvTag = require('./flv-tag.js');

--- a/lib/flv/flv-tag.js
+++ b/lib/flv/flv-tag.js
@@ -1,4 +1,9 @@
 /**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ *
  * An object that stores the bytes of an FLV tag and methods for
  * querying and manipulating that data.
  * @see http://download.macromedia.com/f4v/video_file_format_spec_v10_1.pdf

--- a/lib/flv/index.js
+++ b/lib/flv/index.js
@@ -1,3 +1,9 @@
+/**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ */
 module.exports = {
   tag: require('./flv-tag'),
   Transmuxer: require('./transmuxer'),

--- a/lib/flv/tag-list.js
+++ b/lib/flv/tag-list.js
@@ -1,3 +1,9 @@
+/**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ */
 'use strict';
 
 var TagList = function() {

--- a/lib/flv/transmuxer.js
+++ b/lib/flv/transmuxer.js
@@ -1,3 +1,9 @@
+/**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ */
 'use strict';
 
 var Stream = require('../utils/stream.js');

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,9 @@
+/**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ */
 'use strict';
 
 var muxjs = {

--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -1,9 +1,4 @@
 /**
- * mux.js
- *
- * Copyright (c) 2015 Brightcove
- * All rights reserved.
- *
  * Reads in-band caption information from a video elementary
  * stream. Captions must follow the CEA-708 standard for injection
  * into an MPEG-2 transport streams.

--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -1,4 +1,9 @@
 /**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ *
  * Reads in-band caption information from a video elementary
  * stream. Captions must follow the CEA-708 standard for injection
  * into an MPEG-2 transport streams.

--- a/lib/m2ts/index.js
+++ b/lib/m2ts/index.js
@@ -1,1 +1,7 @@
+/**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ */
 module.exports = require('./m2ts');

--- a/lib/m2ts/m2ts.js
+++ b/lib/m2ts/m2ts.js
@@ -1,9 +1,4 @@
 /**
- * mux.js
- *
- * Copyright (c) 2015 Brightcove
- * All rights reserved.
- *
  * A stream-based mp2t to mp4 converter. This utility can be used to
  * deliver mp4s to a SourceBuffer on platforms that support native
  * Media Source Extensions.

--- a/lib/m2ts/m2ts.js
+++ b/lib/m2ts/m2ts.js
@@ -1,4 +1,9 @@
 /**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ *
  * A stream-based mp2t to mp4 converter. This utility can be used to
  * deliver mp4s to a SourceBuffer on platforms that support native
  * Media Source Extensions.

--- a/lib/m2ts/metadata-stream.js
+++ b/lib/m2ts/metadata-stream.js
@@ -1,4 +1,9 @@
 /**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ *
  * Accepts program elementary stream (PES) data events and parses out
  * ID3 metadata from them, if present.
  * @see http://id3.org/id3v2.3.0

--- a/lib/m2ts/probe.js
+++ b/lib/m2ts/probe.js
@@ -1,9 +1,4 @@
 /**
- * mux.js
- *
- * Copyright (c) 2016 Brightcove
- * All rights reserved.
- *
  * Utilities to detect basic properties and metadata about TS Segments.
  */
 'use strict';

--- a/lib/m2ts/probe.js
+++ b/lib/m2ts/probe.js
@@ -1,4 +1,9 @@
 /**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ *
  * Utilities to detect basic properties and metadata about TS Segments.
  */
 'use strict';

--- a/lib/m2ts/stream-types.js
+++ b/lib/m2ts/stream-types.js
@@ -1,3 +1,9 @@
+/**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ */
 'use strict';
 
 module.exports = {

--- a/lib/m2ts/timestamp-rollover-stream.js
+++ b/lib/m2ts/timestamp-rollover-stream.js
@@ -1,9 +1,4 @@
 /**
- * mux.js
- *
- * Copyright (c) 2016 Brightcove
- * All rights reserved.
- *
  * Accepts program elementary stream (PES) data events and corrects
  * decode and presentation time stamps to account for a rollover
  * of the 33 bit value.

--- a/lib/m2ts/timestamp-rollover-stream.js
+++ b/lib/m2ts/timestamp-rollover-stream.js
@@ -1,4 +1,9 @@
 /**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ *
  * Accepts program elementary stream (PES) data events and corrects
  * decode and presentation time stamps to account for a rollover
  * of the 33 bit value.

--- a/lib/mp4/audio-frame-utils.js
+++ b/lib/mp4/audio-frame-utils.js
@@ -1,3 +1,9 @@
+/**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ */
 var coneOfSilence = require('../data/silence');
 var clock = require('../utils/clock');
 

--- a/lib/mp4/caption-parser.js
+++ b/lib/mp4/caption-parser.js
@@ -1,9 +1,4 @@
 /**
- * mux.js
- *
- * Copyright (c) 2015 Brightcove
- * All rights reserved.
- *
  * Reads in-band CEA-708 captions out of FMP4 segments.
  * @see https://en.wikipedia.org/wiki/CEA-708
  */

--- a/lib/mp4/caption-parser.js
+++ b/lib/mp4/caption-parser.js
@@ -1,4 +1,9 @@
 /**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ *
  * Reads in-band CEA-708 captions out of FMP4 segments.
  * @see https://en.wikipedia.org/wiki/CEA-708
  */

--- a/lib/mp4/frame-utils.js
+++ b/lib/mp4/frame-utils.js
@@ -1,3 +1,9 @@
+/**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ */
 // Convert an array of nal units into an array of frames with each frame being
 // composed of the nal units that make up that frame
 // Also keep track of cummulative data about the frame from the nal units such

--- a/lib/mp4/index.js
+++ b/lib/mp4/index.js
@@ -1,3 +1,9 @@
+/**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ */
 module.exports = {
   generator: require('./mp4-generator'),
   probe: require('./probe'),

--- a/lib/mp4/mp4-generator.js
+++ b/lib/mp4/mp4-generator.js
@@ -1,9 +1,4 @@
 /**
- * mux.js
- *
- * Copyright (c) 2015 Brightcove
- * All rights reserved.
- *
  * Functions that generate fragmented MP4s suitable for use with Media
  * Source Extensions.
  */

--- a/lib/mp4/mp4-generator.js
+++ b/lib/mp4/mp4-generator.js
@@ -1,4 +1,9 @@
 /**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ *
  * Functions that generate fragmented MP4s suitable for use with Media
  * Source Extensions.
  */

--- a/lib/mp4/probe.js
+++ b/lib/mp4/probe.js
@@ -1,9 +1,4 @@
 /**
- * mux.js
- *
- * Copyright (c) 2015 Brightcove
- * All rights reserved.
- *
  * Utilities to detect basic properties and metadata about MP4s.
  */
 'use strict';

--- a/lib/mp4/probe.js
+++ b/lib/mp4/probe.js
@@ -1,4 +1,9 @@
 /**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ *
  * Utilities to detect basic properties and metadata about MP4s.
  */
 'use strict';

--- a/lib/mp4/track-decode-info.js
+++ b/lib/mp4/track-decode-info.js
@@ -1,3 +1,9 @@
+/**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ */
 var ONE_SECOND_IN_TS = 90000; // 90kHz clock
 
 /**

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -1,9 +1,4 @@
 /**
- * mux.js
- *
- * Copyright (c) 2015 Brightcove
- * All rights reserved.
- *
  * A stream-based mp2t to mp4 converter. This utility can be used to
  * deliver mp4s to a SourceBuffer on platforms that support native
  * Media Source Extensions.

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -1,4 +1,9 @@
 /**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ *
  * A stream-based mp2t to mp4 converter. This utility can be used to
  * deliver mp4s to a SourceBuffer on platforms that support native
  * Media Source Extensions.

--- a/lib/tools/caption-packet-parser.js
+++ b/lib/tools/caption-packet-parser.js
@@ -1,9 +1,4 @@
 /**
- * mux.js
- *
- * Copyright (c) 2015 Brightcove
- * All rights reserved.
- *
  * Reads in-band caption information from a video elementary
  * stream. Captions must follow the CEA-708 standard for injection
  * into an MPEG-2 transport streams.

--- a/lib/tools/caption-packet-parser.js
+++ b/lib/tools/caption-packet-parser.js
@@ -1,4 +1,9 @@
 /**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ *
  * Reads in-band caption information from a video elementary
  * stream. Captions must follow the CEA-708 standard for injection
  * into an MPEG-2 transport streams.

--- a/lib/tools/flv-inspector.js
+++ b/lib/tools/flv-inspector.js
@@ -1,3 +1,9 @@
+/**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ */
 'use strict';
 
 var

--- a/lib/tools/mp4-inspector.js
+++ b/lib/tools/mp4-inspector.js
@@ -1,9 +1,4 @@
 /**
- * mux.js
- *
- * Copyright (c) 2015 Brightcove
- * All rights reserved.
- *
  * Parse the internal MP4 structure into an equivalent javascript
  * object.
  */

--- a/lib/tools/mp4-inspector.js
+++ b/lib/tools/mp4-inspector.js
@@ -1,4 +1,9 @@
 /**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ *
  * Parse the internal MP4 structure into an equivalent javascript
  * object.
  */

--- a/lib/tools/ts-inspector.js
+++ b/lib/tools/ts-inspector.js
@@ -1,9 +1,4 @@
 /**
- * mux.js
- *
- * Copyright (c) 2016 Brightcove
- * All rights reserved.
- *
  * Parse mpeg2 transport stream packets to extract basic timing information
  */
 'use strict';

--- a/lib/tools/ts-inspector.js
+++ b/lib/tools/ts-inspector.js
@@ -1,4 +1,9 @@
 /**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ *
  * Parse mpeg2 transport stream packets to extract basic timing information
  */
 'use strict';

--- a/lib/utils/bin.js
+++ b/lib/utils/bin.js
@@ -1,3 +1,9 @@
+/**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ */
 var toUnsigned = function(value) {
   return value >>> 0;
 };

--- a/lib/utils/clock.js
+++ b/lib/utils/clock.js
@@ -1,3 +1,9 @@
+/**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ */
 var
   ONE_SECOND_IN_TS = 90000, // 90kHz clock
   secondsToVideoTs,

--- a/lib/utils/exp-golomb.js
+++ b/lib/utils/exp-golomb.js
@@ -1,3 +1,9 @@
+/**
+ * mux.js
+ *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ */
 'use strict';
 
 var ExpGolomb;

--- a/lib/utils/stream.js
+++ b/lib/utils/stream.js
@@ -1,6 +1,9 @@
 /**
  * mux.js
  *
+ * Copyright (c) Brightcove
+ * Licensed Apache-2.0 https://github.com/videojs/mux.js/blob/master/LICENSE
+ *
  * A lightweight readable stream implemention that handles event dispatching.
  * Objects that inherit from streams should call init in their constructors.
  */

--- a/lib/utils/stream.js
+++ b/lib/utils/stream.js
@@ -1,9 +1,6 @@
 /**
  * mux.js
  *
- * Copyright (c) 2014 Brightcove
- * All rights reserved.
- *
  * A lightweight readable stream implemention that handles event dispatching.
  * Objects that inherit from streams should call init in their constructors.
  */


### PR DESCRIPTION
Update the LICENSE file to include the full text of the license, remove year from license, and add a header with a link to the license to each file.

Fixes #259