### PR TITLE
fix: Do not trim audio output when keepOriginalTimestamps is set

### DIFF
--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -1010,10 +1010,11 @@ Transmuxer = function(options) {
           pipeline.videoSegmentStream = new VideoSegmentStream(videoTrack, options);
 
           pipeline.videoSegmentStream.on('timelineStartInfo', function(timelineStartInfo) {
-          // When video emits timelineStartInfo data after a flush, we forward that
-          // info to the AudioSegmentStream, if it exists, because video timeline
-          // data takes precedence.
-            if (audioTrack) {
+            // When video emits timelineStartInfo data after a flush, we forward that
+            // info to the AudioSegmentStream, if it exists, because video timeline
+            // data takes precedence.  Do not do this if keepOriginalTimestamps is set,
+            // because this is a particularly subtle form of timestamp alteration.
+            if (audioTrack && !options.keepOriginalTimestamps) {
               audioTrack.timelineStartInfo = timelineStartInfo;
               // On the first segment we trim AAC frames that exist before the
               // very earliest DTS we have seen in video because Chrome will

--- a/test/transmuxer.test.js
+++ b/test/transmuxer.test.js
@@ -3486,8 +3486,9 @@ QUnit.test('adjusts caption and ID3 times when configured to adjust timestamps',
 
   QUnit.test('Audio frames trimmed before video, ' + name, function() {
     var
-    segments = [],
+      segments = [],
       earliestDts = 15000,
+      baseTime = test.options.baseMediaDecodeTime || test.baseMediaSetter || 0,
       transmuxer = createTransmuxer();
 
     transmuxer.on('data', function(segment) {
@@ -3506,7 +3507,7 @@ QUnit.test('adjusts caption and ID3 times when configured to adjust timestamps',
 
     transmuxer.push(packetize(audioPes([
       0x19, 0x47
-    ], true, earliestDts - (test.options.baseMediaDecodeTime || test.baseMediaSetter || 0) - 1)));
+    ], true, earliestDts - baseTime - 1)));
     transmuxer.push(packetize(videoPes([
       0x09, 0x01 // access_unit_delimiter_rbsp
     ], true, earliestDts)));
@@ -3529,7 +3530,11 @@ QUnit.test('adjusts caption and ID3 times when configured to adjust timestamps',
     QUnit.equal(segments.length, 1, 'generated a combined segment');
     // The audio frame is 10 bytes. The full data is 305 bytes without anything
     // trimmed. If the audio frame was trimmed this will be 295 bytes.
-    QUnit.equal(segments[0].data.length, 295, 'trimmed audio frame');
+    if (test.options.keepOriginalTimestamps && !baseTime) {
+      QUnit.equal(segments[0].data.length, 305, 'trimmed audio frame');
+    } else {
+      QUnit.equal(segments[0].data.length, 295, 'trimmed audio frame');
+    }
   });
 });
 

--- a/test/transmuxer.test.js
+++ b/test/transmuxer.test.js
@@ -3530,7 +3530,9 @@ QUnit.test('adjusts caption and ID3 times when configured to adjust timestamps',
     QUnit.equal(segments.length, 1, 'generated a combined segment');
     // The audio frame is 10 bytes. The full data is 305 bytes without anything
     // trimmed. If the audio frame was trimmed this will be 295 bytes.
-    if (test.options.keepOriginalTimestamps && !baseTime) {
+// Note that if the baseMediaDecodeTime is set via options or the setter, frames may still
+// be removed, even if keepOriginalTimestamps is true.
+if (test.options.keepOriginalTimestamps && !baseTime) {
       QUnit.equal(segments[0].data.length, 305, 'trimmed audio frame');
     } else {
       QUnit.equal(segments[0].data.length, 295, 'trimmed audio frame');


### PR DESCRIPTION
Because the first segment after a discontinuity may have a smaller timestamp than the first segment overall, the post-discontinuity segment may have its audio completely removed.

With the keepOriginalTimestamps flag, this subtle form of timestamp manipulation should be avoided, leaving apps in complete control of the timestamps.

Closes #328