### PR TITLE
Detect AVC codec precisely to avoid false detecting with HEVC (h265)

### DIFF
--- a/lib/mp4/probe.js
+++ b/lib/mp4/probe.js
@@ -299,7 +299,7 @@ getTracks = function(init) {
 
       if (codecBox) {
         // https://tools.ietf.org/html/rfc6381#section-3.3
-        if ((/^[a-z]vc[1-9]$/i).test(track.codec)) {
+        if ((/^[asm]vc[1-9]$/i).test(track.codec)) {
           // we don't need anything but the "config" parameter of the
           // avc1 codecBox
           codecConfig = codecBox.subarray(78);


### PR DESCRIPTION
Hi.

New iPhone can easily record HEVC video.
When this library loads such video,
it false detects  as AVC1.

HEVC codec signature is `hvc1`.
So regex matches it.

According to RFC6381,
valid AVC1 codecs are only `avc1`, `avc2`, `svc1`, `mvc1`, `mvc2`.

So I shrink pattern `[a-z]` to `[asm]`.