### PR TITLE
fix: Fix an issue where a rollover in only one audio or video track could cause the other to be dropped.

### DIFF
--- a/lib/m2ts/timestamp-rollover-stream.js
+++ b/lib/m2ts/timestamp-rollover-stream.js
@@ -17,6 +17,8 @@ var MAX_TS = 8589934592;
 
 var RO_THRESH = 4294967296;
 
+var TYPE_SHARED = 'shared';
+
 var handleRollover = function(value, reference) {
   var direction = 1;
 
@@ -45,10 +47,16 @@ var TimestampRolloverStream = function(type) {
 
   TimestampRolloverStream.prototype.init.call(this);
 
-  this.type_ = type;
+  // The "shared" type is used in cases where a stream will contain muxed
+  // video and audio. We could use `undefined` here, but having a string
+  // makes debugging a little clearer.
+  this.type_ = type || TYPE_SHARED;
 
   this.push = function(data) {
-    if (data.type !== this.type_) {
+
+    // Any "shared" rollover streams will accept _all_ data. Otherwise,
+    // streams will only accept data that matches their type.
+    if (this.type_ !== TYPE_SHARED && data.type !== this.type_) {
       return;
     }
 

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -1103,6 +1103,9 @@ Transmuxer = function(options) {
       if (!options.keepOriginalTimestamps) {
         audioTrack.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
       }
+      if (pipeline.audioTimestampRolloverStream) {
+        pipeline.audioTimestampRolloverStream.discontinuity();
+      }
       if (pipeline.timestampRolloverStream) {
         pipeline.timestampRolloverStream.discontinuity();
       }

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -1111,7 +1111,6 @@ Transmuxer = function(options) {
     if (videoTrack) {
       if (pipeline.videoSegmentStream) {
         pipeline.videoSegmentStream.gopCache_ = [];
-        pipeline.timestampRolloverStream.discontinuity();
       }
       videoTrack.timelineStartInfo.dts = undefined;
       videoTrack.timelineStartInfo.pts = undefined;

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -1121,10 +1121,6 @@ Transmuxer = function(options) {
       }
     }
 
-    if (pipeline.timedMetadataTimestampRolloverStream) {
-      pipeline.timedMetadataTimestampRolloverStream.discontinuity();
-    }
-
     if (pipeline.timestampRolloverStream) {
       pipeline.timestampRolloverStream.discontinuity();
     }

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -1106,9 +1106,6 @@ Transmuxer = function(options) {
       if (pipeline.audioTimestampRolloverStream) {
         pipeline.audioTimestampRolloverStream.discontinuity();
       }
-      if (pipeline.timestampRolloverStream) {
-        pipeline.timestampRolloverStream.discontinuity();
-      }
     }
     if (videoTrack) {
       if (pipeline.videoSegmentStream) {
@@ -1122,6 +1119,10 @@ Transmuxer = function(options) {
       if (!options.keepOriginalTimestamps) {
         videoTrack.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
       }
+    }
+
+    if (pipeline.timedMetadataTimestampRolloverStream) {
+      pipeline.timedMetadataTimestampRolloverStream.discontinuity();
     }
 
     if (pipeline.timestampRolloverStream) {

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -985,12 +985,13 @@ Transmuxer = function(options) {
 
     // !!THIS ORDER IS IMPORTANT!!
     // demux the streams
-    pipeline.elementaryStream
+    pipeline.timestampRolloverStream
       .pipe(pipeline.h264Stream);
-    pipeline.elementaryStream
+
+    pipeline.timestampRolloverStream
       .pipe(pipeline.adtsStream);
 
-    pipeline.elementaryStream
+    pipeline.timestampRolloverStream
       .pipe(pipeline.metadataStream)
       .pipe(pipeline.coalesceStream);
 

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -970,9 +970,7 @@ Transmuxer = function(options) {
     pipeline.packetStream = new m2ts.TransportPacketStream();
     pipeline.parseStream = new m2ts.TransportParseStream();
     pipeline.elementaryStream = new m2ts.ElementaryStream();
-    pipeline.videoTimestampRolloverStream = new m2ts.TimestampRolloverStream('video');
-    pipeline.audioTimestampRolloverStream = new m2ts.TimestampRolloverStream('audio');
-    pipeline.timedMetadataTimestampRolloverStream = new m2ts.TimestampRolloverStream('timed-metadata');
+    pipeline.timestampRolloverStream = new m2ts.TimestampRolloverStream();
     pipeline.adtsStream = new AdtsStream();
     pipeline.h264Stream = new H264Stream();
     pipeline.captionStream = new m2ts.CaptionStream();
@@ -987,14 +985,12 @@ Transmuxer = function(options) {
     // !!THIS ORDER IS IMPORTANT!!
     // demux the streams
     pipeline.elementaryStream
-      .pipe(pipeline.videoTimestampRolloverStream)
+      .pipe(pipeline.timestampRolloverStream)
       .pipe(pipeline.h264Stream);
     pipeline.elementaryStream
-      .pipe(pipeline.audioTimestampRolloverStream)
       .pipe(pipeline.adtsStream);
 
     pipeline.elementaryStream
-      .pipe(pipeline.timedMetadataTimestampRolloverStream)
       .pipe(pipeline.metadataStream)
       .pipe(pipeline.coalesceStream);
 
@@ -1107,14 +1103,14 @@ Transmuxer = function(options) {
       if (!options.keepOriginalTimestamps) {
         audioTrack.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
       }
-      if (pipeline.audioTimestampRolloverStream) {
-        pipeline.audioTimestampRolloverStream.discontinuity();
+      if (pipeline.timestampRolloverStream) {
+        pipeline.timestampRolloverStream.discontinuity();
       }
     }
     if (videoTrack) {
       if (pipeline.videoSegmentStream) {
         pipeline.videoSegmentStream.gopCache_ = [];
-        pipeline.videoTimestampRolloverStream.discontinuity();
+        pipeline.timestampRolloverStream.discontinuity();
       }
       videoTrack.timelineStartInfo.dts = undefined;
       videoTrack.timelineStartInfo.pts = undefined;
@@ -1125,8 +1121,8 @@ Transmuxer = function(options) {
       }
     }
 
-    if (pipeline.timedMetadataTimestampRolloverStream) {
-      pipeline.timedMetadataTimestampRolloverStream.discontinuity();
+    if (pipeline.timestampRolloverStream) {
+      pipeline.timestampRolloverStream.discontinuity();
     }
   };
 

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -980,12 +980,12 @@ Transmuxer = function(options) {
     // disassemble MPEG2-TS packets into elementary streams
     pipeline.packetStream
       .pipe(pipeline.parseStream)
-      .pipe(pipeline.elementaryStream);
+      .pipe(pipeline.elementaryStream)
+      .pipe(pipeline.timestampRolloverStream);
 
     // !!THIS ORDER IS IMPORTANT!!
     // demux the streams
     pipeline.elementaryStream
-      .pipe(pipeline.timestampRolloverStream)
       .pipe(pipeline.h264Stream);
     pipeline.elementaryStream
       .pipe(pipeline.adtsStream);


### PR DESCRIPTION
### Problem
We saw an issue where some streams had a discontinuity and DTS rollover in one track (e.g. video), but not in another (e.g. audio). The effect of this was that the audio would be interpreted as being ~23 hours in the past and would be thrown out.

For live streams, this meant that the stream would abruptly halt and ultimately cause the player to time out. For VOD streams - at least, in the test case we have - this means audio would be dropped, but video would continue to play.

### Solution
The solution here is to use a single, shared `TimestampRolloverStream` for cases where this is possible.