### PR TITLE
If there isn't any video OR audio track data, just emit done

### DIFF
--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -740,81 +740,83 @@ CoalesceStream.prototype.flush = function(flushSource) {
     }, this);
   }
 
-  if (this.pendingTracks.length === 1) {
-    event.type = this.pendingTracks[0].type;
-  } else {
-    event.type = 'combined';
-  }
-
-  this.emittedTracks += this.pendingTracks.length;
-
-  initSegment = mp4.initSegment(this.pendingTracks);
-
-  // Create a new typed array to hold the init segment
-  event.initSegment = new Uint8Array(initSegment.byteLength);
-
-  // Create an init segment containing a moov
-  // and track definitions
-  event.initSegment.set(initSegment);
-
-  // Create a new typed array to hold the moof+mdats
-  event.data = new Uint8Array(this.pendingBytes);
-
-  // Append each moof+mdat (one per track) together
-  for (i = 0; i < this.pendingBoxes.length; i++) {
-    event.data.set(this.pendingBoxes[i], offset);
-    offset += this.pendingBoxes[i].byteLength;
-  }
-
-  // Translate caption PTS times into second offsets to match the
-  // video timeline for the segment, and add track info
-  for (i = 0; i < this.pendingCaptions.length; i++) {
-    caption = this.pendingCaptions[i];
-
-    caption.startTime = caption.startPts;
-    if (!this.keepOriginalTimestamps) {
-      caption.startTime -= timelineStartPts;
+  if (this.videoTrack || this.audioTrack) {
+    if (this.pendingTracks.length === 1) {
+      event.type = this.pendingTracks[0].type;
+    } else {
+      event.type = 'combined';
     }
-    caption.startTime /= 90e3;
 
-    caption.endTime = caption.endPts;
-    if (!this.keepOriginalTimestamps) {
-      caption.endTime -= timelineStartPts;
+    this.emittedTracks += this.pendingTracks.length;
+
+    initSegment = mp4.initSegment(this.pendingTracks);
+
+    // Create a new typed array to hold the init segment
+    event.initSegment = new Uint8Array(initSegment.byteLength);
+
+    // Create an init segment containing a moov
+    // and track definitions
+    event.initSegment.set(initSegment);
+
+    // Create a new typed array to hold the moof+mdats
+    event.data = new Uint8Array(this.pendingBytes);
+
+    // Append each moof+mdat (one per track) together
+    for (i = 0; i < this.pendingBoxes.length; i++) {
+      event.data.set(this.pendingBoxes[i], offset);
+      offset += this.pendingBoxes[i].byteLength;
     }
-    caption.endTime /= 90e3;
 
-    event.captionStreams[caption.stream] = true;
-    event.captions.push(caption);
-  }
+    // Translate caption PTS times into second offsets to match the
+    // video timeline for the segment, and add track info
+    for (i = 0; i < this.pendingCaptions.length; i++) {
+      caption = this.pendingCaptions[i];
 
-  // Translate ID3 frame PTS times into second offsets to match the
-  // video timeline for the segment
-  for (i = 0; i < this.pendingMetadata.length; i++) {
-    id3 = this.pendingMetadata[i];
+      caption.startTime = caption.startPts;
+      if (!this.keepOriginalTimestamps) {
+        caption.startTime -= timelineStartPts;
+      }
+      caption.startTime /= 90e3;
 
-    id3.cueTime = id3.pts;
-    if (!this.keepOriginalTimestamps) {
-      id3.cueTime -= timelineStartPts;
+      caption.endTime = caption.endPts;
+      if (!this.keepOriginalTimestamps) {
+        caption.endTime -= timelineStartPts;
+      }
+      caption.endTime /= 90e3;
+
+      event.captionStreams[caption.stream] = true;
+      event.captions.push(caption);
     }
-    id3.cueTime /= 90e3;
 
-    event.metadata.push(id3);
+    // Translate ID3 frame PTS times into second offsets to match the
+    // video timeline for the segment
+    for (i = 0; i < this.pendingMetadata.length; i++) {
+      id3 = this.pendingMetadata[i];
+
+      id3.cueTime = id3.pts;
+      if (!this.keepOriginalTimestamps) {
+        id3.cueTime -= timelineStartPts;
+      }
+      id3.cueTime /= 90e3;
+
+      event.metadata.push(id3);
+    }
+
+    // We add this to every single emitted segment even though we only need
+    // it for the first
+    event.metadata.dispatchType = this.metadataStream.dispatchType;
+
+    // Reset stream state
+    this.pendingTracks.length = 0;
+    this.videoTrack = null;
+    this.pendingBoxes.length = 0;
+    this.pendingCaptions.length = 0;
+    this.pendingBytes = 0;
+    this.pendingMetadata.length = 0;
+
+    // Emit the built segment
+    this.trigger('data', event);
   }
-
-  // We add this to every single emitted segment even though we only need
-  // it for the first
-  event.metadata.dispatchType = this.metadataStream.dispatchType;
-
-  // Reset stream state
-  this.pendingTracks.length = 0;
-  this.videoTrack = null;
-  this.pendingBoxes.length = 0;
-  this.pendingCaptions.length = 0;
-  this.pendingBytes = 0;
-  this.pendingMetadata.length = 0;
-
-  // Emit the built segment
-  this.trigger('data', event);
 
   // Only emit `done` if all tracks have been flushed and emitted
   if (this.emittedTracks >= this.numberOfTracks) {


### PR DESCRIPTION
This is a version of #279, but for the 5.1.x line of mux.js. There are regression(s) in 5.2.0 pre-releases that are blocking some things.

There are scenarios where we parsed timed-metadata but did NOT find any video or audio data. For timing reasons, we can't map the timed-metadata to a proper cue-time until we have received PTS timing data from audio or video tracks. This change causes the transmuxer to hold onto any parsed timed-metadata info instead of emitting it, treating that timed-metadata like it came from the NEXT segment (which hopefully has content) so that we can do a proper mapping to generate the cues' startTime and endTime.