### PR TITLE
revert: use baseMediaDecode to set earliest dts (#317)

### DIFF
--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -988,8 +988,6 @@ Transmuxer = function(options) {
     pipeline.elementaryStream.on('data', function(data) {
       var i;
 
-      var baseMediaDecodeTime = !options.keepOriginalTimestamps ? self.baseMediaDecodeTime : 0;
-
       if (data.type === 'metadata') {
         i = data.tracks.length;
 
@@ -997,10 +995,10 @@ Transmuxer = function(options) {
         while (i--) {
           if (!videoTrack && data.tracks[i].type === 'video') {
             videoTrack = data.tracks[i];
-            videoTrack.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
+            videoTrack.timelineStartInfo.baseMediaDecodeTime = self.baseMediaDecodeTime;
           } else if (!audioTrack && data.tracks[i].type === 'audio') {
             audioTrack = data.tracks[i];
-            audioTrack.timelineStartInfo.baseMediaDecodeTime = baseMediaDecodeTime;
+            audioTrack.timelineStartInfo.baseMediaDecodeTime = self.baseMediaDecodeTime;
           }
         }
 
@@ -1082,7 +1080,9 @@ Transmuxer = function(options) {
   this.setBaseMediaDecodeTime = function(baseMediaDecodeTime) {
     var pipeline = this.transmuxPipeline_;
 
-    this.baseMediaDecodeTime = baseMediaDecodeTime;
+    if (!options.keepOriginalTimestamps) {
+      this.baseMediaDecodeTime = baseMediaDecodeTime;
+    }
 
     if (audioTrack) {
       audioTrack.timelineStartInfo.dts = undefined;

--- a/lib/partial/transmuxer.js
+++ b/lib/partial/transmuxer.js
@@ -65,6 +65,7 @@ var tsPipeline = function(options) {
     for (var i = 0; i < data.tracks.length; i++) {
       if (!pipeline.tracks[data.tracks[i].type]) {
         pipeline.tracks[data.tracks[i].type] = data.tracks[i];
+        pipeline.tracks[data.tracks[i].type].timelineStartInfo.baseMediaDecodeTime = options.baseMediaDecodeTime;
       }
     }
 
@@ -191,7 +192,7 @@ var aacPipeline = function(options) {
 
     pipeline.tracks.audio = pipeline.tracks.audio || {
       timelineStartInfo: {
-        baseMediaDecodeTime: !options.keepOriginalTimestamps ? options.baseMediaDecodeTime : 0
+        baseMediaDecodeTime: options.baseMediaDecodeTime
       },
       codec: 'adts',
       type: 'audio'

--- a/lib/partial/transmuxer.js
+++ b/lib/partial/transmuxer.js
@@ -72,7 +72,7 @@ var tsPipeline = function(options) {
       pipeline.videoSegmentStream = new VideoSegmentStream(pipeline.tracks.video, options);
 
       pipeline.videoSegmentStream.on('timelineStartInfo', function(timelineStartInfo) {
-        if (pipeline.tracks.audio) {
+        if (pipeline.tracks.audio && !options.keepOriginalTimestamps) {
           pipeline.audioSegmentStream.setEarliestDts(timelineStartInfo.dts - options.baseMediaDecodeTime);
         }
       });
@@ -315,7 +315,9 @@ var Transmuxer = function(options) {
   };
 
   this.setBaseMediaDecodeTime = function(baseMediaDecodeTime) {
-    options.baseMediaDecodeTime = baseMediaDecodeTime;
+    if (!options.keepOriginalTimestamps) {
+      options.baseMediaDecodeTime = baseMediaDecodeTime;
+    }
 
     if (!pipeline) {
       return;

--- a/test/partial.test.js
+++ b/test/partial.test.js
@@ -130,8 +130,6 @@ QUnit.module('Partial Transmuxer - Options');
 
     // the partial transmuxer only generates a video segment
     // when all audio frames are trimmed.
-    // Note that if the baseMediaDecodeTime is set via options or the setter, frames may still
-    // be removed, even if keepOriginalTimestamps is true.
     if (test.options.keepOriginalTimestamps && !baseTime) {
       QUnit.equal(segments.length, 2, 'generated both a video/audio segment');
       QUnit.equal(segments[0].type, 'video', 'segment is video');

--- a/test/transmuxer.test.js
+++ b/test/transmuxer.test.js
@@ -3530,10 +3530,10 @@ QUnit.test('adjusts caption and ID3 times when configured to adjust timestamps',
     QUnit.equal(segments.length, 1, 'generated a combined segment');
     // The audio frame is 10 bytes. The full data is 305 bytes without anything
     // trimmed. If the audio frame was trimmed this will be 295 bytes.
-// Note that if the baseMediaDecodeTime is set via options or the setter, frames may still
-// be removed, even if keepOriginalTimestamps is true.
-if (test.options.keepOriginalTimestamps && !baseTime) {
-      QUnit.equal(segments[0].data.length, 305, 'trimmed audio frame');
+    // Note that if the baseMediaDecodeTime is set via options or the setter, frames may still
+    // be removed, even if keepOriginalTimestamps is true.
+    if (test.options.keepOriginalTimestamps && !baseTime) {
+      QUnit.equal(segments[0].data.length, 305, 'did not trim audio frame');
     } else {
       QUnit.equal(segments[0].data.length, 295, 'trimmed audio frame');
     }

--- a/test/transmuxer.test.js
+++ b/test/transmuxer.test.js
@@ -3530,8 +3530,6 @@ QUnit.test('adjusts caption and ID3 times when configured to adjust timestamps',
     QUnit.equal(segments.length, 1, 'generated a combined segment');
     // The audio frame is 10 bytes. The full data is 305 bytes without anything
     // trimmed. If the audio frame was trimmed this will be 295 bytes.
-    // Note that if the baseMediaDecodeTime is set via options or the setter, frames may still
-    // be removed, even if keepOriginalTimestamps is true.
     if (test.options.keepOriginalTimestamps && !baseTime) {
       QUnit.equal(segments[0].data.length, 305, 'did not trim audio frame');
     } else {


### PR DESCRIPTION
Reverts the part of #317 that always uses `baseMediaDecodeTime` to trim audio even when `keepOriginalTimestamps` is on. It seems like the actual fix fo the issue in #317 was fixed with #329. I have also included the updates from #329 into the partial transmuxer in this pull request so that it remains up to date. 

Right now this code breaks alternative audio tracks as we do not trim audio as expected and switching to an alternative audio track causes us to infinite buffer due to a gap.