### PR TITLE
Feat: change remux after initial creation

### DIFF
--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -257,7 +257,8 @@ VideoSegmentStream = function(track, options) {
       }, this);
     }
 
-    if (nalUnit.nalUnitType === 'pic_parameter_set_rbsp' && !pps) {
+    if (nalUnit.nalUnitType === 'pic_parameter_set_rbsp' &&
+        !pps) {
       pps = nalUnit.data;
       track.pps = [nalUnit.data];
     }

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -21,8 +21,8 @@ var AdtsStream = require('../codecs/adts.js');
 var H264Stream = require('../codecs/h264').H264Stream;
 var AacStream = require('../aac');
 var isLikelyAacData = require('../aac/utils').isLikelyAacData;
+var ONE_SECOND_IN_TS = require('../utils/clock').ONE_SECOND_IN_TS;
 
-var ONE_SECOND_IN_TS = 90000; // 90kHz clock
 
 // constants
 var AUDIO_PROPERTIES = [
@@ -257,8 +257,7 @@ VideoSegmentStream = function(track, options) {
       }, this);
     }
 
-    if (nalUnit.nalUnitType === 'pic_parameter_set_rbsp' &&
-        !pps) {
+    if (nalUnit.nalUnitType === 'pic_parameter_set_rbsp' && !pps) {
       pps = nalUnit.data;
       track.pps = [nalUnit.data];
     }
@@ -709,14 +708,21 @@ CoalesceStream = function(options, metadataStream) {
     // important information required for the construction of
     // the final segment
     this.pendingTracks.push(output.track);
-    this.pendingBoxes.push(output.boxes);
     this.pendingBytes += output.boxes.byteLength;
 
+    // TODO: is there an issue for this against chrome?
+    // We unshift audio and push video because
+    // as of Chrome 75 when switching from
+    // one init segment to another if the video
+    // mdat does not appear after the audio mdat
+    // only audio will play for the duration of our transmux.
     if (output.track.type === 'video') {
       this.videoTrack = output.track;
+      this.pendingBoxes.push(output.boxes);
     }
     if (output.track.type === 'audio') {
       this.audioTrack = output.track;
+      this.pendingBoxes.unshift(output.boxes);
     }
   };
 };
@@ -866,6 +872,10 @@ CoalesceStream.prototype.flush = function(flushSource) {
     this.trigger('done');
     this.emittedTracks = 0;
   }
+};
+
+CoalesceStream.prototype.setRemux = function(val) {
+  this.remuxTracks = val;
 };
 /**
  * A Stream that expects MP2T binary data as input and produces
@@ -1116,6 +1126,16 @@ Transmuxer = function(options) {
   this.setAudioAppendStart = function(timestamp) {
     if (audioTrack) {
       this.transmuxPipeline_.audioSegmentStream.setAudioAppendStart(timestamp);
+    }
+  };
+
+  this.setRemux = function(val) {
+    var pipeline = this.transmuxPipeline_;
+
+    options.remux = val;
+
+    if (pipeline && pipeline.coalesceStream) {
+      pipeline.coalesceStream.setRemux(val);
     }
   };
 

--- a/lib/partial/audio-segment-stream.js
+++ b/lib/partial/audio-segment-stream.js
@@ -4,6 +4,7 @@ var Stream = require('../utils/stream.js');
 var mp4 = require('../mp4/mp4-generator.js');
 var audioFrameUtils = require('../mp4/audio-frame-utils');
 var trackInfo = require('../mp4/track-decode-info.js');
+var ONE_SECOND_IN_TS = require('../utils/clock').ONE_SECOND_IN_TS;
 
 // constants
 var AUDIO_PROPERTIES = [
@@ -13,8 +14,6 @@ var AUDIO_PROPERTIES = [
   'samplingfrequencyindex',
   'samplesize'
 ];
-
-var ONE_SECOND_IN_TS = 90000; // 90kHz clock
 
 /**
  * Constructs a single-track, ISO BMFF media segment from AAC data

--- a/lib/partial/transmuxer.js
+++ b/lib/partial/transmuxer.js
@@ -352,6 +352,15 @@ var Transmuxer = function(options) {
     }
   };
 
+  this.setRemux = function(val) {
+    options.remux = val;
+
+    if (pipeline && pipeline.coalesceStream) {
+      pipeline.coalesceStream.setRemux(val);
+    }
+  };
+
+
   this.setAudioAppendStart = function(audioAppendStart) {
     if (!pipeline || !pipeline.tracks.audio || !pipeline.audioSegmentStream) {
       return;

--- a/test/transmuxer.test.js
+++ b/test/transmuxer.test.js
@@ -3738,7 +3738,7 @@ validateTrackFragment = function(track, segment, metadata, type) {
 QUnit.test('parses an example mp2t file and generates combined media segments', function() {
   var
     segments = [],
-    i, j, boxes, mfhd, trackType = 'video', trackId = 256, baseOffset = 0, initSegment;
+    i, j, boxes, mfhd, trackType = 'audio', trackId = 257, baseOffset = 0, initSegment;
 
   transmuxer.on('data', function(segment) {
     if (segment.type === 'combined') {
@@ -3780,15 +3780,16 @@ QUnit.test('parses an example mp2t file and generates combined media segments', 
       }
 
       validateTrackFragment(boxes[i].boxes[1], segments[0].data, {
-        trackId: trackId++,
+        trackId: trackId,
         width: 388,
         height: 300,
         baseOffset: baseOffset,
         mdatOffset: boxes[i].size
       }, trackType);
 
+      trackId--;
       baseOffset = 0;
-      trackType = 'audio';
+      trackType = 'video';
     }
   }
 });


### PR DESCRIPTION
For fmp4 playlists with ts segment discontinuities the track ids of the fmp4 files and the ts segments that we transmux to fmp4 must match up. 