### PR TITLE
fix: handle recursive id3 in isLikelyAacData

### DIFF
--- a/lib/aac/utils.js
+++ b/lib/aac/utils.js
@@ -45,7 +45,7 @@ var parseId3TagSize = function(header, byteIndex) {
 var getId3Offset = function(data, offset) {
   if (data.length - offset < 10 ||
       data[offset] !== 'I'.charCodeAt(0) ||
-      data[offset + 1] !== 'D'.charCodeAt(0) &&
+      data[offset + 1] !== 'D'.charCodeAt(0) ||
       data[offset + 2] !== '3'.charCodeAt(0)) {
     return offset;
   }

--- a/lib/aac/utils.js
+++ b/lib/aac/utils.js
@@ -39,15 +39,23 @@ var parseId3TagSize = function(header, byteIndex) {
   return returnSize + 10;
 };
 
+var getId3Offset = function(data, offset) {
+  if (data.length - offset < 10 ||
+      data[offset] !== 'I'.charCodeAt(0) ||
+      data[offset + 1] !== 'D'.charCodeAt(0) &&
+      data[offset + 2] !== '3'.charCodeAt(0)) {
+    return offset;
+  }
+
+  offset += parseId3TagSize(data, offset);
+
+  return getId3Offset(data, offset);
+};
+
+
 // TODO: use vhs-utils
 var isLikelyAacData = function(data) {
-  var offset = 0;
-
-  if (data.length > 10 && (data[0] === 'I'.charCodeAt(0)) &&
-      (data[1] === 'D'.charCodeAt(0)) &&
-      (data[2] === '3'.charCodeAt(0))) {
-    offset = parseId3TagSize(data, 0);
-  }
+  var offset = getId3Offset(data, 0);
 
   return data.length >= offset + 2 &&
     (data[offset] & 0xFF) === 0xFF &&

--- a/lib/aac/utils.js
+++ b/lib/aac/utils.js
@@ -33,6 +33,9 @@ var parseId3TagSize = function(header, byteIndex) {
     flags = header[byteIndex + 5],
     footerPresent = (flags & 16) >> 4;
 
+  // if we get a negative returnSize clamp it to 0
+  returnSize = returnSize >= 0 ? returnSize : 0;
+
   if (footerPresent) {
     return returnSize + 20;
   }

--- a/test/aac-utils.test.js
+++ b/test/aac-utils.test.js
@@ -14,10 +14,22 @@ QUnit.module('AAC Utils');
 QUnit.test('correctly determines aac data', function(assert) {
   assert.ok(utils.isLikelyAacData(testSegment), 'test segment is aac');
 
+
   var id3Offset = utils.parseId3TagSize(testSegment, 0);
-  assert.ok(utils.isLikelyAacData(testSegment.subarray(id3Offset)), 'test segment is aac without id3');
+  const id3 = Array.prototype.slice.call(testSegment, 0, id3Offset);
+  const segmentOnly = testSegment.subarray(id3Offset);
+  const multipleId3 = new Uint8Array([]
+    .concat(id3)
+    .concat(id3)
+    .concat(id3)
+    .concat(id3)
+    .concat(Array.prototype.slice.call(segmentOnly))
+  )
+
+  assert.ok(utils.isLikelyAacData(segmentOnly), 'test segment is aac without id3');
   assert.notOk(utils.isLikelyAacData(testSegment.subarray(id3Offset + 25)), 'non aac data not recognized');
   assert.notOk(utils.isLikelyAacData(testSegment.subarray(0, 5)), 'not enough aac data is not recognized');
+  assert.ok(utils.isLikelyAacData(multipleId3), 'test segment with multilpe id3');
 });
 
 

--- a/test/aac-utils.test.js
+++ b/test/aac-utils.test.js
@@ -16,15 +16,15 @@ QUnit.test('correctly determines aac data', function(assert) {
 
 
   var id3Offset = utils.parseId3TagSize(testSegment, 0);
-  const id3 = Array.prototype.slice.call(testSegment, 0, id3Offset);
-  const segmentOnly = testSegment.subarray(id3Offset);
-  const multipleId3 = new Uint8Array([]
+  var id3 = Array.prototype.slice.call(testSegment, 0, id3Offset);
+  var segmentOnly = testSegment.subarray(id3Offset);
+  var multipleId3 = new Uint8Array([]
     .concat(id3)
     .concat(id3)
     .concat(id3)
     .concat(id3)
     .concat(Array.prototype.slice.call(segmentOnly))
-  )
+  );
 
   assert.ok(utils.isLikelyAacData(segmentOnly), 'test segment is aac without id3');
   assert.notOk(utils.isLikelyAacData(testSegment.subarray(id3Offset + 25)), 'non aac data not recognized');


### PR DESCRIPTION
handle multiple id3 sections at the start of aac data.