### PR TITLE
fix: on flush if a pmt has not been emitted and we have one, emit it

### DIFF
--- a/lib/m2ts/m2ts.js
+++ b/lib/m2ts/m2ts.js
@@ -294,6 +294,7 @@ TransportParseStream.STREAM_TYPES  = {
 ElementaryStream = function() {
   var
     self = this,
+    segmentHadPmt = false,
     // PES packet fragments
     video = {
       data: [],
@@ -406,6 +407,40 @@ ElementaryStream = function() {
         stream.data.length = 0;
       }
 
+      if (!segmentHadPmt) {
+        var
+          pmt = {
+            type: 'metadata',
+            tracks: []
+          };
+        // translate audio and video streams to tracks
+        if (programMapTable.video !== null) {
+          pmt.tracks.push({
+            timelineStartInfo: {
+              baseMediaDecodeTime: 0
+            },
+            id: +programMapTable.video,
+            codec: 'avc',
+            type: 'video'
+          });
+        }
+
+        if (programMapTable.audio !== null) {
+          pmt.tracks.push({
+            timelineStartInfo: {
+              baseMediaDecodeTime: 0
+            },
+            id: +programMapTable.audio,
+            codec: 'adts',
+            type: 'audio'
+          });
+        }
+
+        self.trigger('data', pmt);
+      }
+
+      segmentHadPmt = false;
+
       // only emit packets that are complete. this is to avoid assembling
       // incomplete PES packets due to poor segmentation
       if (packetFlushable) {
@@ -487,6 +522,8 @@ ElementaryStream = function() {
             type: 'audio'
           });
         }
+
+        segmentHadPmt = true;
 
         self.trigger('data', event);
       }

--- a/lib/m2ts/m2ts.js
+++ b/lib/m2ts/m2ts.js
@@ -407,40 +407,6 @@ ElementaryStream = function() {
         stream.data.length = 0;
       }
 
-      if (!segmentHadPmt) {
-        var
-          pmt = {
-            type: 'metadata',
-            tracks: []
-          };
-        // translate audio and video streams to tracks
-        if (programMapTable.video !== null) {
-          pmt.tracks.push({
-            timelineStartInfo: {
-              baseMediaDecodeTime: 0
-            },
-            id: +programMapTable.video,
-            codec: 'avc',
-            type: 'video'
-          });
-        }
-
-        if (programMapTable.audio !== null) {
-          pmt.tracks.push({
-            timelineStartInfo: {
-              baseMediaDecodeTime: 0
-            },
-            id: +programMapTable.audio,
-            codec: 'adts',
-            type: 'audio'
-          });
-        }
-
-        self.trigger('data', pmt);
-      }
-
-      segmentHadPmt = false;
-
       // only emit packets that are complete. this is to avoid assembling
       // incomplete PES packets due to poor segmentation
       if (packetFlushable) {
@@ -556,6 +522,42 @@ ElementaryStream = function() {
   };
 
   this.flush = function() {
+    // if on flush we haven't had a pmt emitted
+    // and we have a pmt to emit. emit the pmt
+    // so that we trigger a trackinfo downstream.
+    if (!segmentHadPmt && programMapTable) {
+      var
+        pmt = {
+          type: 'metadata',
+          tracks: []
+        };
+      // translate audio and video streams to tracks
+      if (programMapTable.video !== null) {
+        pmt.tracks.push({
+          timelineStartInfo: {
+            baseMediaDecodeTime: 0
+          },
+          id: +programMapTable.video,
+          codec: 'avc',
+          type: 'video'
+        });
+      }
+
+      if (programMapTable.audio !== null) {
+        pmt.tracks.push({
+          timelineStartInfo: {
+            baseMediaDecodeTime: 0
+          },
+          id: +programMapTable.audio,
+          codec: 'adts',
+          type: 'audio'
+        });
+      }
+
+      self.trigger('data', pmt);
+    }
+
+    segmentHadPmt = false;
     this.flushStreams_();
     this.trigger('done');
   };


### PR DESCRIPTION
Always emit trackinfo, even if we didn't process a pmt.