### PR TITLE
Cache buffer.byteLength in NalByteStream.push

### DIFF
--- a/lib/codecs/h264.js
+++ b/lib/codecs/h264.js
@@ -40,6 +40,7 @@ NalByteStream = function() {
       swapBuffer.set(data.data, buffer.byteLength);
       buffer = swapBuffer;
     }
+    var len = buffer.byteLength;
 
     // Rec. ITU-T H.264, Annex B
     // scan for NAL unit boundaries
@@ -52,7 +53,7 @@ NalByteStream = function() {
     // ^ sync point        ^ i
 
     // advance the sync point to a NAL start, if necessary
-    for (; syncPoint < buffer.byteLength - 3; syncPoint++) {
+    for (; syncPoint < len - 3; syncPoint++) {
       if (buffer[syncPoint + 2] === 1) {
         // the sync point is properly aligned
         i = syncPoint + 5;
@@ -60,7 +61,7 @@ NalByteStream = function() {
       }
     }
 
-    while (i < buffer.byteLength) {
+    while (i < len) {
       // look at the current byte to determine if we've hit the end of
       // a NAL unit boundary
       switch (buffer[i]) {
@@ -82,7 +83,7 @@ NalByteStream = function() {
         // drop trailing zeroes
         do {
           i++;
-        } while (buffer[i] !== 1 && i < buffer.length);
+        } while (buffer[i] !== 1 && i < len);
         syncPoint = i - 2;
         i += 3;
         break;


### PR DESCRIPTION
Significant speedup in (pre-Chromium) Edge, especially for high
bitrates such as uncompressed or lightly-compressed frames.

Previously, buffer.byteLength and buffer.length got looked up
multiple times per byte processed in Edge, leading to higher
CPU usage.