### PR TITLE
fix: inspect all program map tables for stream types

### DIFF
--- a/lib/tools/ts-inspector.js
+++ b/lib/tools/ts-inspector.js
@@ -38,22 +38,13 @@ var parsePsi_ = function(bytes, pmt) {
 
       switch (type) {
         case 'pat':
-          if (!pmt.pid) {
-            pmt.pid = probe.ts.parsePat(packet);
-          }
+          var pid = probe.ts.parsePat(packet);
           break;
         case 'pmt':
-          if (!pmt.table) {
-            pmt.table = probe.ts.parsePmt(packet);
-          }
+          var pmt = probe.ts.parsePmt(packet);
           break;
         default:
           break;
-      }
-
-      // Found the pat and pmt, we can stop walking the segment
-      if (pmt.pid && pmt.table) {
-        return;
       }
 
       startIndex += MP2T_PACKET_LENGTH;

--- a/lib/tools/ts-inspector.js
+++ b/lib/tools/ts-inspector.js
@@ -38,10 +38,17 @@ var parsePsi_ = function(bytes, pmt) {
 
       switch (type) {
         case 'pat':
-          var pid = probe.ts.parsePat(packet);
+          pmt.pid = probe.ts.parsePat(packet);
           break;
         case 'pmt':
-          var pmt = probe.ts.parsePmt(packet);
+          var table = probe.ts.parsePmt(packet);
+
+          pmt.table = pmt.table || {};
+
+          Object.keys(table).forEach(function(key) {
+            pmt.table[key] = table[key];
+          });
+
           break;
         default:
           break;


### PR DESCRIPTION
We currently have issues with ts files that add stream types after the first program map table as we only look at the first one. So if audio were to be added in a subsequent program map table we wouldn't know to account for it.