### PR TITLE
fix: ID3 does not indicate aac data

### DIFF
--- a/lib/aac/utils.js
+++ b/lib/aac/utils.js
@@ -24,13 +24,35 @@ var ADTS_SAMPLING_FREQUENCIES = [
   7350
 ];
 
+var parseId3TagSize = function(header, byteIndex) {
+  var
+    returnSize = (header[byteIndex + 6] << 21) |
+                 (header[byteIndex + 7] << 14) |
+                 (header[byteIndex + 8] << 7) |
+                 (header[byteIndex + 9]),
+    flags = header[byteIndex + 5],
+    footerPresent = (flags & 16) >> 4;
+
+  if (footerPresent) {
+    return returnSize + 20;
+  }
+  return returnSize + 10;
+};
+
+// TODO: use vhs-utils
 var isLikelyAacData = function(data) {
+  var offset = 0;
+
   if ((data[0] === 'I'.charCodeAt(0)) &&
       (data[1] === 'D'.charCodeAt(0)) &&
       (data[2] === '3'.charCodeAt(0))) {
-    return true;
+    offset = parseId3TagSize(data, 0);
   }
-  return false;
+
+  return data.length >= offset + 2 &&
+    (data[offset] & 0xFF) === 0xFF &&
+    (data[offset + 1] & 0xE0) === 0xE0 &&
+    (data[offset + 1] & 0x16) === 0x10;
 };
 
 var parseSyncSafeInteger = function(data) {
@@ -54,21 +76,6 @@ var percentEncode = function(bytes, start, end) {
 // interpreted as ISO-8859-1.
 var parseIso88591 = function(bytes, start, end) {
   return unescape(percentEncode(bytes, start, end)); // jshint ignore:line
-};
-
-var parseId3TagSize = function(header, byteIndex) {
-  var
-    returnSize = (header[byteIndex + 6] << 21) |
-                 (header[byteIndex + 7] << 14) |
-                 (header[byteIndex + 8] << 7) |
-                 (header[byteIndex + 9]),
-    flags = header[byteIndex + 5],
-    footerPresent = (flags & 16) >> 4;
-
-  if (footerPresent) {
-    return returnSize + 20;
-  }
-  return returnSize + 10;
 };
 
 var parseAdtsSize = function(header, byteIndex) {

--- a/lib/aac/utils.js
+++ b/lib/aac/utils.js
@@ -43,7 +43,7 @@ var parseId3TagSize = function(header, byteIndex) {
 var isLikelyAacData = function(data) {
   var offset = 0;
 
-  if ((data[0] === 'I'.charCodeAt(0)) &&
+  if (data.length > 10 && (data[0] === 'I'.charCodeAt(0)) &&
       (data[1] === 'D'.charCodeAt(0)) &&
       (data[2] === '3'.charCodeAt(0))) {
     offset = parseId3TagSize(data, 0);

--- a/lib/aac/utils.js
+++ b/lib/aac/utils.js
@@ -51,9 +51,9 @@ var isLikelyAacData = function(data) {
 
   return data.length >= offset + 2 &&
     (data[offset] & 0xFF) === 0xFF &&
+    (data[offset + 1] & 0xE0) === 0xE0 &&
     // verify that the 2 layer bits are 0, aka this
     // is not mp3 data but aac data.
-    (data[offset + 1] & 0xE0) === 0xE0 &&
     (data[offset + 1] & 0x16) === 0x10;
 };
 

--- a/lib/aac/utils.js
+++ b/lib/aac/utils.js
@@ -51,7 +51,7 @@ var isLikelyAacData = function(data) {
 
   return data.length >= offset + 2 &&
     (data[offset] & 0xFF) === 0xFF &&
-    (data[offset + 1] & 0xE0) === 0xE0 &&
+    (data[offset + 1] & 0xF0) === 0xF0 &&
     // verify that the 2 layer bits are 0, aka this
     // is not mp3 data but aac data.
     (data[offset + 1] & 0x16) === 0x10;

--- a/lib/aac/utils.js
+++ b/lib/aac/utils.js
@@ -51,6 +51,8 @@ var isLikelyAacData = function(data) {
 
   return data.length >= offset + 2 &&
     (data[offset] & 0xFF) === 0xFF &&
+    // verify that the 2 layer bits are 0, aka this
+    // is not mp3 data but aac data.
     (data[offset + 1] & 0xE0) === 0xE0 &&
     (data[offset + 1] & 0x16) === 0x10;
 };

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -911,26 +911,28 @@ Transmuxer = function(options) {
     });
 
     pipeline.aacStream.on('data', function(data) {
-      if ((data.type === 'timed-metadata' || data.type === 'audio') && !pipeline.audioSegmentStream) {
-        audioTrack = audioTrack || {
-          timelineStartInfo: {
-            baseMediaDecodeTime: self.baseMediaDecodeTime
-          },
-          codec: 'adts',
-          type: 'audio'
-        };
-        // hook up the audio segment stream to the first track with aac data
-        pipeline.coalesceStream.numberOfTracks++;
-        pipeline.audioSegmentStream = new AudioSegmentStream(audioTrack, options);
-
-        pipeline.audioSegmentStream.on('timingInfo',
-          self.trigger.bind(self, 'audioTimingInfo'));
-
-        // Set up the final part of the audio pipeline
-        pipeline.adtsStream
-          .pipe(pipeline.audioSegmentStream)
-          .pipe(pipeline.coalesceStream);
+      if ((data.type !== 'timed-metadata' && data.type !== 'audio') || pipeline.audioSegmentStream) {
+        return;
       }
+
+      audioTrack = audioTrack || {
+        timelineStartInfo: {
+          baseMediaDecodeTime: self.baseMediaDecodeTime
+        },
+        codec: 'adts',
+        type: 'audio'
+      };
+      // hook up the audio segment stream to the first track with aac data
+      pipeline.coalesceStream.numberOfTracks++;
+      pipeline.audioSegmentStream = new AudioSegmentStream(audioTrack, options);
+
+      pipeline.audioSegmentStream.on('timingInfo',
+        self.trigger.bind(self, 'audioTimingInfo'));
+
+      // Set up the final part of the audio pipeline
+      pipeline.adtsStream
+        .pipe(pipeline.audioSegmentStream)
+        .pipe(pipeline.coalesceStream);
 
       // emit pmt info
       self.trigger('trackinfo', {

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -911,7 +911,7 @@ Transmuxer = function(options) {
     });
 
     pipeline.aacStream.on('data', function(data) {
-      if (data.type === 'timed-metadata' && !pipeline.audioSegmentStream) {
+      if ((data.type === 'timed-metadata' || data.type === 'audio') && !pipeline.audioSegmentStream) {
         audioTrack = audioTrack || {
           timelineStartInfo: {
             baseMediaDecodeTime: self.baseMediaDecodeTime

--- a/lib/partial/transmuxer.js
+++ b/lib/partial/transmuxer.js
@@ -186,7 +186,7 @@ var aacPipeline = function(options) {
   });
 
   pipeline.aacStream.on('data', function(data) {
-    if (data.type !== 'timed-metadata' || pipeline.audioSegmentStream) {
+    if ((data.type !== 'timed-metadata' && data.type !== 'audio') || pipeline.audioSegmentStream) {
       return;
     }
 

--- a/test/aac-utils.test.js
+++ b/test/aac-utils.test.js
@@ -11,6 +11,15 @@ var audioFrameOffset = 73;
 
 QUnit.module('AAC Utils');
 
+QUnit.test('correctly determines aac data', function(assert) {
+  assert.ok(utils.isLikelyAacData(testSegment), 'test segment is aac');
+
+  var id3Offset = utils.parseId3TagSize(testSegment, 0);
+
+  assert.ok(utils.isLikelyAacData(testSegment.subarray(id3Offset)), 'test segment is aac without id3');
+});
+
+
 QUnit.test('correctly parses aac packet type', function() {
   QUnit.equal(utils.parseType(testSegment, id3TagOffset), 'timed-metadata',
     'parsed timed-metadata type');

--- a/test/aac-utils.test.js
+++ b/test/aac-utils.test.js
@@ -17,7 +17,7 @@ QUnit.test('correctly determines aac data', function(assert) {
   var id3Offset = utils.parseId3TagSize(testSegment, 0);
   assert.ok(utils.isLikelyAacData(testSegment.subarray(id3Offset)), 'test segment is aac without id3');
   assert.notOk(utils.isLikelyAacData(testSegment.subarray(id3Offset + 25)), 'non aac data not recognized');
-  assert.notOk(utils.isLikelyAacData(testSegment.subarray(0, 5)), 'not enouch aac data is not recognized');
+  assert.notOk(utils.isLikelyAacData(testSegment.subarray(0, 5)), 'not enough aac data is not recognized');
 });
 
 

--- a/test/aac-utils.test.js
+++ b/test/aac-utils.test.js
@@ -15,8 +15,9 @@ QUnit.test('correctly determines aac data', function(assert) {
   assert.ok(utils.isLikelyAacData(testSegment), 'test segment is aac');
 
   var id3Offset = utils.parseId3TagSize(testSegment, 0);
-
   assert.ok(utils.isLikelyAacData(testSegment.subarray(id3Offset)), 'test segment is aac without id3');
+  assert.notOk(utils.isLikelyAacData(testSegment.subarray(id3Offset + 25)), 'non aac data not recognized');
+  assert.notOk(utils.isLikelyAacData(testSegment.subarray(0, 5)), 'not enouch aac data is not recognized');
 });
 
 

--- a/test/transmuxer.test.js
+++ b/test/transmuxer.test.js
@@ -3791,14 +3791,14 @@ QUnit.test('pipeline dynamically configures itself based on input', function() {
   transmuxer.flush();
   QUnit.equal(transmuxer.transmuxPipeline_.type, 'ts', 'detected TS file data');
 
-  transmuxer.push(new Uint8Array(id3.id3Tag(id3.id3Frame('PRIV', 0x00, 0x01))));
+  transmuxer.push(new Uint8Array(id3.id3Tag(id3.id3Frame('PRIV', 0x00, 0x01)).concat([0xFF, 0xF1])));
   transmuxer.flush();
   QUnit.equal(transmuxer.transmuxPipeline_.type, 'aac', 'detected AAC file data');
 });
 
 QUnit.test('reuses audio track object when the pipeline reconfigures itself', function() {
   var boxes, segments = [],
-    id3Tag = new Uint8Array(73),
+    id3Tag = new Uint8Array(75),
     streamTimestamp = 'com.apple.streaming.transportStreamTimestamp',
     priv = 'PRIV',
     i,
@@ -3813,6 +3813,8 @@ QUnit.test('reuses audio track object when the pipeline reconfigures itself', fu
   id3Tag[70] = 13;
   id3Tag[71] = 187;
   id3Tag[72] = 160;
+  id3Tag[73] = 0xFF;
+  id3Tag[74] = 0xF1;
 
   for (i = 0; i < priv.length; i++) {
     id3Tag[i + 10] = priv.charCodeAt(i);


### PR DESCRIPTION
ID3 tags are not specific to aac data. Almost any audio container format can use it. AAC has a specific syncbyte `0xFFF1` that we need to look for instead.