### PR TITLE
fix: Fire trackinfo for audio only transmuxers

### DIFF
--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -934,6 +934,12 @@ Transmuxer = function(options) {
           .pipe(pipeline.audioSegmentStream)
           .pipe(pipeline.coalesceStream);
       }
+
+      // emit pmt info
+      self.trigger('trackinfo', {
+        hasAudio: !!audioTrack,
+        hasVideo: !!videoTrack
+      });
     });
 
     // Re-emit any data coming from the coalesce stream to the outside world

--- a/lib/partial/transmuxer.js
+++ b/lib/partial/transmuxer.js
@@ -165,11 +165,7 @@ var aacPipeline = function(options) {
     pipeline = {
     type: 'aac',
     tracks: {
-      audio: {
-        timelineStartInfo: {
-          baseMediaDecodeTime: options.baseMediaDecodeTime
-        }
-      }
+      audio: null
     },
     metadataStream: new m2ts.MetadataStream(),
     aacStream: new AacStream(),
@@ -197,9 +193,9 @@ var aacPipeline = function(options) {
       return;
     }
 
-    pipeline.tracks.audio = {
+    pipeline.tracks.audio = pipeline.tracks.audio || {
       timelineStartInfo: {
-        baseMediaDecodeTime: pipeline.tracks.audio.timelineStartInfo.baseMediaDecodeTime
+        baseMediaDecodeTime: options.baseMediaDecodeTime
       },
       codec: 'adts',
       type: 'audio'
@@ -208,19 +204,13 @@ var aacPipeline = function(options) {
     // hook up the audio segment stream to the first track with aac data
     pipeline.audioSegmentStream = new AudioSegmentStream(pipeline.tracks.audio, options);
 
-    pipeline.audioSegmentStream.on('timingInfo',
-      pipeline.trigger.bind(pipeline, 'audioTimingInfo'));
-
-    // Set up the final part of the audio pipeline
-    pipeline.adtsStream
-      .pipe(pipeline.audioSegmentStream);
-
     pipeline.audioSegmentStream.on('data', function(data) {
       pipeline.trigger('data', {
         type: 'audio',
         data: data
       });
     });
+
     pipeline.audioSegmentStream.on('partialdone',
                                    pipeline.trigger.bind(pipeline, 'partialdone'));
     pipeline.audioSegmentStream.on('done', pipeline.trigger.bind(pipeline, 'done'));
@@ -229,6 +219,14 @@ var aacPipeline = function(options) {
     pipeline.audioSegmentStream.on('timingInfo',
                                    pipeline.trigger.bind(pipeline, 'audioTimingInfo'));
 
+    // Set up the final part of the audio pipeline
+    pipeline.adtsStream
+      .pipe(pipeline.audioSegmentStream);
+
+    pipeline.trigger('trackinfo', {
+      hasAudio: !!pipeline.tracks.audio,
+      hasVideo: !!pipeline.tracks.video
+    });
   });
 
   // set the pipeline up as a stream before binding to get access to the trigger function
@@ -266,6 +264,7 @@ var Transmuxer = function(options) {
     hasFlushed = true;
 
   Transmuxer.prototype.init.call(this);
+  options.baseMediaDecodeTime = options.baseMediaDecodeTime || 0;
 
   this.push = function(bytes) {
     if (hasFlushed) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1343,12 +1343,13 @@
       "dev": true
     },
     "d": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
       "dev": true,
       "requires": {
-        "es5-ext": "^0.10.9"
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
       }
     },
     "dash-ast": {
@@ -1892,14 +1893,14 @@
       }
     },
     "es6-weak-map": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
       "dev": true,
       "requires": {
         "d": "1",
-        "es5-ext": "^0.10.14",
-        "es6-iterator": "^2.0.1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.1"
       }
     },
@@ -2451,9 +2452,9 @@
           }
         },
         "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }
@@ -3346,6 +3347,14 @@
         "setprototypeof": "1.1.1",
         "statuses": ">= 1.5.0 < 2",
         "toidentifier": "1.0.0"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        }
       }
     },
     "http-proxy": {
@@ -3415,9 +3424,9 @@
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
     "inline-source-map": {
@@ -5210,9 +5219,9 @@
       "dev": true
     },
     "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
     "progress": {
@@ -5803,9 +5812,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
-      "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+      "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -6713,6 +6722,12 @@
       "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
       "dev": true
     },
+    "type": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.0.1.tgz",
+      "integrity": "sha512-MAM5dBMJCJNKs9E7JXo4CXRAansRfG0nlJxW7Wf6GZzSOvH31zClSaHdIMWLehe/EGMBkqeC55rrkaOr5Oo7Nw==",
+      "dev": true
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
@@ -6936,6 +6951,14 @@
       "dev": true,
       "requires": {
         "inherits": "2.0.3"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        }
       }
     },
     "util-deprecate": {


### PR DESCRIPTION
Right now we only fire `trackinfo` for `tsPipelines`, but  we should fire it for `aacPipelines` as well. 