### PR TITLE
feat: support codec probes for opus/flac

### DIFF
--- a/lib/mp4/probe.js
+++ b/lib/mp4/probe.js
@@ -335,7 +335,8 @@ getTracks = function(init) {
             track.codec = 'mp4a.40.2';
           }
         } else {
-          // TODO: show a warning? for unknown codec type
+          // flac, opus, etc
+          track.codec = track.codec.toLowerCase();
         }
       }
     }


### PR DESCRIPTION
`flac` comes in as `fLaC` which is an invalid codec in chrome unless it is lower case. `opus` comes in as `Opus` and that has the same issue.