### PR TITLE
fix(caption-parser): do not fail when first sei sample is null

### DIFF
--- a/lib/mp4/caption-parser.js
+++ b/lib/mp4/caption-parser.js
@@ -89,11 +89,15 @@ var findSeiNals = function(avcStream, samples, trackId) {
         seiNal.pts = matchingSample.pts;
         seiNal.dts = matchingSample.dts;
         lastMatchedSample = matchingSample;
-      } else {
+      } else if (lastMatchedSample) {
         // If a matching sample cannot be found, use the last
         // sample's values as they should be as close as possible
         seiNal.pts = lastMatchedSample.pts;
         seiNal.dts = lastMatchedSample.dts;
+      } else {
+        // eslint-disable-next-line no-console
+        console.log("We've encountered a nal unit without data. See mux.js#233.");
+        break;
       }
 
       result.push(seiNal);


### PR DESCRIPTION
Do a null check around lastMatchedSample in caption-parser. While having
the null check makes sense, it's possible the content is malformed or
that we're doing a miscalculation somewhere else in the caption-parser.
So, while this will help with #233, we won't close #233 until we can
spend a bit more time investigating the underlying issue.