### PR TITLE
Check if baseTimestamp is NaN

### DIFF
--- a/lib/tools/ts-inspector.js
+++ b/lib/tools/ts-inspector.js
@@ -318,7 +318,7 @@ var parseVideoPes_ = function(bytes, pmt, result) {
 var adjustTimestamp_ = function(segmentInfo, baseTimestamp) {
   if (segmentInfo.audio && segmentInfo.audio.length) {
     var audioBaseTimestamp = baseTimestamp;
-    if (typeof audioBaseTimestamp === 'undefined') {
+    if (typeof audioBaseTimestamp === 'undefined' || isNaN(audioBaseTimestamp)) {
       audioBaseTimestamp = segmentInfo.audio[0].dts;
     }
     segmentInfo.audio.forEach(function(info) {
@@ -332,7 +332,7 @@ var adjustTimestamp_ = function(segmentInfo, baseTimestamp) {
 
   if (segmentInfo.video && segmentInfo.video.length) {
     var videoBaseTimestamp = baseTimestamp;
-    if (typeof videoBaseTimestamp === 'undefined') {
+    if (typeof videoBaseTimestamp === 'undefined' || isNaN(videoBaseTimestamp)) {
       videoBaseTimestamp = segmentInfo.video[0].dts;
     }
     segmentInfo.video.forEach(function(info) {


### PR DESCRIPTION
if baseTimestamp is NaN, we do not set the baseTimestamp for the track... This means when video.js http-streaming uses mux.js to transmux from TS to MP4, the probe timestamp results use a 0-based baseMediaDecodeTime and the actual transmux uses a DTS-based baseMediaDecodeTime.

If not doing a partial transmux, this causes video.js to use a start time of 0 (from probe) and an end time of DTS (whatever that is). If DTS happens to be negative, then the duration calculated for the first segment ends up being ~25 hours (close to 2^33, the size of the DTS field, because DTS is being interpreted unsigned)

See:
https://github.com/videojs/http-streaming/blob/main/src/media-segment-request.js#L289-L308
https://github.com/videojs/http-streaming/blob/main/src/media-segment-request.js#L329-L339