### PR TITLE
fix: Do not scale width by sarRatio, we already generate a pasp box with sarRatio information.

### DIFF
--- a/lib/codecs/h264.js
+++ b/lib/codecs/h264.js
@@ -151,7 +151,8 @@ PROFILES_WITH_OPTIONAL_SPS_DATA = {
   118: true,
   128: true,
 
-  // TODO: these three don't appear to be in the specificiation anymore?
+  // TODO: the three profiles below don't
+  // appear to have sps data in the specificiation anymore?
   138: true,
   139: true,
   134: true

--- a/lib/codecs/h264.js
+++ b/lib/codecs/h264.js
@@ -214,10 +214,10 @@ H264Stream = function() {
         pts: currentPts,
         dts: currentDts,
         data: data,
-        nalUnitType: data[0] & 0x1f
+        nalUnitTypeCode: data[0] & 0x1f
       };
 
-    switch (event.nalUnitType) {
+    switch (event.nalUnitTypeCode) {
     case 0x05:
       event.nalUnitType = 'slice_layer_without_partitioning_rbsp_idr';
       break;

--- a/lib/codecs/h264.js
+++ b/lib/codecs/h264.js
@@ -150,6 +150,8 @@ PROFILES_WITH_OPTIONAL_SPS_DATA = {
   86: true,
   118: true,
   128: true,
+
+  // TODO: these three don't appear to be in the specificiation anymore?
   138: true,
   139: true,
   134: true
@@ -365,7 +367,7 @@ H264Stream = function() {
       picHeightInMapUnitsMinus1,
       frameMbsOnlyFlag,
       scalingListCount,
-      sarRatio,
+      sarRatio = [1, 1],
       aspectRatioIdc,
       i;
 

--- a/lib/codecs/h264.js
+++ b/lib/codecs/h264.js
@@ -210,10 +210,11 @@ H264Stream = function() {
         trackId: trackId,
         pts: currentPts,
         dts: currentDts,
-        data: data
+        data: data,
+        nalUnitType: data[0] & 0x1f
       };
 
-    switch (data[0] & 0x1f) {
+    switch (event.nalUnitType) {
     case 0x05:
       event.nalUnitType = 'slice_layer_without_partitioning_rbsp_idr';
       break;
@@ -232,7 +233,6 @@ H264Stream = function() {
     case 0x09:
       event.nalUnitType = 'access_unit_delimiter_rbsp';
       break;
-
     default:
       break;
     }
@@ -470,7 +470,7 @@ H264Stream = function() {
       profileIdc: profileIdc,
       levelIdc: levelIdc,
       profileCompatibility: profileCompatibility,
-      width: Math.ceil((((picWidthInMbsMinus1 + 1) * 16) - frameCropLeftOffset * 2 - frameCropRightOffset * 2) * sarScale),
+      width: (((picWidthInMbsMinus1 + 1) * 16) - frameCropLeftOffset * 2 - frameCropRightOffset * 2),
       height: ((2 - frameMbsOnlyFlag) * (picHeightInMapUnitsMinus1 + 1) * 16) - (frameCropTopOffset * 2) - (frameCropBottomOffset * 2),
       sarRatio: sarRatio
     };

--- a/lib/codecs/h264.js
+++ b/lib/codecs/h264.js
@@ -474,6 +474,7 @@ H264Stream = function() {
       profileCompatibility: profileCompatibility,
       width: (((picWidthInMbsMinus1 + 1) * 16) - frameCropLeftOffset * 2 - frameCropRightOffset * 2),
       height: ((2 - frameMbsOnlyFlag) * (picHeightInMapUnitsMinus1 + 1) * 16) - (frameCropTopOffset * 2) - (frameCropBottomOffset * 2),
+      // sar is sample aspect ratio
       sarRatio: sarRatio
     };
   };

--- a/test/transmuxer.test.js
+++ b/test/transmuxer.test.js
@@ -853,7 +853,7 @@ QUnit.test('properly parses seq_parameter_set_rbsp nal units', function(assert) 
       profileCompatibility: 192,
       width: 720,
       height: 404,
-      sarRatio: undefined
+      sarRatio: [1, 1]
     };
 
   h264Stream.on('data', function(event) {
@@ -889,7 +889,7 @@ QUnit.test('Properly parses seq_parameter_set VUI nal unit', function(assert) {
       profileIdc: 66,
       levelIdc: 30,
       profileCompatibility: 192,
-      width: 64,
+      width: 16,
       height: 16,
       sarRatio: [65528, 16384]
     };
@@ -924,7 +924,7 @@ QUnit.test('Properly parses seq_parameter_set nal unit with defined sarRatio', f
       profileIdc: 77,
       levelIdc: 21,
       profileCompatibility: 64,
-      width: 640,
+      width: 352,
       height: 480,
       sarRatio: [20, 11]
     };
@@ -959,7 +959,7 @@ QUnit.test('Properly parses seq_parameter_set nal unit with extended sarRatio', 
       profileIdc: 77,
       levelIdc: 21,
       profileCompatibility: 64,
-      width: 403,
+      width: 352,
       height: 480,
       sarRatio: [8, 7]
     };
@@ -994,7 +994,7 @@ QUnit.test('Properly parses seq_parameter_set nal unit without VUI', function(as
       profileCompatibility: 64,
       width: 352,
       height: 480,
-      sarRatio: undefined
+      sarRatio: [1, 1]
     };
 
   h264Stream.on('data', function(event) {


### PR DESCRIPTION
While this doesn't give us the absolute width when we have a `sarRatio`, we don't want to use the absolute width. This is because we already encode the `sarRatio` in the `pasp` atom of our mp4 output. By encoding the `sarRatio` and an absolute width, the width is skewed even further unless the decoder looks directly at the nal units and calculates it itself. Example:
* `sarRatio` is `0.5`
* `width` is `640` without `sarRatio`

How it is now with `sarRatio` width would get set to `320` and then when the decoder see's the `pasp` atom with `sarRatio` it will think that width is `160`. Some decoders will ignore all these values on use nal units to calculate the width, but mobile Samsung Chrome on Android 11 will not. This causes a media decode error as the actual width of the video is `320`. 

With this change width will be set to `640` and the `sarRatio` `pasp` encoding will make the decoder set the width to `320`