### PR TITLE
perf: Single allocation of Uint8Array in trun.

### DIFF
--- a/lib/mp4/mp4-generator.js
+++ b/lib/mp4/mp4-generator.js
@@ -710,62 +710,65 @@ trex = function(track) {
   };
 
   videoTrun = function(track, offset) {
-    var bytes, samples, sample, i;
+    var bytesOffest, bytes, header, samples, sample, i;
 
     samples = track.samples || [];
     offset += 8 + 12 + (16 * samples.length);
-
-    bytes = trunHeader(samples, offset);
+    header = trunHeader(samples, offset);
+    bytes = new Uint8Array(header.length + samples.length * 16);
+    bytes.set(header);
+    bytesOffest = header.length;
 
     for (i = 0; i < samples.length; i++) {
       sample = samples[i];
-      bytes = bytes.concat([
-        (sample.duration & 0xFF000000) >>> 24,
-        (sample.duration & 0xFF0000) >>> 16,
-        (sample.duration & 0xFF00) >>> 8,
-        sample.duration & 0xFF, // sample_duration
-        (sample.size & 0xFF000000) >>> 24,
-        (sample.size & 0xFF0000) >>> 16,
-        (sample.size & 0xFF00) >>> 8,
-        sample.size & 0xFF, // sample_size
-        (sample.flags.isLeading << 2) | sample.flags.dependsOn,
-        (sample.flags.isDependedOn << 6) |
+
+      bytes[bytesOffest++] = (sample.duration & 0xFF000000) >>> 24;
+      bytes[bytesOffest++] = (sample.duration & 0xFF0000) >>> 16;
+      bytes[bytesOffest++] = (sample.duration & 0xFF00) >>> 8;
+      bytes[bytesOffest++] = sample.duration & 0xFF; // sample_duration
+      bytes[bytesOffest++] = (sample.size & 0xFF000000) >>> 24;
+      bytes[bytesOffest++] = (sample.size & 0xFF0000) >>> 16;
+      bytes[bytesOffest++] = (sample.size & 0xFF00) >>> 8;
+      bytes[bytesOffest++] = sample.size & 0xFF; // sample_size
+      bytes[bytesOffest++] = (sample.flags.isLeading << 2) | sample.flags.dependsOn;
+      bytes[bytesOffest++] = (sample.flags.isDependedOn << 6) |
           (sample.flags.hasRedundancy << 4) |
           (sample.flags.paddingValue << 1) |
-          sample.flags.isNonSyncSample,
-        sample.flags.degradationPriority & 0xF0 << 8,
-        sample.flags.degradationPriority & 0x0F, // sample_flags
-        (sample.compositionTimeOffset & 0xFF000000) >>> 24,
-        (sample.compositionTimeOffset & 0xFF0000) >>> 16,
-        (sample.compositionTimeOffset & 0xFF00) >>> 8,
-        sample.compositionTimeOffset & 0xFF // sample_composition_time_offset
-      ]);
+          sample.flags.isNonSyncSample;
+      bytes[bytesOffest++] = sample.flags.degradationPriority & 0xF0 << 8;
+      bytes[bytesOffest++] = sample.flags.degradationPriority & 0x0F; // sample_flags
+      bytes[bytesOffest++] = (sample.compositionTimeOffset & 0xFF000000) >>> 24;
+      bytes[bytesOffest++] = (sample.compositionTimeOffset & 0xFF0000) >>> 16;
+      bytes[bytesOffest++] = (sample.compositionTimeOffset & 0xFF00) >>> 8;
+      bytes[bytesOffest++] = sample.compositionTimeOffset & 0xFF; // sample_composition_time_offset
     }
-    return box(types.trun, new Uint8Array(bytes));
+    return box(types.trun, bytes);
   };
 
   audioTrun = function(track, offset) {
-    var bytes, samples, sample, i;
+    var bytes, bytesOffest, header, samples, sample, i;
 
     samples = track.samples || [];
     offset += 8 + 12 + (8 * samples.length);
 
-    bytes = trunHeader(samples, offset);
+    header = trunHeader(samples, offset);
+    bytes = new Uint8Array(header.length + samples.length * 8);
+    bytes.set(header);
+    bytesOffest = header.length;
 
     for (i = 0; i < samples.length; i++) {
       sample = samples[i];
-      bytes = bytes.concat([
-        (sample.duration & 0xFF000000) >>> 24,
-        (sample.duration & 0xFF0000) >>> 16,
-        (sample.duration & 0xFF00) >>> 8,
-        sample.duration & 0xFF, // sample_duration
-        (sample.size & 0xFF000000) >>> 24,
-        (sample.size & 0xFF0000) >>> 16,
-        (sample.size & 0xFF00) >>> 8,
-        sample.size & 0xFF]); // sample_size
+      bytes[bytesOffest++] = (sample.duration & 0xFF000000) >>> 24;
+      bytes[bytesOffest++] = (sample.duration & 0xFF0000) >>> 16;
+      bytes[bytesOffest++] = (sample.duration & 0xFF00) >>> 8;
+      bytes[bytesOffest++] = sample.duration & 0xFF; // sample_duration
+      bytes[bytesOffest++] = (sample.size & 0xFF000000) >>> 24;
+      bytes[bytesOffest++] = (sample.size & 0xFF0000) >>> 16;
+      bytes[bytesOffest++] = (sample.size & 0xFF00) >>> 8;
+      bytes[bytesOffest++] = sample.size & 0xFF; // sample_size
     }
 
-    return box(types.trun, new Uint8Array(bytes));
+    return box(types.trun, bytes);
   };
 
   trun = function(track, offset) {


### PR DESCRIPTION
This change improve performance by 3X (measured with node.js)

Instead of using array.concat when we iterate the frames (Which create
a new array + copy data from old to new for each iteration)
We are now creating a one time single array with the size of the
final array and filling it up.