### PR TITLE
fix: mp4Inspector should return unsigned baseMediaDecodeTime

### DIFF
--- a/lib/tools/mp4-inspector.js
+++ b/lib/tools/mp4-inspector.js
@@ -14,6 +14,7 @@ var
   textifyMp4,
 
   parseType = require('../mp4/probe').parseType,
+  toUnsigned = require('../utils/bin').toUnsigned,
   parseMp4Date = function(seconds) {
     return new Date(seconds * 1000 - 2082844800000);
   },
@@ -508,11 +509,11 @@ var
       var result = {
         version: data[0],
         flags: new Uint8Array(data.subarray(1, 4)),
-        baseMediaDecodeTime: data[4] << 24 | data[5] << 16 | data[6] << 8 | data[7]
+        baseMediaDecodeTime: toUnsigned(data[4] << 24 | data[5] << 16 | data[6] << 8 | data[7])
       };
       if (result.version === 1) {
         result.baseMediaDecodeTime *= Math.pow(2, 32);
-        result.baseMediaDecodeTime += data[8] << 24 | data[9] << 16 | data[10] << 8 | data[11];
+        result.baseMediaDecodeTime += toUnsigned(data[8] << 24 | data[9] << 16 | data[10] << 8 | data[11]);
       }
       return result;
     },

--- a/test/mp4-inspector.test.js
+++ b/test/mp4-inspector.test.js
@@ -976,11 +976,11 @@ QUnit.test('can parse a version 0 tfdt', function() {
             }]);
 });
 
-QUnit.test('can parse a version 1 tfdt', function() {
+QUnit.test('can parse a version 1 tfdt and return an unsigned integer value', function() {
   var data = box('tfdt',
                  0x01, // version
                  0x00, 0x00, 0x00, // flags
-                 0x01, 0x02, 0x03, 0x04,
+                 0x81, 0x02, 0x03, 0x04,
                  0x05, 0x06, 0x07, 0x08); // baseMediaDecodeTime
   QUnit.deepEqual(mp4.tools.inspect(new Uint8Array(data)),
             [{
@@ -988,7 +988,7 @@ QUnit.test('can parse a version 1 tfdt', function() {
               version: 1,
               size: 20,
               flags: new Uint8Array([0, 0, 0]),
-              baseMediaDecodeTime: 0x0102030405060708
+              baseMediaDecodeTime: 0x8102030405060708
             }]);
 });
 


### PR DESCRIPTION
## Description
According to the ISO BMFF spec, the base media decode time is stored as an unsigned integer within the `tfdt` box. The mp4 probe [already returns](https://github.com/videojs/mux.js/blob/master/lib/mp4/probe.js#L167-L170) an unsigned integer, but the mp4 inspector does not. This PR corrects that behavior, ensuring that the same unsigned value is returned by both the probe and inspector.