### PR TITLE
fix: always calculate the earliest allowed dts using baseMediaDecodeTime

### DIFF
--- a/lib/constants/audio-properties.js
+++ b/lib/constants/audio-properties.js
@@ -1,0 +1,10 @@
+// constants
+var AUDIO_PROPERTIES = [
+  'audioobjecttype',
+  'channelcount',
+  'samplerate',
+  'samplingfrequencyindex',
+  'samplesize'
+];
+
+module.exports = AUDIO_PROPERTIES;

--- a/lib/constants/video-properties.js
+++ b/lib/constants/video-properties.js
@@ -1,0 +1,11 @@
+var VIDEO_PROPERTIES = [
+  'width',
+  'height',
+  'profileIdc',
+  'levelIdc',
+  'profileCompatibility',
+  'sarRatio'
+];
+
+
+module.exports = VIDEO_PROPERTIES;

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -132,7 +132,7 @@ AudioSegmentStream = function(track, options) {
   };
 
   this.setEarliestDts = function(earliestDts) {
-    earliestAllowedDts = earliestDts - track.timelineStartInfo.baseMediaDecodeTime;
+    earliestAllowedDts = earliestDts;
   };
 
   this.setVideoBaseMediaDecodeTime = function(baseMediaDecodeTime) {
@@ -1005,6 +1005,8 @@ Transmuxer = function(options) {
     pipeline.elementaryStream.on('data', function(data) {
       var i;
 
+      var baseMediaDecodeTime = !options.keepOriginalTimestamps ? self.baseMediaDecodeTime : 0;
+
       if (data.type === 'metadata') {
         i = data.tracks.length;
 
@@ -1012,10 +1014,10 @@ Transmuxer = function(options) {
         while (i--) {
           if (!videoTrack && data.tracks[i].type === 'video') {
             videoTrack = data.tracks[i];
-            videoTrack.timelineStartInfo.baseMediaDecodeTime = self.baseMediaDecodeTime;
+            videoTrack.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
           } else if (!audioTrack && data.tracks[i].type === 'audio') {
             audioTrack = data.tracks[i];
-            audioTrack.timelineStartInfo.baseMediaDecodeTime = self.baseMediaDecodeTime;
+            audioTrack.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
           }
         }
 
@@ -1034,7 +1036,7 @@ Transmuxer = function(options) {
               // very earliest DTS we have seen in video because Chrome will
               // interpret any video track with a baseMediaDecodeTime that is
               // non-zero as a gap.
-              pipeline.audioSegmentStream.setEarliestDts(timelineStartInfo.dts);
+              pipeline.audioSegmentStream.setEarliestDts(timelineStartInfo.dts - self.baseMediaDecodeTime);
             }
           });
 
@@ -1096,17 +1098,17 @@ Transmuxer = function(options) {
   this.setBaseMediaDecodeTime = function(baseMediaDecodeTime) {
     var pipeline = this.transmuxPipeline_;
 
+    this.baseMediaDecodeTime = baseMediaDecodeTime;
+
     if (!options.keepOriginalTimestamps) {
-      this.baseMediaDecodeTime = baseMediaDecodeTime;
+      baseMediaDecodeTime = 0;
     }
 
     if (audioTrack) {
       audioTrack.timelineStartInfo.dts = undefined;
       audioTrack.timelineStartInfo.pts = undefined;
       trackDecodeInfo.clearDtsInfo(audioTrack);
-      if (!options.keepOriginalTimestamps) {
-        audioTrack.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
-      }
+      audioTrack.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
       if (pipeline.audioTimestampRolloverStream) {
         pipeline.audioTimestampRolloverStream.discontinuity();
       }
@@ -1119,9 +1121,7 @@ Transmuxer = function(options) {
       videoTrack.timelineStartInfo.pts = undefined;
       trackDecodeInfo.clearDtsInfo(videoTrack);
       pipeline.captionStream.reset();
-      if (!options.keepOriginalTimestamps) {
-        videoTrack.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
-      }
+      videoTrack.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
     }
 
     if (pipeline.timestampRolloverStream) {

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -1100,15 +1100,10 @@ Transmuxer = function(options) {
 
     this.baseMediaDecodeTime = baseMediaDecodeTime;
 
-    if (!options.keepOriginalTimestamps) {
-      baseMediaDecodeTime = 0;
-    }
-
     if (audioTrack) {
       audioTrack.timelineStartInfo.dts = undefined;
       audioTrack.timelineStartInfo.pts = undefined;
       trackDecodeInfo.clearDtsInfo(audioTrack);
-      audioTrack.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
       if (pipeline.audioTimestampRolloverStream) {
         pipeline.audioTimestampRolloverStream.discontinuity();
       }
@@ -1121,7 +1116,6 @@ Transmuxer = function(options) {
       videoTrack.timelineStartInfo.pts = undefined;
       trackDecodeInfo.clearDtsInfo(videoTrack);
       pipeline.captionStream.reset();
-      videoTrack.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
     }
 
     if (pipeline.timestampRolloverStream) {

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -22,25 +22,8 @@ var H264Stream = require('../codecs/h264').H264Stream;
 var AacStream = require('../aac');
 var isLikelyAacData = require('../aac/utils').isLikelyAacData;
 var ONE_SECOND_IN_TS = require('../utils/clock').ONE_SECOND_IN_TS;
-
-
-// constants
-var AUDIO_PROPERTIES = [
-  'audioobjecttype',
-  'channelcount',
-  'samplerate',
-  'samplingfrequencyindex',
-  'samplesize'
-];
-
-var VIDEO_PROPERTIES = [
-  'width',
-  'height',
-  'profileIdc',
-  'levelIdc',
-  'profileCompatibility',
-  'sarRatio'
-];
+var AUDIO_PROPERTIES = require('../constants/audio-properties.js');
+var VIDEO_PROPERTIES = require('../constants/video-properties.js');
 
 // object types
 var VideoSegmentStream, AudioSegmentStream, Transmuxer, CoalesceStream;

--- a/lib/partial/audio-segment-stream.js
+++ b/lib/partial/audio-segment-stream.js
@@ -5,15 +5,7 @@ var mp4 = require('../mp4/mp4-generator.js');
 var audioFrameUtils = require('../mp4/audio-frame-utils');
 var trackInfo = require('../mp4/track-decode-info.js');
 var ONE_SECOND_IN_TS = require('../utils/clock').ONE_SECOND_IN_TS;
-
-// constants
-var AUDIO_PROPERTIES = [
-  'audioobjecttype',
-  'channelcount',
-  'samplerate',
-  'samplingfrequencyindex',
-  'samplesize'
-];
+var AUDIO_PROPERTIES = require('../constants/audio-properties.js');
 
 /**
  * Constructs a single-track, ISO BMFF media segment from AAC data

--- a/lib/partial/transmuxer.js
+++ b/lib/partial/transmuxer.js
@@ -77,7 +77,7 @@ var tsPipeline = function(options) {
 
       pipeline.videoSegmentStream.on('timelineStartInfo', function(timelineStartInfo) {
         if (pipeline.tracks.audio) {
-          pipeline.audioSegmentStream.setEarliestDts(timelineStartInfo.dts);
+          pipeline.audioSegmentStream.setEarliestDts(timelineStartInfo.dts - options.baseMediaDecodeTime);
         }
       });
 
@@ -195,7 +195,7 @@ var aacPipeline = function(options) {
 
     pipeline.tracks.audio = pipeline.tracks.audio || {
       timelineStartInfo: {
-        baseMediaDecodeTime: options.baseMediaDecodeTime
+        baseMediaDecodeTime: !options.keepOriginalTimestamps ? options.baseMediaDecodeTime : 0
       },
       codec: 'adts',
       type: 'audio'
@@ -317,8 +317,10 @@ var Transmuxer = function(options) {
   };
 
   this.setBaseMediaDecodeTime = function(baseMediaDecodeTime) {
+    options.baseMediaDecodeTime = baseMediaDecodeTime;
+
     if (!options.keepOriginalTimestamps) {
-      options.baseMediaDecodeTime = baseMediaDecodeTime;
+      baseMediaDecodeTime = 0;
     }
 
     if (!pipeline) {
@@ -329,9 +331,7 @@ var Transmuxer = function(options) {
       pipeline.tracks.audio.timelineStartInfo.dts = undefined;
       pipeline.tracks.audio.timelineStartInfo.pts = undefined;
       trackInfo.clearDtsInfo(pipeline.tracks.audio);
-      if (!options.keepOriginalTimestamps) {
-        pipeline.tracks.audio.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
-      }
+      pipeline.tracks.audio.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
       if (pipeline.audioRollover) {
         pipeline.audioRollover.discontinuity();
       }
@@ -345,9 +345,7 @@ var Transmuxer = function(options) {
       pipeline.tracks.video.timelineStartInfo.pts = undefined;
       trackInfo.clearDtsInfo(pipeline.tracks.video);
       // pipeline.captionStream.reset();
-      if (!options.keepOriginalTimestamps) {
-        pipeline.tracks.video.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
-      }
+      pipeline.tracks.video.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
     }
   };
 

--- a/lib/partial/transmuxer.js
+++ b/lib/partial/transmuxer.js
@@ -263,6 +263,8 @@ var Transmuxer = function(options) {
     pipeline = null,
     hasFlushed = true;
 
+  options = options || {};
+
   Transmuxer.prototype.init.call(this);
   options.baseMediaDecodeTime = options.baseMediaDecodeTime || 0;
 

--- a/lib/partial/transmuxer.js
+++ b/lib/partial/transmuxer.js
@@ -319,10 +319,6 @@ var Transmuxer = function(options) {
   this.setBaseMediaDecodeTime = function(baseMediaDecodeTime) {
     options.baseMediaDecodeTime = baseMediaDecodeTime;
 
-    if (!options.keepOriginalTimestamps) {
-      baseMediaDecodeTime = 0;
-    }
-
     if (!pipeline) {
       return;
     }
@@ -331,7 +327,6 @@ var Transmuxer = function(options) {
       pipeline.tracks.audio.timelineStartInfo.dts = undefined;
       pipeline.tracks.audio.timelineStartInfo.pts = undefined;
       trackInfo.clearDtsInfo(pipeline.tracks.audio);
-      pipeline.tracks.audio.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
       if (pipeline.audioRollover) {
         pipeline.audioRollover.discontinuity();
       }
@@ -345,7 +340,6 @@ var Transmuxer = function(options) {
       pipeline.tracks.video.timelineStartInfo.pts = undefined;
       trackInfo.clearDtsInfo(pipeline.tracks.video);
       // pipeline.captionStream.reset();
-      pipeline.tracks.video.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
     }
   };
 

--- a/lib/partial/transmuxer.js
+++ b/lib/partial/transmuxer.js
@@ -27,13 +27,11 @@ var tsPipeline = function(options) {
       packet: new m2ts.TransportPacketStream(),
       parse: new m2ts.TransportParseStream(),
       elementary: new m2ts.ElementaryStream(),
-      videoRollover: new m2ts.TimestampRolloverStream('video'),
-      audioRollover: new m2ts.TimestampRolloverStream('audio'),
+      timestampRollover: new m2ts.TimestampRolloverStream(),
       adts: new codecs.Adts(),
       h264: new codecs.h264.H264Stream(),
       captionStream: new m2ts.CaptionStream(),
-      metadataStream: new m2ts.MetadataStream(),
-      timedMetadataRollover: new m2ts.TimestampRolloverStream('timed-metadata')
+      metadataStream: new m2ts.MetadataStream()
   };
 
   pipeline.headOfPipeline = pipeline.packet;
@@ -41,24 +39,22 @@ var tsPipeline = function(options) {
   // Transport Stream
   pipeline.packet
     .pipe(pipeline.parse)
-    .pipe(pipeline.elementary);
+    .pipe(pipeline.elementary)
+    .pipe(pipeline.timestampRollover);
 
   // H264
-  pipeline.elementary
-    .pipe(pipeline.videoRollover)
+  pipeline.timestampRollover
     .pipe(pipeline.h264);
 
   // Hook up CEA-608/708 caption stream
   pipeline.h264
     .pipe(pipeline.captionStream);
 
-  pipeline.elementary
-    .pipe(pipeline.timedMetadataRollover)
+  pipeline.timestampRollover
     .pipe(pipeline.metadataStream);
 
   // ADTS
-  pipeline.elementary
-    .pipe(pipeline.audioRollover)
+  pipeline.timestampRollover
     .pipe(pipeline.adts);
 
   pipeline.elementary.on('data', function(data) {
@@ -336,12 +332,16 @@ var Transmuxer = function(options) {
     if (pipeline.tracks.video) {
       if (pipeline.videoSegmentStream) {
         pipeline.videoSegmentStream.gopCache_ = [];
-        pipeline.videoRollover.discontinuity();
       }
       pipeline.tracks.video.timelineStartInfo.dts = undefined;
       pipeline.tracks.video.timelineStartInfo.pts = undefined;
       trackInfo.clearDtsInfo(pipeline.tracks.video);
       // pipeline.captionStream.reset();
+    }
+
+    if (pipeline.timestampRollover) {
+      pipeline.timestampRollover.discontinuity();
+
     }
   };
 

--- a/lib/partial/video-segment-stream.js
+++ b/lib/partial/video-segment-stream.js
@@ -13,14 +13,7 @@ var Stream = require('../utils/stream.js');
 var mp4 = require('../mp4/mp4-generator.js');
 var trackInfo = require('../mp4/track-decode-info.js');
 var frameUtils = require('../mp4/frame-utils');
-
-var VIDEO_PROPERTIES = [
-  'width',
-  'height',
-  'profileIdc',
-  'levelIdc',
-  'profileCompatibility'
-];
+var VIDEO_PROPERTIES = require('../constants/video-properties.js');
 
 var VideoSegmentStream = function(track, options) {
   var

--- a/test/partial.test.js
+++ b/test/partial.test.js
@@ -7,365 +7,130 @@ var packetize = utils.packetize;
 var PAT = utils.PAT;
 
 QUnit.module('Partial Transmuxer - Options');
-QUnit.test('Audio frames trimmed before video, keepOriginalTimestamps = false', function() {
-  var
-    segments = [],
-    earliestDts = 15000,
-    transmuxer = new Transmuxer({
-      keepOriginalTimestamps: false
-    });
+[
+  {options: {keepOriginalTimestamps: false}},
+  {options: {keepOriginalTimestamps: true}},
+  {options: {keepOriginalTimestamps: false, baseMediaDecodeTime: 15000}},
+  {options: {keepOriginalTimestamps: true, baseMediaDecodeTime: 15000}},
+  {options: {keepOriginalTimestamps: false}, baseMediaSetter: 15000},
+  {options: {keepOriginalTimestamps: true}, baseMediaSetter: 15000}
+].forEach(function(test) {
+  var createTransmuxer = function() {
+    var transmuxer = new Transmuxer(test.options);
 
-  transmuxer.on('data', function(segment) {
-    segments.push(segment);
+    if (test.baseMediaSetter) {
+      transmuxer.setBaseMediaDecodeTime(test.baseMediaSetter);
+    }
+
+    return transmuxer;
+  };
+
+  var name = '';
+
+  Object.keys(test.options).forEach(function(optionName) {
+    name += '' + optionName + ' ' + test.options[optionName] + ' ';
   });
 
-  transmuxer.push(packetize(PAT));
-  transmuxer.push(packetize(generatePMT({
-    hasVideo: true,
-    hasAudio: true
-  })));
+  if (test.baseMediaSetter) {
+    name += 'baseMediaDecodeTime setter ' + test.baseMediaSetter;
+  }
 
-  transmuxer.push(packetize(audioPes([
-    0x19, 0x47
-  ], true, earliestDts - 1)));
-
-  transmuxer.push(packetize(videoPes([
-      0x09, 0x01 // access_unit_delimiter_rbsp
-  ], true, earliestDts)));
-  transmuxer.push(packetize(videoPes([
-      0x08, 0x01 // pic_parameter_set_rbsp
-  ], true, earliestDts)));
-  transmuxer.push(packetize(videoPes([
-    0x07, // seq_parameter_set_rbsp
-    0x27, 0x42, 0xe0, 0x0b,
-    0xa9, 0x18, 0x60, 0x9d,
-    0x80, 0x53, 0x06, 0x01,
-    0x06, 0xb6, 0xc2, 0xb5,
-    0xef, 0x7c, 0x04
-  ], false, earliestDts)));
-  transmuxer.push(packetize(videoPes([
-      0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
-  ], true, earliestDts)));
-
-  transmuxer.flush();
-
-  QUnit.equal(segments.length, 1, 'generated only a video segment');
-});
-
-QUnit.test('Audio frames trimmed before video, keepOriginalTimestamps = true', function() {
-  var
+  QUnit.test('Audio frames after video not trimmed, ' + name, function() {
+    var
     segments = [],
-    earliestDts = 15000,
-    transmuxer = new Transmuxer({
-      keepOriginalTimestamps: true
+      earliestDts = 15000,
+      transmuxer = createTransmuxer();
+
+    transmuxer.on('data', function(segment) {
+      segments.push(segment);
     });
 
-  transmuxer.on('data', function(segment) {
-    segments.push(segment);
+    // the following transmuxer pushes add tiny video and
+    // audio data to the transmuxer. When we add the data
+    // we also set the pts/dts time so that audio should
+    // not be trimmed.
+    transmuxer.push(packetize(PAT));
+    transmuxer.push(packetize(generatePMT({
+      hasVideo: true,
+      hasAudio: true
+    })));
+
+    transmuxer.push(packetize(audioPes([
+      0x19, 0x47
+    ], true, earliestDts + 1)));
+    transmuxer.push(packetize(videoPes([
+      0x09, 0x01 // access_unit_delimiter_rbsp
+    ], true, earliestDts)));
+    transmuxer.push(packetize(videoPes([
+      0x08, 0x01 // pic_parameter_set_rbsp
+    ], true, earliestDts)));
+    transmuxer.push(packetize(videoPes([
+      0x07, // seq_parameter_set_rbsp
+      0x27, 0x42, 0xe0, 0x0b,
+      0xa9, 0x18, 0x60, 0x9d,
+      0x80, 0x53, 0x06, 0x01,
+      0x06, 0xb6, 0xc2, 0xb5,
+      0xef, 0x7c, 0x04
+    ], false, earliestDts)));
+    transmuxer.push(packetize(videoPes([
+      0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
+    ], true, earliestDts)));
+    transmuxer.flush();
+
+    // the partial transmuxer only generates a video segment
+    // when all audio frames are trimmed. So we should have an audio and video
+    // segment
+    QUnit.equal(segments.length, 2, 'generated a video and an audio segment');
+    QUnit.equal(segments[0].type, 'video', 'video segment exists');
+    QUnit.equal(segments[1].type, 'audio', 'audio segment exists');
   });
 
-  transmuxer.push(packetize(PAT));
-  transmuxer.push(packetize(generatePMT({
-    hasVideo: true,
-    hasAudio: true
-  })));
-
-  transmuxer.push(packetize(audioPes([
-    0x19, 0x47
-  ], true, earliestDts - 1)));
-  transmuxer.push(packetize(videoPes([
-      0x09, 0x01 // access_unit_delimiter_rbsp
-  ], true, earliestDts)));
-  transmuxer.push(packetize(videoPes([
-      0x08, 0x01 // pic_parameter_set_rbsp
-  ], true, earliestDts)));
-  transmuxer.push(packetize(videoPes([
-    0x07, // seq_parameter_set_rbsp
-    0x27, 0x42, 0xe0, 0x0b,
-    0xa9, 0x18, 0x60, 0x9d,
-    0x80, 0x53, 0x06, 0x01,
-    0x06, 0xb6, 0xc2, 0xb5,
-    0xef, 0x7c, 0x04
-  ], false, earliestDts)));
-  transmuxer.push(packetize(videoPes([
-      0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
-  ], true, earliestDts)));
-  transmuxer.flush();
-
-  QUnit.equal(segments.length, 1, 'generated only a video segment');
-});
-
-QUnit.test('Audio frames after video not trimmed, keepOriginalTimestamps = false', function() {
-  var
+  QUnit.test('Audio frames trimmed before video, ' + name, function() {
+    var
     segments = [],
-    earliestDts = 15000,
-    transmuxer = new Transmuxer({
-      keepOriginalTimestamps: false
+      earliestDts = 15000,
+      transmuxer = createTransmuxer();
+
+    transmuxer.on('data', function(segment) {
+      segments.push(segment);
     });
 
-  transmuxer.on('data', function(segment) {
-    segments.push(segment);
-  });
+    // the following transmuxer pushes add tiny video and
+    // audio data to the transmuxer. When we add the data
+    // we also set the pts/dts time so that audio should
+    // be trimmed.
+    transmuxer.push(packetize(PAT));
+    transmuxer.push(packetize(generatePMT({
+      hasVideo: true,
+      hasAudio: true
+    })));
 
-  transmuxer.push(packetize(PAT));
-  transmuxer.push(packetize(generatePMT({
-    hasVideo: true,
-    hasAudio: true
-  })));
-
-  transmuxer.push(packetize(audioPes([
-    0x19, 0x47
-  ], true, earliestDts + 1)));
-  transmuxer.push(packetize(videoPes([
+    transmuxer.push(packetize(audioPes([
+      0x19, 0x47
+    ], true, earliestDts - (test.options.baseMediaDecodeTime || test.baseMediaSetter || 0) - 1)));
+    transmuxer.push(packetize(videoPes([
       0x09, 0x01 // access_unit_delimiter_rbsp
-  ], true, earliestDts)));
-  transmuxer.push(packetize(videoPes([
+    ], true, earliestDts)));
+    transmuxer.push(packetize(videoPes([
       0x08, 0x01 // pic_parameter_set_rbsp
-  ], true, earliestDts)));
-  transmuxer.push(packetize(videoPes([
-    0x07, // seq_parameter_set_rbsp
-    0x27, 0x42, 0xe0, 0x0b,
-    0xa9, 0x18, 0x60, 0x9d,
-    0x80, 0x53, 0x06, 0x01,
-    0x06, 0xb6, 0xc2, 0xb5,
-    0xef, 0x7c, 0x04
-  ], false, earliestDts)));
-  transmuxer.push(packetize(videoPes([
+    ], true, earliestDts)));
+    transmuxer.push(packetize(videoPes([
+      0x07, // seq_parameter_set_rbsp
+      0x27, 0x42, 0xe0, 0x0b,
+      0xa9, 0x18, 0x60, 0x9d,
+      0x80, 0x53, 0x06, 0x01,
+      0x06, 0xb6, 0xc2, 0xb5,
+      0xef, 0x7c, 0x04
+    ], false, earliestDts)));
+    transmuxer.push(packetize(videoPes([
       0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
-  ], true, earliestDts)));
-  transmuxer.flush();
+    ], true, earliestDts)));
+    transmuxer.flush();
 
-  QUnit.equal(segments.length, 2, 'generated a video and an audio segment');
-  QUnit.equal(segments[1].data.boxes.length, 122, 'trimmed audio frame');
-});
-
-QUnit.test('Audio frames after video not trimmed, keepOriginalTimestamps = true', function() {
-  var
-    segments = [],
-    earliestDts = 15000,
-    transmuxer = new Transmuxer({
-      keepOriginalTimestamps: true
-    });
-
-  transmuxer.on('data', function(segment) {
-    segments.push(segment);
+    // the partial transmuxer only generates a video segment
+    // when all audio frames are trimmed. So we should only have
+    // a video segment
+    QUnit.equal(segments.length, 1, 'generated only a video segment');
+    QUnit.equal(segments[0].type, 'video', 'segment is video');
   });
-
-  transmuxer.push(packetize(PAT));
-  transmuxer.push(packetize(generatePMT({
-    hasVideo: true,
-    hasAudio: true
-  })));
-
-  transmuxer.push(packetize(audioPes([
-    0x19, 0x47
-  ], true, earliestDts + 1)));
-  transmuxer.push(packetize(videoPes([
-      0x09, 0x01 // access_unit_delimiter_rbsp
-  ], true, earliestDts)));
-  transmuxer.push(packetize(videoPes([
-      0x08, 0x01 // pic_parameter_set_rbsp
-  ], true, earliestDts)));
-  transmuxer.push(packetize(videoPes([
-    0x07, // seq_parameter_set_rbsp
-    0x27, 0x42, 0xe0, 0x0b,
-    0xa9, 0x18, 0x60, 0x9d,
-    0x80, 0x53, 0x06, 0x01,
-    0x06, 0xb6, 0xc2, 0xb5,
-    0xef, 0x7c, 0x04
-  ], false, earliestDts)));
-  transmuxer.push(packetize(videoPes([
-      0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
-  ], true, earliestDts)));
-  transmuxer.flush();
-
-  QUnit.equal(segments.length, 2, 'generated a video and an audio segment');
-  QUnit.equal(segments[1].data.boxes.length, 122, 'trimmed audio frame');
 });
-
-QUnit.test('Audio frames after video not trimmed, keepOriginalTimestamps = false, baseMediaDecodeTime option', function() {
-  var
-    segments = [],
-    earliestDts = 15000,
-    baseMediaDecodeTime = 15000,
-    transmuxer = new Transmuxer({
-      keepOriginalTimestamps: false,
-      baseMediaDecodeTime: baseMediaDecodeTime
-    });
-
-  transmuxer.on('data', function(segment) {
-    segments.push(segment);
-  });
-
-  transmuxer.push(packetize(PAT));
-  transmuxer.push(packetize(generatePMT({
-    hasVideo: true,
-    hasAudio: true
-  })));
-
-  transmuxer.push(packetize(audioPes([
-    0x19, 0x47
-  ], true, earliestDts + 1)));
-  transmuxer.push(packetize(videoPes([
-      0x09, 0x01 // access_unit_delimiter_rbsp
-  ], true, earliestDts + baseMediaDecodeTime)));
-  transmuxer.push(packetize(videoPes([
-      0x08, 0x01 // pic_parameter_set_rbsp
-  ], true, earliestDts + baseMediaDecodeTime)));
-  transmuxer.push(packetize(videoPes([
-    0x07, // seq_parameter_set_rbsp
-    0x27, 0x42, 0xe0, 0x0b,
-    0xa9, 0x18, 0x60, 0x9d,
-    0x80, 0x53, 0x06, 0x01,
-    0x06, 0xb6, 0xc2, 0xb5,
-    0xef, 0x7c, 0x04
-  ], false, earliestDts + baseMediaDecodeTime)));
-  transmuxer.push(packetize(videoPes([
-      0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
-  ], true, earliestDts + baseMediaDecodeTime)));
-  transmuxer.flush();
-
-  QUnit.equal(segments.length, 2, 'generated a video and an audio segment');
-  QUnit.equal(segments[1].data.boxes.length, 122, 'trimmed audio frame');
-});
-
-QUnit.test('Audio frames after video not trimmed, keepOriginalTimestamps = true, baseMediaDecodeTime option', function() {
-  var
-    segments = [],
-    earliestDts = 15000,
-    baseMediaDecodeTime = 15000,
-    transmuxer = new Transmuxer({
-      keepOriginalTimestamps: true,
-      baseMediaDecodeTime: baseMediaDecodeTime
-    });
-
-  transmuxer.on('data', function(segment) {
-    segments.push(segment);
-  });
-
-  transmuxer.push(packetize(PAT));
-  transmuxer.push(packetize(generatePMT({
-    hasVideo: true,
-    hasAudio: true
-  })));
-
-  transmuxer.push(packetize(audioPes([
-    0x19, 0x47
-  ], true, earliestDts + 1)));
-  transmuxer.push(packetize(videoPes([
-      0x09, 0x01 // access_unit_delimiter_rbsp
-  ], true, earliestDts + baseMediaDecodeTime)));
-  transmuxer.push(packetize(videoPes([
-      0x08, 0x01 // pic_parameter_set_rbsp
-  ], true, earliestDts + baseMediaDecodeTime)));
-  transmuxer.push(packetize(videoPes([
-    0x07, // seq_parameter_set_rbsp
-    0x27, 0x42, 0xe0, 0x0b,
-    0xa9, 0x18, 0x60, 0x9d,
-    0x80, 0x53, 0x06, 0x01,
-    0x06, 0xb6, 0xc2, 0xb5,
-    0xef, 0x7c, 0x04
-  ], false, earliestDts + baseMediaDecodeTime)));
-  transmuxer.push(packetize(videoPes([
-      0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
-  ], true, earliestDts + baseMediaDecodeTime)));
-  transmuxer.flush();
-
-  QUnit.equal(segments.length, 2, 'generated a video and an audio segment');
-  QUnit.equal(segments[1].data.boxes.length, 122, 'trimmed audio frame');
-});
-
-QUnit.test('Audio frames after video not trimmed, keepOriginalTimestamps = false, baseMediaDecodeTime setter', function() {
-  var
-    segments = [],
-    earliestDts = 15000,
-    baseMediaDecodeTime = 15000,
-    transmuxer = new Transmuxer({
-      keepOriginalTimestamps: false
-    });
-
-  transmuxer.setBaseMediaDecodeTime(baseMediaDecodeTime);
-
-  transmuxer.on('data', function(segment) {
-    segments.push(segment);
-  });
-
-  transmuxer.push(packetize(PAT));
-  transmuxer.push(packetize(generatePMT({
-    hasVideo: true,
-    hasAudio: true
-  })));
-
-  transmuxer.push(packetize(audioPes([
-    0x19, 0x47
-  ], true, earliestDts + 1)));
-  transmuxer.push(packetize(videoPes([
-      0x09, 0x01 // access_unit_delimiter_rbsp
-  ], true, earliestDts + baseMediaDecodeTime)));
-  transmuxer.push(packetize(videoPes([
-      0x08, 0x01 // pic_parameter_set_rbsp
-  ], true, earliestDts + baseMediaDecodeTime)));
-  transmuxer.push(packetize(videoPes([
-    0x07, // seq_parameter_set_rbsp
-    0x27, 0x42, 0xe0, 0x0b,
-    0xa9, 0x18, 0x60, 0x9d,
-    0x80, 0x53, 0x06, 0x01,
-    0x06, 0xb6, 0xc2, 0xb5,
-    0xef, 0x7c, 0x04
-  ], false, earliestDts + baseMediaDecodeTime)));
-  transmuxer.push(packetize(videoPes([
-      0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
-  ], true, earliestDts + baseMediaDecodeTime)));
-  transmuxer.flush();
-
-  QUnit.equal(segments.length, 2, 'generated a video and an audio segment');
-  QUnit.equal(segments[1].data.boxes.length, 122, 'trimmed audio frame');
-});
-
-QUnit.test('Audio frames after video not trimmed, keepOriginalTimestamps = true, baseMediaDecodeTime setter', function() {
-  var
-    segments = [],
-    earliestDts = 15000,
-    baseMediaDecodeTime = 15000,
-    transmuxer = new Transmuxer({
-      keepOriginalTimestamps: true
-    });
-
-  transmuxer.setBaseMediaDecodeTime(baseMediaDecodeTime);
-
-  transmuxer.on('data', function(segment) {
-    segments.push(segment);
-  });
-
-  transmuxer.push(packetize(PAT));
-  transmuxer.push(packetize(generatePMT({
-    hasVideo: true,
-    hasAudio: true
-  })));
-
-  transmuxer.push(packetize(audioPes([
-    0x19, 0x47
-  ], true, earliestDts + 1)));
-  transmuxer.push(packetize(videoPes([
-      0x09, 0x01 // access_unit_delimiter_rbsp
-  ], true, earliestDts + baseMediaDecodeTime)));
-  transmuxer.push(packetize(videoPes([
-      0x08, 0x01 // pic_parameter_set_rbsp
-  ], true, earliestDts + baseMediaDecodeTime)));
-  transmuxer.push(packetize(videoPes([
-    0x07, // seq_parameter_set_rbsp
-    0x27, 0x42, 0xe0, 0x0b,
-    0xa9, 0x18, 0x60, 0x9d,
-    0x80, 0x53, 0x06, 0x01,
-    0x06, 0xb6, 0xc2, 0xb5,
-    0xef, 0x7c, 0x04
-  ], false, earliestDts + baseMediaDecodeTime)));
-  transmuxer.push(packetize(videoPes([
-      0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
-  ], true, earliestDts + baseMediaDecodeTime)));
-  transmuxer.flush();
-
-  QUnit.equal(segments.length, 2, 'generated a video and an audio segment');
-  QUnit.equal(segments[1].data.boxes.length, 122, 'trimmed audio frame');
-});
-

--- a/test/partial.test.js
+++ b/test/partial.test.js
@@ -1,0 +1,371 @@
+var Transmuxer = require('../lib/partial/transmuxer.js');
+var utils = require('./utils');
+var generatePMT = utils.generatePMT;
+var videoPes = utils.videoPes;
+var audioPes = utils.audioPes;
+var packetize = utils.packetize;
+var PAT = utils.PAT;
+
+QUnit.module('Partial Transmuxer - Options');
+QUnit.test('Audio frames trimmed before video, keepOriginalTimestamps = false', function() {
+  var
+    segments = [],
+    earliestDts = 15000,
+    transmuxer = new Transmuxer({
+      keepOriginalTimestamps: false
+    });
+
+  transmuxer.on('data', function(segment) {
+    segments.push(segment);
+  });
+
+  transmuxer.push(packetize(PAT));
+  transmuxer.push(packetize(generatePMT({
+    hasVideo: true,
+    hasAudio: true
+  })));
+
+  transmuxer.push(packetize(audioPes([
+    0x19, 0x47
+  ], true, earliestDts - 1)));
+
+  transmuxer.push(packetize(videoPes([
+      0x09, 0x01 // access_unit_delimiter_rbsp
+  ], true, earliestDts)));
+  transmuxer.push(packetize(videoPes([
+      0x08, 0x01 // pic_parameter_set_rbsp
+  ], true, earliestDts)));
+  transmuxer.push(packetize(videoPes([
+    0x07, // seq_parameter_set_rbsp
+    0x27, 0x42, 0xe0, 0x0b,
+    0xa9, 0x18, 0x60, 0x9d,
+    0x80, 0x53, 0x06, 0x01,
+    0x06, 0xb6, 0xc2, 0xb5,
+    0xef, 0x7c, 0x04
+  ], false, earliestDts)));
+  transmuxer.push(packetize(videoPes([
+      0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
+  ], true, earliestDts)));
+
+  transmuxer.flush();
+
+  QUnit.equal(segments.length, 1, 'generated only a video segment');
+});
+
+QUnit.test('Audio frames trimmed before video, keepOriginalTimestamps = true', function() {
+  var
+    segments = [],
+    earliestDts = 15000,
+    transmuxer = new Transmuxer({
+      keepOriginalTimestamps: true
+    });
+
+  transmuxer.on('data', function(segment) {
+    segments.push(segment);
+  });
+
+  transmuxer.push(packetize(PAT));
+  transmuxer.push(packetize(generatePMT({
+    hasVideo: true,
+    hasAudio: true
+  })));
+
+  transmuxer.push(packetize(audioPes([
+    0x19, 0x47
+  ], true, earliestDts - 1)));
+  transmuxer.push(packetize(videoPes([
+      0x09, 0x01 // access_unit_delimiter_rbsp
+  ], true, earliestDts)));
+  transmuxer.push(packetize(videoPes([
+      0x08, 0x01 // pic_parameter_set_rbsp
+  ], true, earliestDts)));
+  transmuxer.push(packetize(videoPes([
+    0x07, // seq_parameter_set_rbsp
+    0x27, 0x42, 0xe0, 0x0b,
+    0xa9, 0x18, 0x60, 0x9d,
+    0x80, 0x53, 0x06, 0x01,
+    0x06, 0xb6, 0xc2, 0xb5,
+    0xef, 0x7c, 0x04
+  ], false, earliestDts)));
+  transmuxer.push(packetize(videoPes([
+      0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
+  ], true, earliestDts)));
+  transmuxer.flush();
+
+  QUnit.equal(segments.length, 1, 'generated only a video segment');
+});
+
+QUnit.test('Audio frames after video not trimmed, keepOriginalTimestamps = false', function() {
+  var
+    segments = [],
+    earliestDts = 15000,
+    transmuxer = new Transmuxer({
+      keepOriginalTimestamps: false
+    });
+
+  transmuxer.on('data', function(segment) {
+    segments.push(segment);
+  });
+
+  transmuxer.push(packetize(PAT));
+  transmuxer.push(packetize(generatePMT({
+    hasVideo: true,
+    hasAudio: true
+  })));
+
+  transmuxer.push(packetize(audioPes([
+    0x19, 0x47
+  ], true, earliestDts + 1)));
+  transmuxer.push(packetize(videoPes([
+      0x09, 0x01 // access_unit_delimiter_rbsp
+  ], true, earliestDts)));
+  transmuxer.push(packetize(videoPes([
+      0x08, 0x01 // pic_parameter_set_rbsp
+  ], true, earliestDts)));
+  transmuxer.push(packetize(videoPes([
+    0x07, // seq_parameter_set_rbsp
+    0x27, 0x42, 0xe0, 0x0b,
+    0xa9, 0x18, 0x60, 0x9d,
+    0x80, 0x53, 0x06, 0x01,
+    0x06, 0xb6, 0xc2, 0xb5,
+    0xef, 0x7c, 0x04
+  ], false, earliestDts)));
+  transmuxer.push(packetize(videoPes([
+      0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
+  ], true, earliestDts)));
+  transmuxer.flush();
+
+  QUnit.equal(segments.length, 2, 'generated a video and an audio segment');
+  QUnit.equal(segments[1].data.boxes.length, 122, 'trimmed audio frame');
+});
+
+QUnit.test('Audio frames after video not trimmed, keepOriginalTimestamps = true', function() {
+  var
+    segments = [],
+    earliestDts = 15000,
+    transmuxer = new Transmuxer({
+      keepOriginalTimestamps: true
+    });
+
+  transmuxer.on('data', function(segment) {
+    segments.push(segment);
+  });
+
+  transmuxer.push(packetize(PAT));
+  transmuxer.push(packetize(generatePMT({
+    hasVideo: true,
+    hasAudio: true
+  })));
+
+  transmuxer.push(packetize(audioPes([
+    0x19, 0x47
+  ], true, earliestDts + 1)));
+  transmuxer.push(packetize(videoPes([
+      0x09, 0x01 // access_unit_delimiter_rbsp
+  ], true, earliestDts)));
+  transmuxer.push(packetize(videoPes([
+      0x08, 0x01 // pic_parameter_set_rbsp
+  ], true, earliestDts)));
+  transmuxer.push(packetize(videoPes([
+    0x07, // seq_parameter_set_rbsp
+    0x27, 0x42, 0xe0, 0x0b,
+    0xa9, 0x18, 0x60, 0x9d,
+    0x80, 0x53, 0x06, 0x01,
+    0x06, 0xb6, 0xc2, 0xb5,
+    0xef, 0x7c, 0x04
+  ], false, earliestDts)));
+  transmuxer.push(packetize(videoPes([
+      0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
+  ], true, earliestDts)));
+  transmuxer.flush();
+
+  QUnit.equal(segments.length, 2, 'generated a video and an audio segment');
+  QUnit.equal(segments[1].data.boxes.length, 122, 'trimmed audio frame');
+});
+
+QUnit.test('Audio frames after video not trimmed, keepOriginalTimestamps = false, baseMediaDecodeTime option', function() {
+  var
+    segments = [],
+    earliestDts = 15000,
+    baseMediaDecodeTime = 15000,
+    transmuxer = new Transmuxer({
+      keepOriginalTimestamps: false,
+      baseMediaDecodeTime: baseMediaDecodeTime
+    });
+
+  transmuxer.on('data', function(segment) {
+    segments.push(segment);
+  });
+
+  transmuxer.push(packetize(PAT));
+  transmuxer.push(packetize(generatePMT({
+    hasVideo: true,
+    hasAudio: true
+  })));
+
+  transmuxer.push(packetize(audioPes([
+    0x19, 0x47
+  ], true, earliestDts + 1)));
+  transmuxer.push(packetize(videoPes([
+      0x09, 0x01 // access_unit_delimiter_rbsp
+  ], true, earliestDts + baseMediaDecodeTime)));
+  transmuxer.push(packetize(videoPes([
+      0x08, 0x01 // pic_parameter_set_rbsp
+  ], true, earliestDts + baseMediaDecodeTime)));
+  transmuxer.push(packetize(videoPes([
+    0x07, // seq_parameter_set_rbsp
+    0x27, 0x42, 0xe0, 0x0b,
+    0xa9, 0x18, 0x60, 0x9d,
+    0x80, 0x53, 0x06, 0x01,
+    0x06, 0xb6, 0xc2, 0xb5,
+    0xef, 0x7c, 0x04
+  ], false, earliestDts + baseMediaDecodeTime)));
+  transmuxer.push(packetize(videoPes([
+      0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
+  ], true, earliestDts + baseMediaDecodeTime)));
+  transmuxer.flush();
+
+  QUnit.equal(segments.length, 2, 'generated a video and an audio segment');
+  QUnit.equal(segments[1].data.boxes.length, 122, 'trimmed audio frame');
+});
+
+QUnit.test('Audio frames after video not trimmed, keepOriginalTimestamps = true, baseMediaDecodeTime option', function() {
+  var
+    segments = [],
+    earliestDts = 15000,
+    baseMediaDecodeTime = 15000,
+    transmuxer = new Transmuxer({
+      keepOriginalTimestamps: true,
+      baseMediaDecodeTime: baseMediaDecodeTime
+    });
+
+  transmuxer.on('data', function(segment) {
+    segments.push(segment);
+  });
+
+  transmuxer.push(packetize(PAT));
+  transmuxer.push(packetize(generatePMT({
+    hasVideo: true,
+    hasAudio: true
+  })));
+
+  transmuxer.push(packetize(audioPes([
+    0x19, 0x47
+  ], true, earliestDts + 1)));
+  transmuxer.push(packetize(videoPes([
+      0x09, 0x01 // access_unit_delimiter_rbsp
+  ], true, earliestDts + baseMediaDecodeTime)));
+  transmuxer.push(packetize(videoPes([
+      0x08, 0x01 // pic_parameter_set_rbsp
+  ], true, earliestDts + baseMediaDecodeTime)));
+  transmuxer.push(packetize(videoPes([
+    0x07, // seq_parameter_set_rbsp
+    0x27, 0x42, 0xe0, 0x0b,
+    0xa9, 0x18, 0x60, 0x9d,
+    0x80, 0x53, 0x06, 0x01,
+    0x06, 0xb6, 0xc2, 0xb5,
+    0xef, 0x7c, 0x04
+  ], false, earliestDts + baseMediaDecodeTime)));
+  transmuxer.push(packetize(videoPes([
+      0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
+  ], true, earliestDts + baseMediaDecodeTime)));
+  transmuxer.flush();
+
+  QUnit.equal(segments.length, 2, 'generated a video and an audio segment');
+  QUnit.equal(segments[1].data.boxes.length, 122, 'trimmed audio frame');
+});
+
+QUnit.test('Audio frames after video not trimmed, keepOriginalTimestamps = false, baseMediaDecodeTime setter', function() {
+  var
+    segments = [],
+    earliestDts = 15000,
+    baseMediaDecodeTime = 15000,
+    transmuxer = new Transmuxer({
+      keepOriginalTimestamps: false
+    });
+
+  transmuxer.setBaseMediaDecodeTime(baseMediaDecodeTime);
+
+  transmuxer.on('data', function(segment) {
+    segments.push(segment);
+  });
+
+  transmuxer.push(packetize(PAT));
+  transmuxer.push(packetize(generatePMT({
+    hasVideo: true,
+    hasAudio: true
+  })));
+
+  transmuxer.push(packetize(audioPes([
+    0x19, 0x47
+  ], true, earliestDts + 1)));
+  transmuxer.push(packetize(videoPes([
+      0x09, 0x01 // access_unit_delimiter_rbsp
+  ], true, earliestDts + baseMediaDecodeTime)));
+  transmuxer.push(packetize(videoPes([
+      0x08, 0x01 // pic_parameter_set_rbsp
+  ], true, earliestDts + baseMediaDecodeTime)));
+  transmuxer.push(packetize(videoPes([
+    0x07, // seq_parameter_set_rbsp
+    0x27, 0x42, 0xe0, 0x0b,
+    0xa9, 0x18, 0x60, 0x9d,
+    0x80, 0x53, 0x06, 0x01,
+    0x06, 0xb6, 0xc2, 0xb5,
+    0xef, 0x7c, 0x04
+  ], false, earliestDts + baseMediaDecodeTime)));
+  transmuxer.push(packetize(videoPes([
+      0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
+  ], true, earliestDts + baseMediaDecodeTime)));
+  transmuxer.flush();
+
+  QUnit.equal(segments.length, 2, 'generated a video and an audio segment');
+  QUnit.equal(segments[1].data.boxes.length, 122, 'trimmed audio frame');
+});
+
+QUnit.test('Audio frames after video not trimmed, keepOriginalTimestamps = true, baseMediaDecodeTime setter', function() {
+  var
+    segments = [],
+    earliestDts = 15000,
+    baseMediaDecodeTime = 15000,
+    transmuxer = new Transmuxer({
+      keepOriginalTimestamps: true
+    });
+
+  transmuxer.setBaseMediaDecodeTime(baseMediaDecodeTime);
+
+  transmuxer.on('data', function(segment) {
+    segments.push(segment);
+  });
+
+  transmuxer.push(packetize(PAT));
+  transmuxer.push(packetize(generatePMT({
+    hasVideo: true,
+    hasAudio: true
+  })));
+
+  transmuxer.push(packetize(audioPes([
+    0x19, 0x47
+  ], true, earliestDts + 1)));
+  transmuxer.push(packetize(videoPes([
+      0x09, 0x01 // access_unit_delimiter_rbsp
+  ], true, earliestDts + baseMediaDecodeTime)));
+  transmuxer.push(packetize(videoPes([
+      0x08, 0x01 // pic_parameter_set_rbsp
+  ], true, earliestDts + baseMediaDecodeTime)));
+  transmuxer.push(packetize(videoPes([
+    0x07, // seq_parameter_set_rbsp
+    0x27, 0x42, 0xe0, 0x0b,
+    0xa9, 0x18, 0x60, 0x9d,
+    0x80, 0x53, 0x06, 0x01,
+    0x06, 0xb6, 0xc2, 0xb5,
+    0xef, 0x7c, 0x04
+  ], false, earliestDts + baseMediaDecodeTime)));
+  transmuxer.push(packetize(videoPes([
+      0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
+  ], true, earliestDts + baseMediaDecodeTime)));
+  transmuxer.flush();
+
+  QUnit.equal(segments.length, 2, 'generated a video and an audio segment');
+  QUnit.equal(segments[1].data.boxes.length, 122, 'trimmed audio frame');
+});
+

--- a/test/transmuxer.test.js
+++ b/test/transmuxer.test.js
@@ -3170,7 +3170,7 @@ QUnit.test('ensures baseMediaDecodeTime for audio is not negative', function() {
     events.push(event);
   });
   audioSegmentStream.track.timelineStartInfo.baseMediaDecodeTime = 10;
-  audioSegmentStream.setEarliestDts(111);
+  audioSegmentStream.setEarliestDts(101);
   audioSegmentStream.push({
     channelcount: 2,
     samplerate: 90e3,

--- a/test/transmuxer.test.js
+++ b/test/transmuxer.test.js
@@ -3408,6 +3408,416 @@ QUnit.test('adjusts caption and ID3 times when configured to adjust timestamps',
   QUnit.equal(captions[0].endTime, (90004 - 90002) / 90e3, 'caption end time are based on original timeline');
 });
 
+QUnit.test('Audio frames trimmed before video, keepOriginalTimestamps = false', function() {
+  var
+    segments = [],
+    segmentLengthOnDone,
+    earliestDts = 15000,
+    transmuxer = new Transmuxer({
+      keepOriginalTimestamps: false
+    });
+
+  transmuxer.on('data', function(segment) {
+    segments.push(segment);
+  });
+  transmuxer.on('done', function(segment) {
+    if (!segmentLengthOnDone) {
+      segmentLengthOnDone = segments.length;
+    }
+  });
+
+  transmuxer.push(packetize(PAT));
+  transmuxer.push(packetize(generatePMT({
+    hasVideo: true,
+    hasAudio: true
+  })));
+
+  transmuxer.push(packetize(audioPes([
+    0x19, 0x47
+  ], true, earliestDts - 1)));
+  transmuxer.push(packetize(videoPes([
+      0x09, 0x01 // access_unit_delimiter_rbsp
+  ], true, earliestDts)));
+  transmuxer.push(packetize(videoPes([
+      0x08, 0x01 // pic_parameter_set_rbsp
+  ], true, earliestDts)));
+  transmuxer.push(packetize(videoPes([
+    0x07, // seq_parameter_set_rbsp
+    0x27, 0x42, 0xe0, 0x0b,
+    0xa9, 0x18, 0x60, 0x9d,
+    0x80, 0x53, 0x06, 0x01,
+    0x06, 0xb6, 0xc2, 0xb5,
+    0xef, 0x7c, 0x04
+  ], false, earliestDts)));
+  transmuxer.push(packetize(videoPes([
+      0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
+  ], true, earliestDts)));
+  transmuxer.flush();
+
+  QUnit.equal(segments.length, 1, 'generated a combined segment');
+  QUnit.equal(segments[0].data.length, 295, 'trimmed audio frame');
+});
+
+QUnit.test('Audio frames trimmed before video, keepOriginalTimestamps = true', function() {
+  var
+    segments = [],
+    segmentLengthOnDone,
+    earliestDts = 15000,
+    transmuxer = new Transmuxer({
+      keepOriginalTimestamps: true
+    });
+
+  transmuxer.on('data', function(segment) {
+    segments.push(segment);
+  });
+  transmuxer.on('done', function(segment) {
+    if (!segmentLengthOnDone) {
+      segmentLengthOnDone = segments.length;
+    }
+  });
+
+  transmuxer.push(packetize(PAT));
+  transmuxer.push(packetize(generatePMT({
+    hasVideo: true,
+    hasAudio: true
+  })));
+
+  transmuxer.push(packetize(audioPes([
+    0x19, 0x47
+  ], true, earliestDts - 1)));
+  transmuxer.push(packetize(videoPes([
+      0x09, 0x01 // access_unit_delimiter_rbsp
+  ], true, earliestDts)));
+  transmuxer.push(packetize(videoPes([
+      0x08, 0x01 // pic_parameter_set_rbsp
+  ], true, earliestDts)));
+  transmuxer.push(packetize(videoPes([
+    0x07, // seq_parameter_set_rbsp
+    0x27, 0x42, 0xe0, 0x0b,
+    0xa9, 0x18, 0x60, 0x9d,
+    0x80, 0x53, 0x06, 0x01,
+    0x06, 0xb6, 0xc2, 0xb5,
+    0xef, 0x7c, 0x04
+  ], false, earliestDts)));
+  transmuxer.push(packetize(videoPes([
+      0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
+  ], true, earliestDts)));
+  transmuxer.flush();
+
+  QUnit.equal(segments.length, 1, 'generated a combined segment');
+  QUnit.equal(segments[0].data.length, 295, 'trimmed audio frame');
+});
+
+QUnit.test('Audio frames after video not trimmed, keepOriginalTimestamps = false', function() {
+  var
+    segments = [],
+    segmentLengthOnDone,
+    earliestDts = 15000,
+    transmuxer = new Transmuxer({
+      keepOriginalTimestamps: false
+    });
+
+  transmuxer.on('data', function(segment) {
+    segments.push(segment);
+  });
+  transmuxer.on('done', function(segment) {
+    if (!segmentLengthOnDone) {
+      segmentLengthOnDone = segments.length;
+    }
+  });
+
+  transmuxer.push(packetize(PAT));
+  transmuxer.push(packetize(generatePMT({
+    hasVideo: true,
+    hasAudio: true
+  })));
+
+  transmuxer.push(packetize(audioPes([
+    0x19, 0x47
+  ], true, earliestDts + 1)));
+  transmuxer.push(packetize(videoPes([
+      0x09, 0x01 // access_unit_delimiter_rbsp
+  ], true, earliestDts)));
+  transmuxer.push(packetize(videoPes([
+      0x08, 0x01 // pic_parameter_set_rbsp
+  ], true, earliestDts)));
+  transmuxer.push(packetize(videoPes([
+    0x07, // seq_parameter_set_rbsp
+    0x27, 0x42, 0xe0, 0x0b,
+    0xa9, 0x18, 0x60, 0x9d,
+    0x80, 0x53, 0x06, 0x01,
+    0x06, 0xb6, 0xc2, 0xb5,
+    0xef, 0x7c, 0x04
+  ], false, earliestDts)));
+  transmuxer.push(packetize(videoPes([
+      0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
+  ], true, earliestDts)));
+  transmuxer.flush();
+
+  QUnit.equal(segments.length, 1, 'generated a combined segment');
+  QUnit.equal(segments[0].data.length, 305, 'trimmed audio frame');
+});
+
+QUnit.test('Audio frames after video not trimmed, keepOriginalTimestamps = true', function() {
+  var
+    segments = [],
+    segmentLengthOnDone,
+    earliestDts = 15000,
+    transmuxer = new Transmuxer({
+      keepOriginalTimestamps: true
+    });
+
+  transmuxer.on('data', function(segment) {
+    segments.push(segment);
+  });
+  transmuxer.on('done', function(segment) {
+    if (!segmentLengthOnDone) {
+      segmentLengthOnDone = segments.length;
+    }
+  });
+
+  transmuxer.push(packetize(PAT));
+  transmuxer.push(packetize(generatePMT({
+    hasVideo: true,
+    hasAudio: true
+  })));
+
+  transmuxer.push(packetize(audioPes([
+    0x19, 0x47
+  ], true, earliestDts + 1)));
+  transmuxer.push(packetize(videoPes([
+      0x09, 0x01 // access_unit_delimiter_rbsp
+  ], true, earliestDts)));
+  transmuxer.push(packetize(videoPes([
+      0x08, 0x01 // pic_parameter_set_rbsp
+  ], true, earliestDts)));
+  transmuxer.push(packetize(videoPes([
+    0x07, // seq_parameter_set_rbsp
+    0x27, 0x42, 0xe0, 0x0b,
+    0xa9, 0x18, 0x60, 0x9d,
+    0x80, 0x53, 0x06, 0x01,
+    0x06, 0xb6, 0xc2, 0xb5,
+    0xef, 0x7c, 0x04
+  ], false, earliestDts)));
+  transmuxer.push(packetize(videoPes([
+      0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
+  ], true, earliestDts)));
+  transmuxer.flush();
+
+  QUnit.equal(segments.length, 1, 'generated a combined segment');
+  QUnit.equal(segments[0].data.length, 305, 'trimmed audio frame');
+});
+
+QUnit.test('Audio frames after video not trimmed, keepOriginalTimestamps = false, baseMediaDecodeTime option', function() {
+  var
+    segments = [],
+    segmentLengthOnDone,
+    earliestDts = 15000,
+    baseMediaDecodeTime = 15000,
+    transmuxer = new Transmuxer({
+      keepOriginalTimestamps: false,
+      baseMediaDecodeTime: baseMediaDecodeTime
+    });
+
+  transmuxer.on('data', function(segment) {
+    segments.push(segment);
+  });
+  transmuxer.on('done', function(segment) {
+    if (!segmentLengthOnDone) {
+      segmentLengthOnDone = segments.length;
+    }
+  });
+
+  transmuxer.push(packetize(PAT));
+  transmuxer.push(packetize(generatePMT({
+    hasVideo: true,
+    hasAudio: true
+  })));
+
+  transmuxer.push(packetize(audioPes([
+    0x19, 0x47
+  ], true, earliestDts + 1)));
+  transmuxer.push(packetize(videoPes([
+      0x09, 0x01 // access_unit_delimiter_rbsp
+  ], true, earliestDts + baseMediaDecodeTime)));
+  transmuxer.push(packetize(videoPes([
+      0x08, 0x01 // pic_parameter_set_rbsp
+  ], true, earliestDts + baseMediaDecodeTime)));
+  transmuxer.push(packetize(videoPes([
+    0x07, // seq_parameter_set_rbsp
+    0x27, 0x42, 0xe0, 0x0b,
+    0xa9, 0x18, 0x60, 0x9d,
+    0x80, 0x53, 0x06, 0x01,
+    0x06, 0xb6, 0xc2, 0xb5,
+    0xef, 0x7c, 0x04
+  ], false, earliestDts + baseMediaDecodeTime)));
+  transmuxer.push(packetize(videoPes([
+      0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
+  ], true, earliestDts + baseMediaDecodeTime)));
+  transmuxer.flush();
+
+  QUnit.equal(segments.length, 1, 'generated a combined segment');
+  QUnit.equal(segments[0].data.length, 305, 'trimmed audio frame');
+});
+
+QUnit.test('Audio frames after video not trimmed, keepOriginalTimestamps = true, baseMediaDecodeTime option', function() {
+  var
+    segments = [],
+    segmentLengthOnDone,
+    earliestDts = 15000,
+    baseMediaDecodeTime = 15000,
+    transmuxer = new Transmuxer({
+      keepOriginalTimestamps: true,
+      baseMediaDecodeTime: baseMediaDecodeTime
+    });
+
+  transmuxer.on('data', function(segment) {
+    segments.push(segment);
+  });
+  transmuxer.on('done', function(segment) {
+    if (!segmentLengthOnDone) {
+      segmentLengthOnDone = segments.length;
+    }
+  });
+
+  transmuxer.push(packetize(PAT));
+  transmuxer.push(packetize(generatePMT({
+    hasVideo: true,
+    hasAudio: true
+  })));
+
+  transmuxer.push(packetize(audioPes([
+    0x19, 0x47
+  ], true, earliestDts + 1)));
+  transmuxer.push(packetize(videoPes([
+      0x09, 0x01 // access_unit_delimiter_rbsp
+  ], true, earliestDts + baseMediaDecodeTime)));
+  transmuxer.push(packetize(videoPes([
+      0x08, 0x01 // pic_parameter_set_rbsp
+  ], true, earliestDts + baseMediaDecodeTime)));
+  transmuxer.push(packetize(videoPes([
+    0x07, // seq_parameter_set_rbsp
+    0x27, 0x42, 0xe0, 0x0b,
+    0xa9, 0x18, 0x60, 0x9d,
+    0x80, 0x53, 0x06, 0x01,
+    0x06, 0xb6, 0xc2, 0xb5,
+    0xef, 0x7c, 0x04
+  ], false, earliestDts + baseMediaDecodeTime)));
+  transmuxer.push(packetize(videoPes([
+      0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
+  ], true, earliestDts + baseMediaDecodeTime)));
+  transmuxer.flush();
+
+  QUnit.equal(segments.length, 1, 'generated a combined segment');
+  QUnit.equal(segments[0].data.length, 305, 'trimmed audio frame');
+});
+
+QUnit.test('Audio frames after video not trimmed, keepOriginalTimestamps = false, baseMediaDecodeTime setter', function() {
+  var
+    segments = [],
+    segmentLengthOnDone,
+    earliestDts = 15000,
+    baseMediaDecodeTime = 15000,
+    transmuxer = new Transmuxer({
+      keepOriginalTimestamps: false
+    });
+
+  transmuxer.setBaseMediaDecodeTime(baseMediaDecodeTime);
+
+  transmuxer.on('data', function(segment) {
+    segments.push(segment);
+  });
+  transmuxer.on('done', function(segment) {
+    if (!segmentLengthOnDone) {
+      segmentLengthOnDone = segments.length;
+    }
+  });
+
+  transmuxer.push(packetize(PAT));
+  transmuxer.push(packetize(generatePMT({
+    hasVideo: true,
+    hasAudio: true
+  })));
+
+  transmuxer.push(packetize(audioPes([
+    0x19, 0x47
+  ], true, earliestDts + 1)));
+  transmuxer.push(packetize(videoPes([
+      0x09, 0x01 // access_unit_delimiter_rbsp
+  ], true, earliestDts + baseMediaDecodeTime)));
+  transmuxer.push(packetize(videoPes([
+      0x08, 0x01 // pic_parameter_set_rbsp
+  ], true, earliestDts + baseMediaDecodeTime)));
+  transmuxer.push(packetize(videoPes([
+    0x07, // seq_parameter_set_rbsp
+    0x27, 0x42, 0xe0, 0x0b,
+    0xa9, 0x18, 0x60, 0x9d,
+    0x80, 0x53, 0x06, 0x01,
+    0x06, 0xb6, 0xc2, 0xb5,
+    0xef, 0x7c, 0x04
+  ], false, earliestDts + baseMediaDecodeTime)));
+  transmuxer.push(packetize(videoPes([
+      0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
+  ], true, earliestDts + baseMediaDecodeTime)));
+  transmuxer.flush();
+
+  QUnit.equal(segments.length, 1, 'generated a combined segment');
+  QUnit.equal(segments[0].data.length, 305, 'trimmed audio frame');
+});
+
+QUnit.test('Audio frames after video not trimmed, keepOriginalTimestamps = true, baseMediaDecodeTime setter', function() {
+  var
+    segments = [],
+    segmentLengthOnDone,
+    earliestDts = 15000,
+    baseMediaDecodeTime = 15000,
+    transmuxer = new Transmuxer({
+      keepOriginalTimestamps: true
+    });
+
+  transmuxer.setBaseMediaDecodeTime(baseMediaDecodeTime);
+
+  transmuxer.on('data', function(segment) {
+    segments.push(segment);
+  });
+  transmuxer.on('done', function(segment) {
+    if (!segmentLengthOnDone) {
+      segmentLengthOnDone = segments.length;
+    }
+  });
+
+  transmuxer.push(packetize(PAT));
+  transmuxer.push(packetize(generatePMT({
+    hasVideo: true,
+    hasAudio: true
+  })));
+
+  transmuxer.push(packetize(audioPes([
+    0x19, 0x47
+  ], true, earliestDts + 1)));
+  transmuxer.push(packetize(videoPes([
+      0x09, 0x01 // access_unit_delimiter_rbsp
+  ], true, earliestDts + baseMediaDecodeTime)));
+  transmuxer.push(packetize(videoPes([
+      0x08, 0x01 // pic_parameter_set_rbsp
+  ], true, earliestDts + baseMediaDecodeTime)));
+  transmuxer.push(packetize(videoPes([
+    0x07, // seq_parameter_set_rbsp
+    0x27, 0x42, 0xe0, 0x0b,
+    0xa9, 0x18, 0x60, 0x9d,
+    0x80, 0x53, 0x06, 0x01,
+    0x06, 0xb6, 0xc2, 0xb5,
+    0xef, 0x7c, 0x04
+  ], false, earliestDts + baseMediaDecodeTime)));
+  transmuxer.push(packetize(videoPes([
+      0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
+  ], true, earliestDts + baseMediaDecodeTime)));
+  transmuxer.flush();
+
+  QUnit.equal(segments.length, 1, 'generated a combined segment');
+  QUnit.equal(segments[0].data.length, 305, 'trimmed audio frame');
+});
+
 QUnit.test("doesn't adjust caption and ID3 times when configured to keep original timestamps", function() {
   var transmuxer = new Transmuxer({ keepOriginalTimestamps: true });
 

--- a/test/transmuxer.test.js
+++ b/test/transmuxer.test.js
@@ -3408,414 +3408,129 @@ QUnit.test('adjusts caption and ID3 times when configured to adjust timestamps',
   QUnit.equal(captions[0].endTime, (90004 - 90002) / 90e3, 'caption end time are based on original timeline');
 });
 
-QUnit.test('Audio frames trimmed before video, keepOriginalTimestamps = false', function() {
-  var
+[
+  {options: {keepOriginalTimestamps: false}},
+  {options: {keepOriginalTimestamps: true}},
+  {options: {keepOriginalTimestamps: false, baseMediaDecodeTime: 15000}},
+  {options: {keepOriginalTimestamps: true, baseMediaDecodeTime: 15000}},
+  {options: {keepOriginalTimestamps: false}, baseMediaSetter: 15000},
+  {options: {keepOriginalTimestamps: true}, baseMediaSetter: 15000}
+].forEach(function(test) {
+  var createTransmuxer = function() {
+    var transmuxer = new Transmuxer(test.options);
+
+    if (test.baseMediaSetter) {
+      transmuxer.setBaseMediaDecodeTime(test.baseMediaSetter);
+    }
+
+    return transmuxer;
+  };
+
+  var name = '';
+
+  Object.keys(test.options).forEach(function(optionName) {
+    name += '' + optionName + ' ' + test.options[optionName] + ' ';
+  });
+
+  if (test.baseMediaSetter) {
+    name += 'baseMediaDecodeTime setter ' + test.baseMediaSetter;
+  }
+
+  QUnit.test('Audio frames after video not trimmed, ' + name, function() {
+    var
     segments = [],
-    segmentLengthOnDone,
-    earliestDts = 15000,
-    transmuxer = new Transmuxer({
-      keepOriginalTimestamps: false
+      earliestDts = 15000,
+      transmuxer = createTransmuxer();
+
+    transmuxer.on('data', function(segment) {
+      segments.push(segment);
     });
 
-  transmuxer.on('data', function(segment) {
-    segments.push(segment);
-  });
-  transmuxer.on('done', function(segment) {
-    if (!segmentLengthOnDone) {
-      segmentLengthOnDone = segments.length;
-    }
-  });
+    // the following transmuxer pushes add tiny video and
+    // audio data to the transmuxer. When we add the data
+    // we also set the pts/dts time so that audio should
+    // not be trimmed.
+    transmuxer.push(packetize(PAT));
+    transmuxer.push(packetize(generatePMT({
+      hasVideo: true,
+      hasAudio: true
+    })));
 
-  transmuxer.push(packetize(PAT));
-  transmuxer.push(packetize(generatePMT({
-    hasVideo: true,
-    hasAudio: true
-  })));
-
-  transmuxer.push(packetize(audioPes([
-    0x19, 0x47
-  ], true, earliestDts - 1)));
-  transmuxer.push(packetize(videoPes([
+    transmuxer.push(packetize(audioPes([
+      0x19, 0x47
+    ], true, earliestDts + 1)));
+    transmuxer.push(packetize(videoPes([
       0x09, 0x01 // access_unit_delimiter_rbsp
-  ], true, earliestDts)));
-  transmuxer.push(packetize(videoPes([
+    ], true, earliestDts)));
+    transmuxer.push(packetize(videoPes([
       0x08, 0x01 // pic_parameter_set_rbsp
-  ], true, earliestDts)));
-  transmuxer.push(packetize(videoPes([
-    0x07, // seq_parameter_set_rbsp
-    0x27, 0x42, 0xe0, 0x0b,
-    0xa9, 0x18, 0x60, 0x9d,
-    0x80, 0x53, 0x06, 0x01,
-    0x06, 0xb6, 0xc2, 0xb5,
-    0xef, 0x7c, 0x04
-  ], false, earliestDts)));
-  transmuxer.push(packetize(videoPes([
+    ], true, earliestDts)));
+    transmuxer.push(packetize(videoPes([
+      0x07, // seq_parameter_set_rbsp
+      0x27, 0x42, 0xe0, 0x0b,
+      0xa9, 0x18, 0x60, 0x9d,
+      0x80, 0x53, 0x06, 0x01,
+      0x06, 0xb6, 0xc2, 0xb5,
+      0xef, 0x7c, 0x04
+    ], false, earliestDts)));
+    transmuxer.push(packetize(videoPes([
       0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
-  ], true, earliestDts)));
-  transmuxer.flush();
+    ], true, earliestDts)));
+    transmuxer.flush();
 
-  QUnit.equal(segments.length, 1, 'generated a combined segment');
-  QUnit.equal(segments[0].data.length, 295, 'trimmed audio frame');
-});
+    QUnit.equal(segments.length, 1, 'generated a combined segment');
+    // The audio frame is 10 bytes. The full data is 305 bytes without anything
+    // trimmed. If the audio frame was trimmed this will be 295 bytes.
+    QUnit.equal(segments[0].data.length, 305, 'trimmed audio frame');
+  });
 
-QUnit.test('Audio frames trimmed before video, keepOriginalTimestamps = true', function() {
-  var
+  QUnit.test('Audio frames trimmed before video, ' + name, function() {
+    var
     segments = [],
-    segmentLengthOnDone,
-    earliestDts = 15000,
-    transmuxer = new Transmuxer({
-      keepOriginalTimestamps: true
+      earliestDts = 15000,
+      transmuxer = createTransmuxer();
+
+    transmuxer.on('data', function(segment) {
+      segments.push(segment);
     });
 
-  transmuxer.on('data', function(segment) {
-    segments.push(segment);
-  });
-  transmuxer.on('done', function(segment) {
-    if (!segmentLengthOnDone) {
-      segmentLengthOnDone = segments.length;
-    }
-  });
+    // the following transmuxer pushes add tiny video and
+    // audio data to the transmuxer. When we add the data
+    // we also set the pts/dts time so that audio should
+    // be trimmed.
+    transmuxer.push(packetize(PAT));
+    transmuxer.push(packetize(generatePMT({
+      hasVideo: true,
+      hasAudio: true
+    })));
 
-  transmuxer.push(packetize(PAT));
-  transmuxer.push(packetize(generatePMT({
-    hasVideo: true,
-    hasAudio: true
-  })));
-
-  transmuxer.push(packetize(audioPes([
-    0x19, 0x47
-  ], true, earliestDts - 1)));
-  transmuxer.push(packetize(videoPes([
+    transmuxer.push(packetize(audioPes([
+      0x19, 0x47
+    ], true, earliestDts - (test.options.baseMediaDecodeTime || test.baseMediaSetter || 0) - 1)));
+    transmuxer.push(packetize(videoPes([
       0x09, 0x01 // access_unit_delimiter_rbsp
-  ], true, earliestDts)));
-  transmuxer.push(packetize(videoPes([
+    ], true, earliestDts)));
+    transmuxer.push(packetize(videoPes([
       0x08, 0x01 // pic_parameter_set_rbsp
-  ], true, earliestDts)));
-  transmuxer.push(packetize(videoPes([
-    0x07, // seq_parameter_set_rbsp
-    0x27, 0x42, 0xe0, 0x0b,
-    0xa9, 0x18, 0x60, 0x9d,
-    0x80, 0x53, 0x06, 0x01,
-    0x06, 0xb6, 0xc2, 0xb5,
-    0xef, 0x7c, 0x04
-  ], false, earliestDts)));
-  transmuxer.push(packetize(videoPes([
+    ], true, earliestDts)));
+    transmuxer.push(packetize(videoPes([
+      0x07, // seq_parameter_set_rbsp
+      0x27, 0x42, 0xe0, 0x0b,
+      0xa9, 0x18, 0x60, 0x9d,
+      0x80, 0x53, 0x06, 0x01,
+      0x06, 0xb6, 0xc2, 0xb5,
+      0xef, 0x7c, 0x04
+    ], false, earliestDts)));
+    transmuxer.push(packetize(videoPes([
       0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
-  ], true, earliestDts)));
-  transmuxer.flush();
+    ], true, earliestDts)));
+    transmuxer.flush();
 
-  QUnit.equal(segments.length, 1, 'generated a combined segment');
-  QUnit.equal(segments[0].data.length, 295, 'trimmed audio frame');
-});
-
-QUnit.test('Audio frames after video not trimmed, keepOriginalTimestamps = false', function() {
-  var
-    segments = [],
-    segmentLengthOnDone,
-    earliestDts = 15000,
-    transmuxer = new Transmuxer({
-      keepOriginalTimestamps: false
-    });
-
-  transmuxer.on('data', function(segment) {
-    segments.push(segment);
+    QUnit.equal(segments.length, 1, 'generated a combined segment');
+    // The audio frame is 10 bytes. The full data is 305 bytes without anything
+    // trimmed. If the audio frame was trimmed this will be 295 bytes.
+    QUnit.equal(segments[0].data.length, 295, 'trimmed audio frame');
   });
-  transmuxer.on('done', function(segment) {
-    if (!segmentLengthOnDone) {
-      segmentLengthOnDone = segments.length;
-    }
-  });
-
-  transmuxer.push(packetize(PAT));
-  transmuxer.push(packetize(generatePMT({
-    hasVideo: true,
-    hasAudio: true
-  })));
-
-  transmuxer.push(packetize(audioPes([
-    0x19, 0x47
-  ], true, earliestDts + 1)));
-  transmuxer.push(packetize(videoPes([
-      0x09, 0x01 // access_unit_delimiter_rbsp
-  ], true, earliestDts)));
-  transmuxer.push(packetize(videoPes([
-      0x08, 0x01 // pic_parameter_set_rbsp
-  ], true, earliestDts)));
-  transmuxer.push(packetize(videoPes([
-    0x07, // seq_parameter_set_rbsp
-    0x27, 0x42, 0xe0, 0x0b,
-    0xa9, 0x18, 0x60, 0x9d,
-    0x80, 0x53, 0x06, 0x01,
-    0x06, 0xb6, 0xc2, 0xb5,
-    0xef, 0x7c, 0x04
-  ], false, earliestDts)));
-  transmuxer.push(packetize(videoPes([
-      0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
-  ], true, earliestDts)));
-  transmuxer.flush();
-
-  QUnit.equal(segments.length, 1, 'generated a combined segment');
-  QUnit.equal(segments[0].data.length, 305, 'trimmed audio frame');
-});
-
-QUnit.test('Audio frames after video not trimmed, keepOriginalTimestamps = true', function() {
-  var
-    segments = [],
-    segmentLengthOnDone,
-    earliestDts = 15000,
-    transmuxer = new Transmuxer({
-      keepOriginalTimestamps: true
-    });
-
-  transmuxer.on('data', function(segment) {
-    segments.push(segment);
-  });
-  transmuxer.on('done', function(segment) {
-    if (!segmentLengthOnDone) {
-      segmentLengthOnDone = segments.length;
-    }
-  });
-
-  transmuxer.push(packetize(PAT));
-  transmuxer.push(packetize(generatePMT({
-    hasVideo: true,
-    hasAudio: true
-  })));
-
-  transmuxer.push(packetize(audioPes([
-    0x19, 0x47
-  ], true, earliestDts + 1)));
-  transmuxer.push(packetize(videoPes([
-      0x09, 0x01 // access_unit_delimiter_rbsp
-  ], true, earliestDts)));
-  transmuxer.push(packetize(videoPes([
-      0x08, 0x01 // pic_parameter_set_rbsp
-  ], true, earliestDts)));
-  transmuxer.push(packetize(videoPes([
-    0x07, // seq_parameter_set_rbsp
-    0x27, 0x42, 0xe0, 0x0b,
-    0xa9, 0x18, 0x60, 0x9d,
-    0x80, 0x53, 0x06, 0x01,
-    0x06, 0xb6, 0xc2, 0xb5,
-    0xef, 0x7c, 0x04
-  ], false, earliestDts)));
-  transmuxer.push(packetize(videoPes([
-      0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
-  ], true, earliestDts)));
-  transmuxer.flush();
-
-  QUnit.equal(segments.length, 1, 'generated a combined segment');
-  QUnit.equal(segments[0].data.length, 305, 'trimmed audio frame');
-});
-
-QUnit.test('Audio frames after video not trimmed, keepOriginalTimestamps = false, baseMediaDecodeTime option', function() {
-  var
-    segments = [],
-    segmentLengthOnDone,
-    earliestDts = 15000,
-    baseMediaDecodeTime = 15000,
-    transmuxer = new Transmuxer({
-      keepOriginalTimestamps: false,
-      baseMediaDecodeTime: baseMediaDecodeTime
-    });
-
-  transmuxer.on('data', function(segment) {
-    segments.push(segment);
-  });
-  transmuxer.on('done', function(segment) {
-    if (!segmentLengthOnDone) {
-      segmentLengthOnDone = segments.length;
-    }
-  });
-
-  transmuxer.push(packetize(PAT));
-  transmuxer.push(packetize(generatePMT({
-    hasVideo: true,
-    hasAudio: true
-  })));
-
-  transmuxer.push(packetize(audioPes([
-    0x19, 0x47
-  ], true, earliestDts + 1)));
-  transmuxer.push(packetize(videoPes([
-      0x09, 0x01 // access_unit_delimiter_rbsp
-  ], true, earliestDts + baseMediaDecodeTime)));
-  transmuxer.push(packetize(videoPes([
-      0x08, 0x01 // pic_parameter_set_rbsp
-  ], true, earliestDts + baseMediaDecodeTime)));
-  transmuxer.push(packetize(videoPes([
-    0x07, // seq_parameter_set_rbsp
-    0x27, 0x42, 0xe0, 0x0b,
-    0xa9, 0x18, 0x60, 0x9d,
-    0x80, 0x53, 0x06, 0x01,
-    0x06, 0xb6, 0xc2, 0xb5,
-    0xef, 0x7c, 0x04
-  ], false, earliestDts + baseMediaDecodeTime)));
-  transmuxer.push(packetize(videoPes([
-      0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
-  ], true, earliestDts + baseMediaDecodeTime)));
-  transmuxer.flush();
-
-  QUnit.equal(segments.length, 1, 'generated a combined segment');
-  QUnit.equal(segments[0].data.length, 305, 'trimmed audio frame');
-});
-
-QUnit.test('Audio frames after video not trimmed, keepOriginalTimestamps = true, baseMediaDecodeTime option', function() {
-  var
-    segments = [],
-    segmentLengthOnDone,
-    earliestDts = 15000,
-    baseMediaDecodeTime = 15000,
-    transmuxer = new Transmuxer({
-      keepOriginalTimestamps: true,
-      baseMediaDecodeTime: baseMediaDecodeTime
-    });
-
-  transmuxer.on('data', function(segment) {
-    segments.push(segment);
-  });
-  transmuxer.on('done', function(segment) {
-    if (!segmentLengthOnDone) {
-      segmentLengthOnDone = segments.length;
-    }
-  });
-
-  transmuxer.push(packetize(PAT));
-  transmuxer.push(packetize(generatePMT({
-    hasVideo: true,
-    hasAudio: true
-  })));
-
-  transmuxer.push(packetize(audioPes([
-    0x19, 0x47
-  ], true, earliestDts + 1)));
-  transmuxer.push(packetize(videoPes([
-      0x09, 0x01 // access_unit_delimiter_rbsp
-  ], true, earliestDts + baseMediaDecodeTime)));
-  transmuxer.push(packetize(videoPes([
-      0x08, 0x01 // pic_parameter_set_rbsp
-  ], true, earliestDts + baseMediaDecodeTime)));
-  transmuxer.push(packetize(videoPes([
-    0x07, // seq_parameter_set_rbsp
-    0x27, 0x42, 0xe0, 0x0b,
-    0xa9, 0x18, 0x60, 0x9d,
-    0x80, 0x53, 0x06, 0x01,
-    0x06, 0xb6, 0xc2, 0xb5,
-    0xef, 0x7c, 0x04
-  ], false, earliestDts + baseMediaDecodeTime)));
-  transmuxer.push(packetize(videoPes([
-      0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
-  ], true, earliestDts + baseMediaDecodeTime)));
-  transmuxer.flush();
-
-  QUnit.equal(segments.length, 1, 'generated a combined segment');
-  QUnit.equal(segments[0].data.length, 305, 'trimmed audio frame');
-});
-
-QUnit.test('Audio frames after video not trimmed, keepOriginalTimestamps = false, baseMediaDecodeTime setter', function() {
-  var
-    segments = [],
-    segmentLengthOnDone,
-    earliestDts = 15000,
-    baseMediaDecodeTime = 15000,
-    transmuxer = new Transmuxer({
-      keepOriginalTimestamps: false
-    });
-
-  transmuxer.setBaseMediaDecodeTime(baseMediaDecodeTime);
-
-  transmuxer.on('data', function(segment) {
-    segments.push(segment);
-  });
-  transmuxer.on('done', function(segment) {
-    if (!segmentLengthOnDone) {
-      segmentLengthOnDone = segments.length;
-    }
-  });
-
-  transmuxer.push(packetize(PAT));
-  transmuxer.push(packetize(generatePMT({
-    hasVideo: true,
-    hasAudio: true
-  })));
-
-  transmuxer.push(packetize(audioPes([
-    0x19, 0x47
-  ], true, earliestDts + 1)));
-  transmuxer.push(packetize(videoPes([
-      0x09, 0x01 // access_unit_delimiter_rbsp
-  ], true, earliestDts + baseMediaDecodeTime)));
-  transmuxer.push(packetize(videoPes([
-      0x08, 0x01 // pic_parameter_set_rbsp
-  ], true, earliestDts + baseMediaDecodeTime)));
-  transmuxer.push(packetize(videoPes([
-    0x07, // seq_parameter_set_rbsp
-    0x27, 0x42, 0xe0, 0x0b,
-    0xa9, 0x18, 0x60, 0x9d,
-    0x80, 0x53, 0x06, 0x01,
-    0x06, 0xb6, 0xc2, 0xb5,
-    0xef, 0x7c, 0x04
-  ], false, earliestDts + baseMediaDecodeTime)));
-  transmuxer.push(packetize(videoPes([
-      0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
-  ], true, earliestDts + baseMediaDecodeTime)));
-  transmuxer.flush();
-
-  QUnit.equal(segments.length, 1, 'generated a combined segment');
-  QUnit.equal(segments[0].data.length, 305, 'trimmed audio frame');
-});
-
-QUnit.test('Audio frames after video not trimmed, keepOriginalTimestamps = true, baseMediaDecodeTime setter', function() {
-  var
-    segments = [],
-    segmentLengthOnDone,
-    earliestDts = 15000,
-    baseMediaDecodeTime = 15000,
-    transmuxer = new Transmuxer({
-      keepOriginalTimestamps: true
-    });
-
-  transmuxer.setBaseMediaDecodeTime(baseMediaDecodeTime);
-
-  transmuxer.on('data', function(segment) {
-    segments.push(segment);
-  });
-  transmuxer.on('done', function(segment) {
-    if (!segmentLengthOnDone) {
-      segmentLengthOnDone = segments.length;
-    }
-  });
-
-  transmuxer.push(packetize(PAT));
-  transmuxer.push(packetize(generatePMT({
-    hasVideo: true,
-    hasAudio: true
-  })));
-
-  transmuxer.push(packetize(audioPes([
-    0x19, 0x47
-  ], true, earliestDts + 1)));
-  transmuxer.push(packetize(videoPes([
-      0x09, 0x01 // access_unit_delimiter_rbsp
-  ], true, earliestDts + baseMediaDecodeTime)));
-  transmuxer.push(packetize(videoPes([
-      0x08, 0x01 // pic_parameter_set_rbsp
-  ], true, earliestDts + baseMediaDecodeTime)));
-  transmuxer.push(packetize(videoPes([
-    0x07, // seq_parameter_set_rbsp
-    0x27, 0x42, 0xe0, 0x0b,
-    0xa9, 0x18, 0x60, 0x9d,
-    0x80, 0x53, 0x06, 0x01,
-    0x06, 0xb6, 0xc2, 0xb5,
-    0xef, 0x7c, 0x04
-  ], false, earliestDts + baseMediaDecodeTime)));
-  transmuxer.push(packetize(videoPes([
-      0x05, 0x01 // slice_layer_without_partitioning_rbsp_idr
-  ], true, earliestDts + baseMediaDecodeTime)));
-  transmuxer.flush();
-
-  QUnit.equal(segments.length, 1, 'generated a combined segment');
-  QUnit.equal(segments[0].data.length, 305, 'trimmed audio frame');
 });
 
 QUnit.test("doesn't adjust caption and ID3 times when configured to keep original timestamps", function() {


### PR DESCRIPTION
## Problem 
`timelineStartInfo.baseMediaDecodeTime` is `0` when `keepOriginalTimestampOffsets` is `true`. This causes earliestAllowedDts to be much higher than it should be, which means that almost all audio is trimmed when seeking backwards for live stream videos. 

## Solution
Track `baseMediaDecodeTime` even though we don't intend to use it for most things when `keepOriginalTimestampOffsets` is `true`. That way we can use it to get the real timeline start dts.

## Testing
This fixes the stream mentioned in https://github.com/videojs/http-streaming/pull/624#issuecomment-544506799 that can be tested by turning on the `liveui` in the vhs test page and linking in this version of mux.js