### PR TITLE
fix: return proper timescale for version 1 mdhd in mp4 probe getTracks

### DIFF
--- a/lib/mp4/probe.js
+++ b/lib/mp4/probe.js
@@ -11,7 +11,8 @@
 var toUnsigned = require('../utils/bin').toUnsigned;
 var toHexString = require('../utils/bin').toHexString;
 var mp4Inspector = require('../tools/mp4-inspector.js');
-var timescale, startTime, compositionStartTime, getVideoTrackIds, getTracks;
+var timescale, startTime, compositionStartTime, getVideoTrackIds, getTracks,
+  getTimescaleFromMediaHeader;
 
 /**
  * Parses an MP4 initialization segment and extracts the timescale
@@ -219,6 +220,19 @@ getVideoTrackIds = function(init) {
   return videoTrackIds;
 };
 
+getTimescaleFromMediaHeader = function(mdhd) {
+  // mdhd is a FullBox, meaning it will have its own version as the first byte
+  var version = mdhd[0];
+  var index = version === 0 ? 12 : 20;
+
+  return toUnsigned(
+    mdhd[index]     << 24 |
+    mdhd[index + 1] << 16 |
+    mdhd[index + 2] <<  8 |
+    mdhd[index + 3]
+  );
+};
+
 /**
  * Get all the video, audio, and hint tracks from a non fragmented
  * mp4 segment
@@ -230,14 +244,14 @@ getTracks = function(init) {
   traks.forEach(function(trak) {
     var track = {};
     var tkhd = mp4Inspector.findBox(trak, ['tkhd'])[0];
-    var view, version;
+    var view, tkhdVersion;
 
     // id
     if (tkhd) {
       view = new DataView(tkhd.buffer, tkhd.byteOffset, tkhd.byteLength);
-      version = view.getUint8(0);
+      tkhdVersion = view.getUint8(0);
 
-      track.id = (version === 0) ? view.getUint32(12) : view.getUint32(20);
+      track.id = (tkhdVersion === 0) ? view.getUint32(12) : view.getUint32(20);
     }
 
     var hdlr = mp4Inspector.findBox(trak, ['mdia', 'hdlr'])[0];
@@ -312,13 +326,8 @@ getTracks = function(init) {
 
     var mdhd = mp4Inspector.findBox(trak, ['mdia', 'mdhd'])[0];
 
-    if (mdhd && tkhd) {
-      var index = version === 0 ? 12 : 20;
-
-      track.timescale = toUnsigned(mdhd[index]     << 24 |
-                                   mdhd[index + 1] << 16 |
-                                   mdhd[index + 2] <<  8 |
-                                   mdhd[index + 3]);
+    if (mdhd) {
+      track.timescale = getTimescaleFromMediaHeader(mdhd);
     }
 
     tracks.push(track);
@@ -335,5 +344,6 @@ module.exports = {
   startTime: startTime,
   compositionStartTime: compositionStartTime,
   videoTrackIds: getVideoTrackIds,
-  tracks: getTracks
+  tracks: getTracks,
+  getTimescaleFromMediaHeader: getTimescaleFromMediaHeader
 };

--- a/test/mp4-probe.test.js
+++ b/test/mp4-probe.test.js
@@ -107,6 +107,46 @@ test('compositionStartTime uses default composition time offset of 0' +
         'calculated correct composition start time using default offset');
 });
 
+test('getTimescaleFromMediaHeader gets timescale for version 0 mdhd', function() {
+  var mdhd = new Uint8Array([
+    0x00, // version 0
+    0x00, 0x00, 0x00, // flags
+    // version 0 has 32 bit creation_time, modification_time, and duration
+    0x00, 0x00, 0x00, 0x02, // creation_time
+    0x00, 0x00, 0x00, 0x03, // modification_time
+    0x00, 0x00, 0x03, 0xe8, // timescale = 1000
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x02, 0x58, // 600 = 0x258 duration
+    0x15, 0xc7 // 'eng' language
+  ]);
+
+  equal(
+    probe.getTimescaleFromMediaHeader(mdhd),
+    1000,
+    'got timescale from version 0 mdhd'
+  );
+});
+
+test('getTimescaleFromMediaHeader gets timescale for version 0 mdhd', function() {
+  var mdhd = new Uint8Array([
+    0x01, // version 1
+    0x00, 0x00, 0x00, // flags
+    // version 1 has 64 bit creation_time, modification_time, and duration
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, // creation_time
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, // modification_time
+    0x00, 0x00, 0x03, 0xe8, // timescale = 1000
+    0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0x58, // 600 = 0x258 duration
+    0x15, 0xc7 // 'eng' language
+  ]);
+
+  equal(
+    probe.getTimescaleFromMediaHeader(mdhd),
+    1000,
+    'got timescale from version 1 mdhd'
+  );
+});
+
 // ---------
 // Test Data
 // ---------


### PR DESCRIPTION
Previously, getTracks used the track header box version for determining
the version of the media header box. But the versions can be different. This
change uses the version of the mdhd box instead.

This logic should also better match the timescale mp4 probe function: https://github.com/videojs/mux.js/blob/master/lib/mp4/probe.js#L54

Source used for testing: https://irtdashreference-i.akamaihd.net/dash/live/901161/bfs/manifestARD.mpd