### PR TITLE
fix: ignore buffered packet data with no pes header

### DIFF
--- a/lib/m2ts/m2ts.js
+++ b/lib/m2ts/m2ts.js
@@ -310,51 +310,58 @@ ElementaryStream = function() {
     programMapTable,
     parsePes = function(payload, pes) {
       var ptsDtsFlags;
+      const startPrefix = payload[0] << 16 | payload[1] << 8 | payload[2]
+      // default to an empty array
+      pes.data = new Uint8Array()
+      // In certain live streams, the start of a TS fragment has ts packets
+      // that are frame data that is continuing from the previous fragment. This
+      // is to check that the pes data is the start of a new pes payload
+      if (startPrefix === 1) {
+        // get the packet length, this will be 0 for video
+        pes.packetLength = 6 + ((payload[4] << 8) | payload[5]);
 
-      // get the packet length, this will be 0 for video
-      pes.packetLength = 6 + ((payload[4] << 8) | payload[5]);
+        // find out if this packets starts a new keyframe
+        pes.dataAlignmentIndicator = (payload[6] & 0x04) !== 0;
+        // PES packets may be annotated with a PTS value, or a PTS value
+        // and a DTS value. Determine what combination of values is
+        // available to work with.
+        ptsDtsFlags = payload[7];
 
-      // find out if this packets starts a new keyframe
-      pes.dataAlignmentIndicator = (payload[6] & 0x04) !== 0;
-      // PES packets may be annotated with a PTS value, or a PTS value
-      // and a DTS value. Determine what combination of values is
-      // available to work with.
-      ptsDtsFlags = payload[7];
-
-      // PTS and DTS are normally stored as a 33-bit number.  Javascript
-      // performs all bitwise operations on 32-bit integers but javascript
-      // supports a much greater range (52-bits) of integer using standard
-      // mathematical operations.
-      // We construct a 31-bit value using bitwise operators over the 31
-      // most significant bits and then multiply by 4 (equal to a left-shift
-      // of 2) before we add the final 2 least significant bits of the
-      // timestamp (equal to an OR.)
-      if (ptsDtsFlags & 0xC0) {
-        // the PTS and DTS are not written out directly. For information
-        // on how they are encoded, see
-        // http://dvd.sourceforge.net/dvdinfo/pes-hdr.html
-        pes.pts = (payload[9] & 0x0E) << 27 |
-          (payload[10] & 0xFF) << 20 |
-          (payload[11] & 0xFE) << 12 |
-          (payload[12] & 0xFF) <<  5 |
-          (payload[13] & 0xFE) >>>  3;
-        pes.pts *= 4; // Left shift by 2
-        pes.pts += (payload[13] & 0x06) >>> 1; // OR by the two LSBs
-        pes.dts = pes.pts;
-        if (ptsDtsFlags & 0x40) {
-          pes.dts = (payload[14] & 0x0E) << 27 |
-            (payload[15] & 0xFF) << 20 |
-            (payload[16] & 0xFE) << 12 |
-            (payload[17] & 0xFF) << 5 |
-            (payload[18] & 0xFE) >>> 3;
-          pes.dts *= 4; // Left shift by 2
-          pes.dts += (payload[18] & 0x06) >>> 1; // OR by the two LSBs
+        // PTS and DTS are normally stored as a 33-bit number.  Javascript
+        // performs all bitwise operations on 32-bit integers but javascript
+        // supports a much greater range (52-bits) of integer using standard
+        // mathematical operations.
+        // We construct a 31-bit value using bitwise operators over the 31
+        // most significant bits and then multiply by 4 (equal to a left-shift
+        // of 2) before we add the final 2 least significant bits of the
+        // timestamp (equal to an OR.)
+        if (ptsDtsFlags & 0xC0) {
+          // the PTS and DTS are not written out directly. For information
+          // on how they are encoded, see
+          // http://dvd.sourceforge.net/dvdinfo/pes-hdr.html
+          pes.pts = (payload[9] & 0x0E) << 27 |
+            (payload[10] & 0xFF) << 20 |
+            (payload[11] & 0xFE) << 12 |
+            (payload[12] & 0xFF) <<  5 |
+            (payload[13] & 0xFE) >>>  3;
+          pes.pts *= 4; // Left shift by 2
+          pes.pts += (payload[13] & 0x06) >>> 1; // OR by the two LSBs
+          pes.dts = pes.pts;
+          if (ptsDtsFlags & 0x40) {
+            pes.dts = (payload[14] & 0x0E) << 27 |
+              (payload[15] & 0xFF) << 20 |
+              (payload[16] & 0xFE) << 12 |
+              (payload[17] & 0xFF) << 5 |
+              (payload[18] & 0xFE) >>> 3;
+            pes.dts *= 4; // Left shift by 2
+            pes.dts += (payload[18] & 0x06) >>> 1; // OR by the two LSBs
+          }
         }
+        // the data section starts immediately after the PES header.
+        // pes_header_data_length specifies the number of header bytes
+        // that follow the last byte of the field.
+        pes.data = payload.subarray(9 + payload[8]);
       }
-      // the data section starts immediately after the PES header.
-      // pes_header_data_length specifies the number of header bytes
-      // that follow the last byte of the field.
-      pes.data = payload.subarray(9 + payload[8]);
     },
     /**
       * Pass completely parsed PES packets to the next stream in the pipeline

--- a/lib/m2ts/m2ts.js
+++ b/lib/m2ts/m2ts.js
@@ -317,7 +317,7 @@ ElementaryStream = function() {
       // that are frame data that is continuing from the previous fragment. This
       // is to check that the pes data is the start of a new pes payload
       if (startPrefix !== 1) {
-        return
+        return;
       }
       // get the packet length, this will be 0 for video
       pes.packetLength = 6 + ((payload[4] << 8) | payload[5]);

--- a/lib/m2ts/m2ts.js
+++ b/lib/m2ts/m2ts.js
@@ -316,52 +316,53 @@ ElementaryStream = function() {
       // In certain live streams, the start of a TS fragment has ts packets
       // that are frame data that is continuing from the previous fragment. This
       // is to check that the pes data is the start of a new pes payload
-      if (startPrefix === 1) {
-        // get the packet length, this will be 0 for video
-        pes.packetLength = 6 + ((payload[4] << 8) | payload[5]);
-
-        // find out if this packets starts a new keyframe
-        pes.dataAlignmentIndicator = (payload[6] & 0x04) !== 0;
-        // PES packets may be annotated with a PTS value, or a PTS value
-        // and a DTS value. Determine what combination of values is
-        // available to work with.
-        ptsDtsFlags = payload[7];
-
-        // PTS and DTS are normally stored as a 33-bit number.  Javascript
-        // performs all bitwise operations on 32-bit integers but javascript
-        // supports a much greater range (52-bits) of integer using standard
-        // mathematical operations.
-        // We construct a 31-bit value using bitwise operators over the 31
-        // most significant bits and then multiply by 4 (equal to a left-shift
-        // of 2) before we add the final 2 least significant bits of the
-        // timestamp (equal to an OR.)
-        if (ptsDtsFlags & 0xC0) {
-          // the PTS and DTS are not written out directly. For information
-          // on how they are encoded, see
-          // http://dvd.sourceforge.net/dvdinfo/pes-hdr.html
-          pes.pts = (payload[9] & 0x0E) << 27 |
-            (payload[10] & 0xFF) << 20 |
-            (payload[11] & 0xFE) << 12 |
-            (payload[12] & 0xFF) <<  5 |
-            (payload[13] & 0xFE) >>>  3;
-          pes.pts *= 4; // Left shift by 2
-          pes.pts += (payload[13] & 0x06) >>> 1; // OR by the two LSBs
-          pes.dts = pes.pts;
-          if (ptsDtsFlags & 0x40) {
-            pes.dts = (payload[14] & 0x0E) << 27 |
-              (payload[15] & 0xFF) << 20 |
-              (payload[16] & 0xFE) << 12 |
-              (payload[17] & 0xFF) << 5 |
-              (payload[18] & 0xFE) >>> 3;
-            pes.dts *= 4; // Left shift by 2
-            pes.dts += (payload[18] & 0x06) >>> 1; // OR by the two LSBs
-          }
-        }
-        // the data section starts immediately after the PES header.
-        // pes_header_data_length specifies the number of header bytes
-        // that follow the last byte of the field.
-        pes.data = payload.subarray(9 + payload[8]);
+      if (startPrefix !== 1) {
+        return
       }
+      // get the packet length, this will be 0 for video
+      pes.packetLength = 6 + ((payload[4] << 8) | payload[5]);
+
+      // find out if this packets starts a new keyframe
+      pes.dataAlignmentIndicator = (payload[6] & 0x04) !== 0;
+      // PES packets may be annotated with a PTS value, or a PTS value
+      // and a DTS value. Determine what combination of values is
+      // available to work with.
+      ptsDtsFlags = payload[7];
+
+      // PTS and DTS are normally stored as a 33-bit number.  Javascript
+      // performs all bitwise operations on 32-bit integers but javascript
+      // supports a much greater range (52-bits) of integer using standard
+      // mathematical operations.
+      // We construct a 31-bit value using bitwise operators over the 31
+      // most significant bits and then multiply by 4 (equal to a left-shift
+      // of 2) before we add the final 2 least significant bits of the
+      // timestamp (equal to an OR.)
+      if (ptsDtsFlags & 0xC0) {
+        // the PTS and DTS are not written out directly. For information
+        // on how they are encoded, see
+        // http://dvd.sourceforge.net/dvdinfo/pes-hdr.html
+        pes.pts = (payload[9] & 0x0E) << 27 |
+          (payload[10] & 0xFF) << 20 |
+          (payload[11] & 0xFE) << 12 |
+          (payload[12] & 0xFF) <<  5 |
+          (payload[13] & 0xFE) >>>  3;
+        pes.pts *= 4; // Left shift by 2
+        pes.pts += (payload[13] & 0x06) >>> 1; // OR by the two LSBs
+        pes.dts = pes.pts;
+        if (ptsDtsFlags & 0x40) {
+          pes.dts = (payload[14] & 0x0E) << 27 |
+            (payload[15] & 0xFF) << 20 |
+            (payload[16] & 0xFE) << 12 |
+            (payload[17] & 0xFF) << 5 |
+            (payload[18] & 0xFE) >>> 3;
+          pes.dts *= 4; // Left shift by 2
+          pes.dts += (payload[18] & 0x06) >>> 1; // OR by the two LSBs
+        }
+      }
+      // the data section starts immediately after the PES header.
+      // pes_header_data_length specifies the number of header bytes
+      // that follow the last byte of the field.
+      pes.data = payload.subarray(9 + payload[8]);
     },
     /**
       * Pass completely parsed PES packets to the next stream in the pipeline


### PR DESCRIPTION
**Description**
This is a fix for ts files that carry PES packets of framed data from the previous ts fragment. This addresses the `ERROR: (CODE:3 MEDIA_ERR_DECODE)` for the cause
```
The media playback was aborted due to a corruption…media used features your browser did not support
```
or
```
[video|audio] append of [x]b failed for segment #[n]
```

**Content**
The stream I was able to reproduce the bug with is https://e3e2p5m2.ssl.hwcdn.net/hls/main.m3u8. I was able to record when the bug occurred and uploaded the recorded content to https://drive.google.com/drive/folders/174ef0f6DOdMaXI6f3CLYSw_9H5emxzM0?usp=sharing. There is a generated VOD manifest for the recorded content. 

**Steps to reproduce**
I was able to produce this bug using Video.js (v7.11.4).
If you try to playback the content, you can trigger the bug when the player changes bitrates from segment `segment51788.ts @5-1280x720` to segment `segment51788.ts @0-1920x1080`. Another way to quickly see this is by commenting out all the playlists besides `0-1920x1080` and comment out segments `segment51786.ts` and `segment51787.ts`. This is will generate an incorrect init segment. The corrupted generated init segment has an sps that is incorrect. The width and height are 96 X 96 when the content is really 1920 X 1080. The avcC box has incorrect properties that looks like this
```json
{
  "AVCProfileIndication": 252,
  "profile_compatibility": 233,
  "AVCLevelIndication": 163
}
```
when the codec profile and level values should be 
```json
{
  "AVCProfileIndication": 77,
  "profile_compatibility": 64,
  "AVCLevelIndication": 40
}
```

**Issue**
This is happening because in fragment `segment51788.ts @0-1920x1080`, its first 3 ts packets are video pes packets that are continue frame data from the previous fragment. So those 3 PES packets have been buffered and when the next `payload_unit_start_indicator` comes by, it flushes those packets and assumes there is a PES header and when it's pushed to the NalByteStream it incorrectly sees an sps and creates the incorrect config from there. 

```

| pes[0] (v) | pes[1] (v) | pes[2] (v) | ... | pes[9] (payload_start_indicator) (v)| pes[10] (v) | ...
```

**Solution**
The solution I came up with is when the buffered PES packets are flushed to the be parsed, it will check for the first three bytes of the data payload for the start prefix (0x000001) and it will ignore the payload the return an empty `Uint8Array`. 