### PR TITLE
# add duration option

### DIFF
--- a/lib/mp4/mp4-generator.js
+++ b/lib/mp4/mp4-generator.js
@@ -15,6 +15,7 @@ var box, dinf, esds, ftyp, mdat, mfhd, minf, moof, moov, mvex, mvhd,
     trak, tkhd, mdia, mdhd, hdlr, sdtp, stbl, stsd, traf, trex,
     trun, types, MAJOR_BRAND, MINOR_VERSION, AVC1_BRAND, VIDEO_HDLR,
     AUDIO_HDLR, HDLR_TYPES, VMHD, SMHD, DREF, STCO, STSC, STSZ, STTS;
+var customDuration = 0xffffffff;
 
 // pre-calculate constants
 (function() {
@@ -254,6 +255,13 @@ mdhd = function(track) {
     result[13] = (track.samplerate >>> 16) & 0xFF;
     result[14] = (track.samplerate >>>  8) & 0xFF;
     result[15] = (track.samplerate)        & 0xFF;
+
+    // reset duration
+    track.duration = track.duration / 90000 * track.samplerate;
+    result[16] = (track.duration >>> 24) & 0xFF;
+    result[17] = (track.duration >>> 16) & 0xFF;
+    result[18] = (track.duration >>> 8) & 0xFF;
+    result[19] = (track.duration) & 0xFF;
   }
 
   return box(types.mdhd, result);
@@ -304,7 +312,7 @@ moov = function(tracks) {
     boxes[i] = trak(tracks[i]);
   }
 
-  return box.apply(null, [types.moov, mvhd(0xffffffff)].concat(boxes).concat(mvex(tracks)));
+  return box.apply(null, [types.moov, mvhd(customDuration)].concat(boxes).concat(mvex(tracks)));
 };
 mvex = function(tracks) {
   var
@@ -636,7 +644,7 @@ traf = function(track) {
  * @return {Uint8Array} the track box
  */
 trak = function(track) {
-  track.duration = track.duration || 0xffffffff;
+  track.duration = track.duration || customDuration;
   return box(types.trak,
              tkhd(track),
              mdia(track));
@@ -785,6 +793,11 @@ module.exports = {
   mdat: mdat,
   moof: moof,
   moov: moov,
+  setDuration: function(duration) {
+    if (duration) {
+      customDuration = duration * 90000;
+    }
+  },
   initSegment: function(tracks) {
     var
       fileType = ftyp(),

--- a/lib/mp4/transmuxer.js
+++ b/lib/mp4/transmuxer.js
@@ -882,6 +882,7 @@ Transmuxer = function(options) {
   options = options || {};
   this.baseMediaDecodeTime = options.baseMediaDecodeTime || 0;
   this.transmuxPipeline_ = {};
+  mp4.setDuration(options.duration);
 
   this.setupAacPipeline = function() {
     var pipeline = {};


### PR DESCRIPTION
fixed duration's bug in https://github.com/videojs/mux.js/issues/210
add an muxjs.mp4.Transmuxer option 「duration」，can specify mp4 duration。
```
var durationSecond = 60 // video duration
var transmuxer = new muxjs.mp4.Transmuxer({
  duration: durationSecond, 
});
```

