### PR TITLE
fix: use metadataTsToSeconds for id3 as we did previously

### DIFF
--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -828,7 +828,7 @@ CoalesceStream.prototype.flush = function(flushSource) {
     // video timeline for the segment
     for (i = 0; i < this.pendingMetadata.length; i++) {
       id3 = this.pendingMetadata[i];
-      id3.cueTime = clock.videoTsToSeconds(
+      id3.cueTime = clock.metadataTsToSeconds(
         id3.pts, timelineStartPts, this.keepOriginalTimestamps);
 
       event.metadata.push(id3);


### PR DESCRIPTION
Previous to TBA/LHLS we did code that equated to `metadataTsToSeconds` on `id3`s. In master we do `videoTsToSeconds`. The code itself seems to think that `metadataTsToSeconds` should be called as it passes all the parameters for it, and it fixes an issues where cues are not firing at the correct time, since they are trying to use video time and not metadata time.

This means we can close #292 (hopefully)