### PR TITLE
fix: prevent skipping frames on garbage adts data

### DIFF
--- a/lib/codecs/adts.js
+++ b/lib/codecs/adts.js
@@ -76,8 +76,8 @@ AdtsStream = function(handlePartialSegments) {
     // unpack any ADTS frames which have been fully received
     // for details on the ADTS header, see http://wiki.multimedia.cx/index.php?title=ADTS
 
-    // we use i + 7 here because we want to be able to parse the entire header.
-    // If we don't have enough bytes to do that, than we definitely won't have a full frame.
+    // We use i + 7 here because we want to be able to parse the entire header.
+    // If we don't have enough bytes to do that, then we definitely won't have a full frame.
     while ((i + 7) < buffer.length) {
       // Look for the start of an ADTS header..
       if ((buffer[i] !== 0xFF) || (buffer[i + 1] & 0xF6) !== 0xF0) {

--- a/lib/codecs/adts.js
+++ b/lib/codecs/adts.js
@@ -79,13 +79,23 @@ AdtsStream = function(handlePartialSegments) {
     // we use i + 5 here because we want to be able to parse the frame length
     // from the header. If we don't have enough bytes to do that, than we
     // definitely won't have a full frame.
+    let skipping;
     while ((i + 5) < buffer.length) {
       // Look for the start of an ADTS header..
       if ((buffer[i] !== 0xFF) || (buffer[i + 1] & 0xF6) !== 0xF0) {
         // If a valid header was not found,  jump one forward and attempt to
         // find a valid ADTS header starting at the next byte
+        if (!skipping) {
+          skipping = i;
+        }
         i++;
         continue;
+      }
+
+      if (typeof skipping === 'number') {
+        console.log(skipping, i);
+        console.log('skipped', buffer.subarray(skipping, i - 1));
+        skipping = null;
       }
 
       // The protection skip bit tells us if we have 2 bytes of CRC data at the
@@ -94,6 +104,7 @@ AdtsStream = function(handlePartialSegments) {
 
       // Frame length is a 13 bit integer starting 16 bits from the
       // end of the sync sequence
+      // NOTE: frame length includes the size of the header
       frameLength = ((buffer[i + 3] & 0x03) << 11) |
         (buffer[i + 4] << 3) |
         ((buffer[i + 5] & 0xe0) >> 5);
@@ -120,6 +131,7 @@ AdtsStream = function(handlePartialSegments) {
         samplingfrequencyindex: (buffer[i + 2] & 0x3c) >>> 2,
         // assume ISO/IEC 14496-12 AudioSampleEntry default of 16
         samplesize: 16,
+        // data is the frame without it's header
         data: buffer.subarray(i + 7 + protectionSkipBytes, i + frameLength)
       });
 

--- a/lib/codecs/adts.js
+++ b/lib/codecs/adts.js
@@ -79,23 +79,13 @@ AdtsStream = function(handlePartialSegments) {
     // we use i + 5 here because we want to be able to parse the frame length
     // from the header. If we don't have enough bytes to do that, than we
     // definitely won't have a full frame.
-    let skipping;
     while ((i + 5) < buffer.length) {
       // Look for the start of an ADTS header..
       if ((buffer[i] !== 0xFF) || (buffer[i + 1] & 0xF6) !== 0xF0) {
         // If a valid header was not found,  jump one forward and attempt to
         // find a valid ADTS header starting at the next byte
-        if (!skipping) {
-          skipping = i;
-        }
         i++;
         continue;
-      }
-
-      if (typeof skipping === 'number') {
-        console.log(skipping, i);
-        console.log('skipped', buffer.subarray(skipping, i - 1));
-        skipping = null;
       }
 
       // The protection skip bit tells us if we have 2 bytes of CRC data at the

--- a/lib/codecs/adts.js
+++ b/lib/codecs/adts.js
@@ -76,10 +76,9 @@ AdtsStream = function(handlePartialSegments) {
     // unpack any ADTS frames which have been fully received
     // for details on the ADTS header, see http://wiki.multimedia.cx/index.php?title=ADTS
 
-    // we use i + 5 here because we want to be able to parse the frame length
-    // from the header. If we don't have enough bytes to do that, than we
-    // definitely won't have a full frame.
-    while ((i + 5) < buffer.length) {
+    // we use i + 7 here because we want to be able to parse the entire header.
+    // If we don't have enough bytes to do that, than we definitely won't have a full frame.
+    while ((i + 7) < buffer.length) {
       // Look for the start of an ADTS header..
       if ((buffer[i] !== 0xFF) || (buffer[i + 1] & 0xF6) !== 0xF0) {
         // If a valid header was not found,  jump one forward and attempt to

--- a/lib/codecs/adts.js
+++ b/lib/codecs/adts.js
@@ -64,7 +64,7 @@ AdtsStream = function(handlePartialSegments) {
 
     // Prepend any data in the buffer to the input data so that we can parse
     // aac frames the cross a PES packet boundary
-    if (buffer) {
+    if (buffer && buffer.length) {
       oldBuffer = buffer;
       buffer = new Uint8Array(oldBuffer.byteLength + packet.data.byteLength);
       buffer.set(oldBuffer);
@@ -75,8 +75,11 @@ AdtsStream = function(handlePartialSegments) {
 
     // unpack any ADTS frames which have been fully received
     // for details on the ADTS header, see http://wiki.multimedia.cx/index.php?title=ADTS
-    while (i + 5 < buffer.length) {
 
+    // we use i + 3 here because we want to be able to parse the frame length
+    // from the header. If we don't have enough bytes to do that, than we
+    // definitely won't have a full frame.
+    while ((i + 3) < buffer.length) {
       // Look for the start of an ADTS header..
       if ((buffer[i] !== 0xFF) || (buffer[i + 1] & 0xF6) !== 0xF0) {
         // If a valid header was not found,  jump one forward and attempt to
@@ -99,12 +102,10 @@ AdtsStream = function(handlePartialSegments) {
       adtsFrameDuration = (sampleCount * ONE_SECOND_IN_TS) /
         ADTS_SAMPLING_FREQUENCIES[(buffer[i + 2] & 0x3c) >>> 2];
 
-      frameEnd = i + frameLength;
-
-      // If we don't have enough data to actually finish this ADTS frame, return
-      // and wait for more data
-      if (buffer.byteLength < frameEnd) {
-        return;
+      // If we don't have enough data to actually finish this ADTS frame,
+      // then we have to wait for more data
+      if ((buffer.byteLength - i) < frameLength) {
+        break;
       }
 
       // Otherwise, deliver the complete AAC frame
@@ -119,20 +120,15 @@ AdtsStream = function(handlePartialSegments) {
         samplingfrequencyindex: (buffer[i + 2] & 0x3c) >>> 2,
         // assume ISO/IEC 14496-12 AudioSampleEntry default of 16
         samplesize: 16,
-        data: buffer.subarray(i + 7 + protectionSkipBytes, frameEnd)
+        data: buffer.subarray(i + 7 + protectionSkipBytes, i + frameLength)
       });
 
       frameNum++;
-
-      // If the buffer is empty, clear it and return
-      if (buffer.byteLength === frameEnd) {
-        buffer = undefined;
-        return;
-      }
-
-      // Remove the finished frame from the buffer and start the process again
-      buffer = buffer.subarray(frameEnd);
+      i += frameLength;
     }
+
+    // remove processed bytes from the buffer.
+    buffer = buffer.subarray(i);
   };
 
   this.flush = function() {

--- a/lib/codecs/adts.js
+++ b/lib/codecs/adts.js
@@ -76,10 +76,10 @@ AdtsStream = function(handlePartialSegments) {
     // unpack any ADTS frames which have been fully received
     // for details on the ADTS header, see http://wiki.multimedia.cx/index.php?title=ADTS
 
-    // we use i + 3 here because we want to be able to parse the frame length
+    // we use i + 5 here because we want to be able to parse the frame length
     // from the header. If we don't have enough bytes to do that, than we
     // definitely won't have a full frame.
-    while ((i + 3) < buffer.length) {
+    while ((i + 5) < buffer.length) {
       // Look for the start of an ADTS header..
       if ((buffer[i] !== 0xFF) || (buffer[i + 1] & 0xF6) !== 0xF0) {
         // If a valid header was not found,  jump one forward and attempt to


### PR DESCRIPTION
Right now we run into an issue if adts contains data between sync words that is not part of a frame. 

Example
We have an adts file where bytes 0-5 are garbage, and after that the file is like normal. This is what would happen right now:
1. bytes 0-5 are garbage so they fail the syncword check and `i` is now incremented up to `5`.
2. We parse that frame successfully as 400 bytes long.
3. Then we remove those 400 bytes from the front of the buffer using subarray, but we do not reset `i` to `0`
4. On the next loop we check `buffer[i]` for a syncword but `i` is still `5` so we skip everything else in the buffer until the next syncword and further aggravate the problem by incrementing `i` some more. 