### PR TITLE
fix: skip DTG1 packets in parseSei

### DIFF
--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -1010,10 +1010,11 @@ Transmuxer = function(options) {
           pipeline.videoSegmentStream = new VideoSegmentStream(videoTrack, options);
 
           pipeline.videoSegmentStream.on('timelineStartInfo', function(timelineStartInfo) {
-          // When video emits timelineStartInfo data after a flush, we forward that
-          // info to the AudioSegmentStream, if it exists, because video timeline
-          // data takes precedence.
-            if (audioTrack) {
+            // When video emits timelineStartInfo data after a flush, we forward that
+            // info to the AudioSegmentStream, if it exists, because video timeline
+            // data takes precedence.  Do not do this if keepOriginalTimestamps is set,
+            // because this is a particularly subtle form of timestamp alteration.
+            if (audioTrack && !options.keepOriginalTimestamps) {
               audioTrack.timelineStartInfo = timelineStartInfo;
               // On the first segment we trim AAC frames that exist before the
               // very earliest DTS we have seen in video because Chrome will

--- a/lib/tools/caption-packet-parser.js
+++ b/lib/tools/caption-packet-parser.js
@@ -65,7 +65,18 @@ var parseSei = function(bytes) {
       result.payloadType = payloadType;
       result.payloadSize = payloadSize;
       result.payload = bytes.subarray(i, i + payloadSize);
-      break;
+
+      var userIdentifier = String.fromCharCode(
+        result.payload[3],
+        result.payload[4],
+        result.payload[5],
+        result.payload[6]);
+
+      if (userIdentifier === 'GA94') {
+        break;
+      } else {
+        result.payload = undefined;
+      }
     }
 
     // skip the payload and parse the next message

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mux.js",
-  "version": "5.5.2",
+  "version": "5.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mux.js",
-  "version": "5.5.2",
+  "version": "5.5.3",
   "description": "A collection of lightweight utilities for inspecting and manipulating video container formats.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Atypical streams containing 2+ SEI NAL payloads of type 0x04 (CEA-708 caption content) in the sei_rbsp (specifically a DTG1 payload preceding a GA94 payload) fail to display captions in this scenario, as the current logic results in parseSei() prematurely returning with the DTG1 payload.

By checking for the user ID within parseSei, mux.js can continue iterating through the sei_rbsp for the GA94 payload.