### PR TITLE
feat: add compositionStartTime mp4 probe function

### DIFF
--- a/lib/mp4/probe.js
+++ b/lib/mp4/probe.js
@@ -10,61 +10,8 @@
 
 var toUnsigned = require('../utils/bin').toUnsigned;
 var toHexString = require('../utils/bin').toHexString;
-var findBox, parseType, timescale, startTime, getVideoTrackIds, getTracks;
-
-// Find the data for a box specified by its path
-findBox = function(data, path) {
-  var results = [],
-      i, size, type, end, subresults;
-
-  if (!path.length) {
-    // short-circuit the search for empty paths
-    return null;
-  }
-
-  for (i = 0; i < data.byteLength;) {
-    size  = toUnsigned(data[i]     << 24 |
-                       data[i + 1] << 16 |
-                       data[i + 2] <<  8 |
-                       data[i + 3]);
-
-    type = parseType(data.subarray(i + 4, i + 8));
-
-    end = size > 1 ? i + size : data.byteLength;
-
-    if (type === path[0]) {
-      if (path.length === 1) {
-        // this is the end of the path and we've found the box we were
-        // looking for
-        results.push(data.subarray(i + 8, end));
-      } else {
-        // recursively search for the next box along the path
-        subresults = findBox(data.subarray(i + 8, end), path.slice(1));
-        if (subresults.length) {
-          results = results.concat(subresults);
-        }
-      }
-    }
-    i = end;
-  }
-
-  // we've finished searching all of data
-  return results;
-};
-
-/**
- * Returns the string representation of an ASCII encoded four byte buffer.
- * @param buffer {Uint8Array} a four-byte buffer to translate
- * @return {string} the corresponding string
- */
-parseType = function(buffer) {
-  var result = '';
-  result += String.fromCharCode(buffer[0]);
-  result += String.fromCharCode(buffer[1]);
-  result += String.fromCharCode(buffer[2]);
-  result += String.fromCharCode(buffer[3]);
-  return result;
-};
+var mp4Inspector = require('../tools/mp4-inspector.js');
+var timescale, startTime, compositionStartTime, getVideoTrackIds, getTracks;
 
 /**
  * Parses an MP4 initialization segment and extracts the timescale
@@ -87,13 +34,13 @@ parseType = function(buffer) {
 timescale = function(init) {
   var
     result = {},
-    traks = findBox(init, ['moov', 'trak']);
+    traks = mp4Inspector.findBox(init, ['moov', 'trak']);
 
   // mdhd timescale
   return traks.reduce(function(result, trak) {
     var tkhd, version, index, id, mdhd;
 
-    tkhd = findBox(trak, ['tkhd'])[0];
+    tkhd = mp4Inspector.findBox(trak, ['tkhd'])[0];
     if (!tkhd) {
       return null;
     }
@@ -104,7 +51,7 @@ timescale = function(init) {
                     tkhd[index + 2] <<  8 |
                     tkhd[index + 3]);
 
-    mdhd = findBox(trak, ['mdia', 'mdhd'])[0];
+    mdhd = mp4Inspector.findBox(trak, ['mdia', 'mdhd'])[0];
     if (!mdhd) {
       return null;
     }
@@ -138,11 +85,11 @@ startTime = function(timescale, fragment) {
   var trafs, baseTimes, result;
 
   // we need info from two childrend of each track fragment box
-  trafs = findBox(fragment, ['moof', 'traf']);
+  trafs = mp4Inspector.findBox(fragment, ['moof', 'traf']);
 
   // determine the start times for each track
   baseTimes = [].concat.apply([], trafs.map(function(traf) {
-    return findBox(traf, ['tfhd']).map(function(tfhd) {
+    return mp4Inspector.findBox(traf, ['tfhd']).map(function(tfhd) {
       var id, scale, baseTime;
 
       // get the track id from the tfhd
@@ -154,7 +101,7 @@ startTime = function(timescale, fragment) {
       scale = timescale[id] || 90e3;
 
       // get the base media decode time from the tfdt
-      baseTime = findBox(traf, ['tfdt']).map(function(tfdt) {
+      baseTime = mp4Inspector.findBox(traf, ['tfdt']).map(function(tfdt) {
         var version, result;
 
         version = tfdt[0];
@@ -184,6 +131,56 @@ startTime = function(timescale, fragment) {
 };
 
 /**
+ * Determine the composition start, in seconds, for an MP4
+ * fragment.
+ *
+ * The composition start time of a fragment can be calculated using the base
+ * media decode time, composition time offset, and timescale, as follows:
+ *
+ * compositionStartTime = (baseMediaDecodeTime + compositionTimeOffset) / timescale
+ *
+ * All of the aforementioned information is contained within a media fragment's
+ * `traf` box, except for timescale info, which comes from the initialization
+ * segment, so a track id (also contained within a `traf`) is also necessary to
+ * associate it with a timescale
+ *
+ *
+ * @param timescales {object} - a hash of track ids to timescale values.
+ * @param fragment {Unit8Array} - the bytes of a media segment
+ * @return {number} the composition start time for the fragment, in seconds
+ **/
+compositionStartTime = function(timescales, fragment) {
+  var trafBoxes = mp4Inspector.findBox(fragment, ['moof', 'traf']);
+  var baseMediaDecodeTime = 0;
+  var compositionTimeOffset = 0;
+  var trackId;
+
+  if (trafBoxes && trafBoxes.length) {
+    // The spec states that track run samples contained within a `traf` box are contiguous, but
+    // it does not explicitly state whether the `traf` boxes themselves are contiguous.
+    // We will assume that they are, so we only need the first to calculate start time.
+    var parsedTraf = mp4Inspector.parseTraf(trafBoxes[0]);
+
+    for (var i = 0; i < parsedTraf.boxes.length; i++) {
+      if (parsedTraf.boxes[i].type === 'tfhd') {
+        trackId = parsedTraf.boxes[i].trackId;
+      } else if (parsedTraf.boxes[i].type === 'tfdt') {
+        baseMediaDecodeTime = parsedTraf.boxes[i].baseMediaDecodeTime;
+      } else if (parsedTraf.boxes[i].type === 'trun' && parsedTraf.boxes[i].samples.length) {
+        compositionTimeOffset = parsedTraf.boxes[i].samples[0].compositionTimeOffset || 0;
+      }
+    }
+  }
+
+  // Get timescale for this specific track. Assume a 90kHz clock if no timescale was
+  // specified.
+  var timescale = timescales[trackId] || 90e3;
+
+  // return the composition start time, in seconds
+  return (baseMediaDecodeTime + compositionTimeOffset) / timescale;
+};
+
+/**
   * Find the trackIds of the video tracks in this source.
   * Found by parsing the Handler Reference and Track Header Boxes:
   *   moov > trak > mdia > hdlr
@@ -195,15 +192,15 @@ startTime = function(timescale, fragment) {
   * @see ISO-BMFF-12/2015, Section 8.4.3
  **/
 getVideoTrackIds = function(init) {
-  var traks = findBox(init, ['moov', 'trak']);
+  var traks = mp4Inspector.findBox(init, ['moov', 'trak']);
   var videoTrackIds = [];
 
   traks.forEach(function(trak) {
-    var hdlrs = findBox(trak, ['mdia', 'hdlr']);
-    var tkhds = findBox(trak, ['tkhd']);
+    var hdlrs = mp4Inspector.findBox(trak, ['mdia', 'hdlr']);
+    var tkhds = mp4Inspector.findBox(trak, ['tkhd']);
 
     hdlrs.forEach(function(hdlr, index) {
-      var handlerType = parseType(hdlr.subarray(8, 12));
+      var handlerType = mp4Inspector.parseType(hdlr.subarray(8, 12));
       var tkhd = tkhds[index];
       var view;
       var version;
@@ -227,12 +224,12 @@ getVideoTrackIds = function(init) {
  * mp4 segment
  */
 getTracks = function(init) {
-  var traks = findBox(init, ['moov', 'trak']);
+  var traks = mp4Inspector.findBox(init, ['moov', 'trak']);
   var tracks = [];
 
   traks.forEach(function(trak) {
     var track = {};
-    var tkhd = findBox(trak, ['tkhd'])[0];
+    var tkhd = mp4Inspector.findBox(trak, ['tkhd'])[0];
     var view, version;
 
     // id
@@ -243,11 +240,11 @@ getTracks = function(init) {
       track.id = (version === 0) ? view.getUint32(12) : view.getUint32(20);
     }
 
-    var hdlr = findBox(trak, ['mdia', 'hdlr'])[0];
+    var hdlr = mp4Inspector.findBox(trak, ['mdia', 'hdlr'])[0];
 
     // type
     if (hdlr) {
-      var type = parseType(hdlr.subarray(8, 12));
+      var type = mp4Inspector.parseType(hdlr.subarray(8, 12));
 
       if (type === 'vide') {
         track.type = 'video';
@@ -260,14 +257,14 @@ getTracks = function(init) {
 
 
     // codec
-    var stsd = findBox(trak, ['mdia', 'minf', 'stbl', 'stsd'])[0];
+    var stsd = mp4Inspector.findBox(trak, ['mdia', 'minf', 'stbl', 'stsd'])[0];
 
     if (stsd) {
       var sampleDescriptions = stsd.subarray(8);
       // gives the codec type string
-      track.codec = parseType(sampleDescriptions.subarray(4, 8));
+      track.codec = mp4Inspector.parseType(sampleDescriptions.subarray(4, 8));
 
-      var codecBox = findBox(sampleDescriptions, [track.codec])[0];
+      var codecBox = mp4Inspector.findBox(sampleDescriptions, [track.codec])[0];
       var codecConfig, codecConfigType;
 
       if (codecBox) {
@@ -276,7 +273,7 @@ getTracks = function(init) {
           // we don't need anything but the "config" parameter of the
           // avc1 codecBox
           codecConfig = codecBox.subarray(78);
-          codecConfigType = parseType(codecConfig.subarray(4, 8));
+          codecConfigType = mp4Inspector.parseType(codecConfig.subarray(4, 8));
 
           if (codecConfigType === 'avcC' && codecConfig.length > 11) {
             track.codec += '.';
@@ -296,7 +293,7 @@ getTracks = function(init) {
         } else if ((/^mp4[a,v]$/i).test(track.codec)) {
           // we do not need anything but the streamDescriptor of the mp4a codecBox
           codecConfig = codecBox.subarray(28);
-          codecConfigType = parseType(codecConfig.subarray(4, 8));
+          codecConfigType = mp4Inspector.parseType(codecConfig.subarray(4, 8));
 
           if (codecConfigType === 'esds' && codecConfig.length > 20 && codecConfig[19] !== 0) {
             track.codec += '.' + toHexString(codecConfig[19]);
@@ -313,7 +310,7 @@ getTracks = function(init) {
       }
     }
 
-    var mdhd = findBox(trak, ['mdia', 'mdhd'])[0];
+    var mdhd = mp4Inspector.findBox(trak, ['mdia', 'mdhd'])[0];
 
     if (mdhd && tkhd) {
       var index = version === 0 ? 12 : 20;
@@ -331,10 +328,12 @@ getTracks = function(init) {
 };
 
 module.exports = {
-  findBox: findBox,
-  parseType: parseType,
+  // export mp4 inspector's findBox and parseType for backwards compatibility
+  findBox: mp4Inspector.findBox,
+  parseType: mp4Inspector.parseType,
   timescale: timescale,
   startTime: startTime,
+  compositionStartTime: compositionStartTime,
   videoTrackIds: getVideoTrackIds,
   tracks: getTracks
 };

--- a/lib/tools/mp4-inspector.js
+++ b/lib/tools/mp4-inspector.js
@@ -12,8 +12,6 @@
 var
   inspectMp4,
   textifyMp4,
-
-  parseType = require('../mp4/probe').parseType,
   toUnsigned = require('../utils/bin').toUnsigned,
   parseMp4Date = function(seconds) {
     return new Date(seconds * 1000 - 2082844800000);
@@ -28,6 +26,58 @@ var
       isNonSyncSample: flags[1] & 0x01,
       degradationPriority: (flags[2] << 8) | flags[3]
     };
+  },
+  /**
+   * Returns the string representation of an ASCII encoded four byte buffer.
+   * @param buffer {Uint8Array} a four-byte buffer to translate
+   * @return {string} the corresponding string
+   */
+  parseType = function(buffer) {
+    var result = '';
+    result += String.fromCharCode(buffer[0]);
+    result += String.fromCharCode(buffer[1]);
+    result += String.fromCharCode(buffer[2]);
+    result += String.fromCharCode(buffer[3]);
+    return result;
+  },
+  // Find the data for a box specified by its path
+  findBox = function(data, path) {
+    var results = [],
+        i, size, type, end, subresults;
+
+    if (!path.length) {
+      // short-circuit the search for empty paths
+      return null;
+    }
+
+    for (i = 0; i < data.byteLength;) {
+      size  = toUnsigned(data[i]     << 24 |
+                         data[i + 1] << 16 |
+                         data[i + 2] <<  8 |
+                         data[i + 3]);
+
+      type = parseType(data.subarray(i + 4, i + 8));
+
+      end = size > 1 ? i + size : data.byteLength;
+
+      if (type === path[0]) {
+        if (path.length === 1) {
+          // this is the end of the path and we've found the box we were
+          // looking for
+          results.push(data.subarray(i + 8, end));
+        } else {
+          // recursively search for the next box along the path
+          subresults = findBox(data.subarray(i + 8, end), path.slice(1));
+          if (subresults.length) {
+            results = results.concat(subresults);
+          }
+        }
+      }
+      i = end;
+    }
+
+    // we've finished searching all of data
+    return results;
   },
   nalParse = function(avcStream) {
     var
@@ -840,6 +890,8 @@ textifyMp4 = function(inspectedMp4, depth) {
 module.exports = {
   inspect: inspectMp4,
   textify: textifyMp4,
+  parseType: parseType,
+  findBox: findBox,
   parseTraf: parse.traf,
   parseTfdt: parse.tfdt,
   parseHdlr: parse.hdlr,


### PR DESCRIPTION
## Description
This moves some proposed fmp4 box parsing logic from a [VHS PR](https://github.com/videojs/http-streaming/pull/660) into the mux.js mp4 probe module, a more fitting home. I also moved `parseType()` and `findBox()` out of the mp4 probe and into the mp4-inspector as a first step to remove some duplication between the probe and inspector files. We should move all box-parsing logic into the inspector, and then use those parsing functions in the probe rather than have duplicate logic in both places. I'll save that refactoring for a separate PR.

More details about `compositionStartTime()` and the reason for adding it can be found in the VHS PR linked above.