### PR TITLE
perf: make cone of silence lazy

### DIFF
--- a/lib/data/silence.js
+++ b/lib/data/silence.js
@@ -23,19 +23,26 @@ var makeTable = function(metaTable) {
   }, {});
 };
 
-// Frames-of-silence to use for filling in missing AAC frames
-var coneOfSilence = {
-  96000: [highPrefix, [227, 64], zeroFill(154), [56]],
-  88200: [highPrefix, [231], zeroFill(170), [56]],
-  64000: [highPrefix, [248, 192], zeroFill(240), [56]],
-  48000: [highPrefix, [255, 192], zeroFill(268), [55, 148, 128], zeroFill(54), [112]],
-  44100: [highPrefix, [255, 192], zeroFill(268), [55, 163, 128], zeroFill(84), [112]],
-  32000: [highPrefix, [255, 192], zeroFill(268), [55, 234], zeroFill(226), [112]],
-  24000: [highPrefix, [255, 192], zeroFill(268), [55, 255, 128], zeroFill(268), [111, 112], zeroFill(126), [224]],
-  16000: [highPrefix, [255, 192], zeroFill(268), [55, 255, 128], zeroFill(268), [111, 255], zeroFill(269), [223, 108], zeroFill(195), [1, 192]],
-  12000: [lowPrefix, zeroFill(268), [3, 127, 248], zeroFill(268), [6, 255, 240], zeroFill(268), [13, 255, 224], zeroFill(268), [27, 253, 128], zeroFill(259), [56]],
-  11025: [lowPrefix, zeroFill(268), [3, 127, 248], zeroFill(268), [6, 255, 240], zeroFill(268), [13, 255, 224], zeroFill(268), [27, 255, 192], zeroFill(268), [55, 175, 128], zeroFill(108), [112]],
-  8000: [lowPrefix, zeroFill(268), [3, 121, 16], zeroFill(47), [7]]
-};
 
-module.exports = makeTable(coneOfSilence);
+var silence;
+
+module.exports = function() {
+  if (!silence) {
+    // Frames-of-silence to use for filling in missing AAC frames
+    var coneOfSilence = {
+      96000: [highPrefix, [227, 64], zeroFill(154), [56]],
+      88200: [highPrefix, [231], zeroFill(170), [56]],
+      64000: [highPrefix, [248, 192], zeroFill(240), [56]],
+      48000: [highPrefix, [255, 192], zeroFill(268), [55, 148, 128], zeroFill(54), [112]],
+      44100: [highPrefix, [255, 192], zeroFill(268), [55, 163, 128], zeroFill(84), [112]],
+      32000: [highPrefix, [255, 192], zeroFill(268), [55, 234], zeroFill(226), [112]],
+      24000: [highPrefix, [255, 192], zeroFill(268), [55, 255, 128], zeroFill(268), [111, 112], zeroFill(126), [224]],
+      16000: [highPrefix, [255, 192], zeroFill(268), [55, 255, 128], zeroFill(268), [111, 255], zeroFill(269), [223, 108], zeroFill(195), [1, 192]],
+      12000: [lowPrefix, zeroFill(268), [3, 127, 248], zeroFill(268), [6, 255, 240], zeroFill(268), [13, 255, 224], zeroFill(268), [27, 253, 128], zeroFill(259), [56]],
+      11025: [lowPrefix, zeroFill(268), [3, 127, 248], zeroFill(268), [6, 255, 240], zeroFill(268), [13, 255, 224], zeroFill(268), [27, 255, 192], zeroFill(268), [55, 175, 128], zeroFill(108), [112]],
+      8000: [lowPrefix, zeroFill(268), [3, 121, 16], zeroFill(47), [7]]
+    };
+    silence = makeTable(coneOfSilence);
+  }
+  return silence;
+};

--- a/lib/mp4/audio-frame-utils.js
+++ b/lib/mp4/audio-frame-utils.js
@@ -67,7 +67,7 @@ var prefixWithSilence = function(
     return;
   }
 
-  silentFrame = coneOfSilence[track.samplerate];
+  silentFrame = coneOfSilence()[track.samplerate];
 
   if (!silentFrame) {
     // we don't have a silent frame pregenerated for the sample rate, so use a frame


### PR DESCRIPTION
Saves about ~10-20ms of script loading time in the browser in slow browsers/computers.