### PR TITLE
fix: If there isn't any video OR audio track data, just emit done

### DIFF
--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -777,88 +777,90 @@ CoalesceStream.prototype.flush = function(flushSource) {
     }, this);
   }
 
-  if (this.pendingTracks.length === 1) {
-    event.type = this.pendingTracks[0].type;
-  } else {
-    event.type = 'combined';
-  }
+  if (this.videoTrack || this.audioTrack) {
+    if (this.pendingTracks.length === 1) {
+      event.type = this.pendingTracks[0].type;
+    } else {
+      event.type = 'combined';
+    }
 
-  this.emittedTracks += this.pendingTracks.length;
+    this.emittedTracks += this.pendingTracks.length;
 
-  initSegment = mp4.initSegment(this.pendingTracks);
+    initSegment = mp4.initSegment(this.pendingTracks);
 
-  // Create a new typed array to hold the init segment
-  event.initSegment = new Uint8Array(initSegment.byteLength);
+    // Create a new typed array to hold the init segment
+    event.initSegment = new Uint8Array(initSegment.byteLength);
 
-  // Create an init segment containing a moov
-  // and track definitions
-  event.initSegment.set(initSegment);
+    // Create an init segment containing a moov
+    // and track definitions
+    event.initSegment.set(initSegment);
 
-  // Create a new typed array to hold the moof+mdats
-  event.data = new Uint8Array(this.pendingBytes);
+    // Create a new typed array to hold the moof+mdats
+    event.data = new Uint8Array(this.pendingBytes);
 
-  // Append each moof+mdat (one per track) together
-  for (i = 0; i < this.pendingBoxes.length; i++) {
-    event.data.set(this.pendingBoxes[i], offset);
-    offset += this.pendingBoxes[i].byteLength;
-  }
+    // Append each moof+mdat (one per track) together
+    for (i = 0; i < this.pendingBoxes.length; i++) {
+      event.data.set(this.pendingBoxes[i], offset);
+      offset += this.pendingBoxes[i].byteLength;
+    }
 
-  // Translate caption PTS times into second offsets to match the
-  // video timeline for the segment, and add track info
-  for (i = 0; i < this.pendingCaptions.length; i++) {
-    caption = this.pendingCaptions[i];
-    caption.startTime = clock.metadataTsToSeconds(
-      caption.startPts, timelineStartPts, this.keepOriginalTimestamps);
-    caption.endTime = clock.metadataTsToSeconds(
-      caption.endPts, timelineStartPts, this.keepOriginalTimestamps);
+    // Translate caption PTS times into second offsets to match the
+    // video timeline for the segment, and add track info
+    for (i = 0; i < this.pendingCaptions.length; i++) {
+      caption = this.pendingCaptions[i];
+      caption.startTime = clock.metadataTsToSeconds(
+        caption.startPts, timelineStartPts, this.keepOriginalTimestamps);
+      caption.endTime = clock.metadataTsToSeconds(
+        caption.endPts, timelineStartPts, this.keepOriginalTimestamps);
 
-    event.captionStreams[caption.stream] = true;
-    event.captions.push(caption);
-  }
+      event.captionStreams[caption.stream] = true;
+      event.captions.push(caption);
+    }
 
-  // Translate ID3 frame PTS times into second offsets to match the
-  // video timeline for the segment
-  for (i = 0; i < this.pendingMetadata.length; i++) {
-    id3 = this.pendingMetadata[i];
-    id3.cueTime = clock.videoTsToSeconds(
-      id3.pts, timelineStartPts, this.keepOriginalTimestamps);
+    // Translate ID3 frame PTS times into second offsets to match the
+    // video timeline for the segment
+    for (i = 0; i < this.pendingMetadata.length; i++) {
+      id3 = this.pendingMetadata[i];
+      id3.cueTime = clock.videoTsToSeconds(
+        id3.pts, timelineStartPts, this.keepOriginalTimestamps);
 
-    event.metadata.push(id3);
-  }
+      event.metadata.push(id3);
+    }
 
-  // We add this to every single emitted segment even though we only need
-  // it for the first
-  event.metadata.dispatchType = this.metadataStream.dispatchType;
+    // We add this to every single emitted segment even though we only need
+    // it for the first
+    event.metadata.dispatchType = this.metadataStream.dispatchType;
 
-  // Reset stream state
-  this.pendingTracks.length = 0;
-  this.videoTrack = null;
-  this.pendingBoxes.length = 0;
-  this.pendingCaptions.length = 0;
-  this.pendingBytes = 0;
-  this.pendingMetadata.length = 0;
+    // Reset stream state
+    this.pendingTracks.length = 0;
+    this.videoTrack = null;
+    this.pendingBoxes.length = 0;
+    this.pendingCaptions.length = 0;
+    this.pendingBytes = 0;
+    this.pendingMetadata.length = 0;
 
-  // Emit the built segment
-  // We include captions and ID3 tags for backwards compatibility,
-  // ideally we should send only video and audio in the data event
-  this.trigger('data', event);
-  // Emit each caption to the outside world
-  // Ideally, this would happen immediately on parsing captions,
-  // but we need to ensure that video data is sent back first
-  // so that caption timing can be adjusted to match video timing
-  for (i = 0; i < event.captions.length; i++) {
-    caption = event.captions[i];
+    // Emit the built segment
+    // We include captions and ID3 tags for backwards compatibility,
+    // ideally we should send only video and audio in the data event
+    this.trigger('data', event);
+    // Emit each caption to the outside world
+    // Ideally, this would happen immediately on parsing captions,
+    // but we need to ensure that video data is sent back first
+    // so that caption timing can be adjusted to match video timing
+    for (i = 0; i < event.captions.length; i++) {
+      caption = event.captions[i];
 
-    this.trigger('caption', caption);
-  }
-  // Emit each id3 tag to the outside world
-  // Ideally, this would happen immediately on parsing the tag,
-  // but we need to ensure that video data is sent back first
-  // so that ID3 frame timing can be adjusted to match video timing
-  for (i = 0; i < event.metadata.length; i++) {
-    id3 = event.metadata[i];
+      this.trigger('caption', caption);
+    }
+    // Emit each id3 tag to the outside world
+    // Ideally, this would happen immediately on parsing the tag,
+    // but we need to ensure that video data is sent back first
+    // so that ID3 frame timing can be adjusted to match video timing
+    for (i = 0; i < event.metadata.length; i++) {
+      id3 = event.metadata[i];
 
-    this.trigger('id3Frame', id3);
+      this.trigger('id3Frame', id3);
+    }
   }
 
   // Only emit `done` if all tracks have been flushed and emitted


### PR DESCRIPTION
There are scenarios where we parsed timed-metadata but did NOT find any video or audio data. For timing reasons, we can't map the timed-metadata to a proper cue-time until we have received PTS timing data from audio or video tracks. This change causes the transmuxer to hold onto any parsed timed-metadata info instead of emitting it, treating that timed-metadata like it came from the NEXT segment (which hopefully has content) so that we can do a proper mapping to generate the cues' startTime and endTime.