### PR TITLE
Send ID3 tag even when it has malformed content

### DIFF
--- a/lib/m2ts/metadata-stream.js
+++ b/lib/m2ts/metadata-stream.js
@@ -200,7 +200,7 @@ MetadataStream = function(options) {
           level: 'warn',
           message: 'Malformed ID3 frame encountered. Skipping metadata parsing.'
         });
-        return;
+        break;
       }
       frameHeader = String.fromCharCode(tag.data[frameStart],
                                         tag.data[frameStart + 1],

--- a/lib/m2ts/metadata-stream.js
+++ b/lib/m2ts/metadata-stream.js
@@ -198,8 +198,10 @@ MetadataStream = function(options) {
       if (frameSize < 1) {
         this.trigger('log', {
           level: 'warn',
-          message: 'Malformed ID3 frame encountered. Skipping metadata parsing.'
+          message: 'Malformed ID3 frame encountered. Skipping remaining metadata parsing.'
         });
+        // If the frame is malformed, don't parse any further frames but allow previous valid parsed frames
+        // to be sent along.
         break;
       }
       frameHeader = String.fromCharCode(tag.data[frameStart],

--- a/test/metadata-stream.test.js
+++ b/test/metadata-stream.test.js
@@ -72,7 +72,7 @@ QUnit.test('triggers log for non-id3/invalid data', function(assert) {
   assert.deepEqual(logs, [
     {level: 'warn', message: 'Skipping unrecognized metadata packet'},
     {level: 'warn', message: 'Skipping unrecognized metadata packet'},
-    {level: 'warn', message: 'Malformed ID3 frame encountered. Skipping metadata parsing.'}
+    {level: 'warn', message: 'Malformed ID3 frame encountered. Skipping remaining metadata parsing.'}
   ], 'logs as expected.');
 });
 


### PR DESCRIPTION
Enables sending ID3 tag with as many frames as could be parsed.

Without this change [this.trigger('data', tag)](https://github.com/videojs/mux.js/blob/main/lib/m2ts/metadata-stream.js#L249) wasn't called if stumbled upon malformed ID3 tag/frame.

Beneficiaries: Tellos Z/IP Stream encoder produces ID3 data with `TIT2`, `WOAF` and `TENC` frames, from which only `TIT2` can be parsed by mux.js, so let's take those frames that have been parsed.

Additionally, I'll take a look at mux.js' ID3 parser and try to find out if that metadata is really malformed or it's an issue with the parser.