### PR TITLE
refactor: use inspect.findBox, rather than importing probe

### DIFF
--- a/lib/mp4/caption-parser.js
+++ b/lib/mp4/caption-parser.js
@@ -11,7 +11,6 @@
 
 var discardEmulationPreventionBytes = require('../tools/caption-packet-parser').discardEmulationPreventionBytes;
 var CaptionStream = require('../m2ts/caption-stream').CaptionStream;
-var probe = require('./probe');
 var inspect = require('../tools/mp4-inspector');
 
 /**
@@ -170,9 +169,9 @@ var parseSamples = function(truns, baseMediaDecodeTime, tfhd) {
  **/
 var parseCaptionNals = function(segment, videoTrackId) {
   // To get the samples
-  var trafs = probe.findBox(segment, ['moof', 'traf']);
+  var trafs = inspect.findBox(segment, ['moof', 'traf']);
   // To get SEI NAL units
-  var mdats = probe.findBox(segment, ['mdat']);
+  var mdats = inspect.findBox(segment, ['mdat']);
   var captionNals = {};
   var mdatTrafPairs = [];
 
@@ -188,14 +187,14 @@ var parseCaptionNals = function(segment, videoTrackId) {
   mdatTrafPairs.forEach(function(pair) {
     var mdat = pair.mdat;
     var traf = pair.traf;
-    var tfhd = probe.findBox(traf, ['tfhd']);
+    var tfhd = inspect.findBox(traf, ['tfhd']);
     // Exactly 1 tfhd per traf
     var headerInfo = inspect.parseTfhd(tfhd[0]);
     var trackId = headerInfo.trackId;
-    var tfdt = probe.findBox(traf, ['tfdt']);
+    var tfdt = inspect.findBox(traf, ['tfdt']);
     // Either 0 or 1 tfdt per traf
     var baseMediaDecodeTime = (tfdt.length > 0) ? inspect.parseTfdt(tfdt[0]).baseMediaDecodeTime : 0;
-    var truns = probe.findBox(traf, ['trun']);
+    var truns = inspect.findBox(traf, ['trun']);
     var samples;
     var seiNals;
 


### PR DESCRIPTION
Saves us 435 gzipped bytes in VHS