### PR TITLE
fix: added support for 64 bit atom sizes

### DIFF
--- a/lib/mp4/find-box.js
+++ b/lib/mp4/find-box.js
@@ -18,6 +18,20 @@ var findBox = function(data, path) {
 
     type = parseType(data.subarray(i + 4, i + 8));
 
+    if (size === 1) {
+      size = toUnsigned(
+        data[i + 8] << 56 |
+        data[i + 9] << 48 |
+        data[i + 10] << 40 |
+        data[i + 11] << 32 |
+        data[i + 12] << 24 |
+        data[i + 13] << 16 |
+        data[i + 14] <<  8 |
+        data[i + 15]);
+      i += 8;
+      size -= 8;
+    }
+
     end = size > 1 ? i + size : data.byteLength;
 
     if (type === path[0]) {

--- a/lib/tools/mp4-inspector.js
+++ b/lib/tools/mp4-inspector.js
@@ -661,6 +661,11 @@ inspectMp4 = function(data) {
     // parse box data
     size = view.getUint32(i);
     type =  parseType(data.subarray(i + 4, i + 8));
+    if (size === 1) {
+      size = getUint64(data.subarray(i + 8));
+      i += 8;
+      size -= 8;
+    }
     end = size > 1 ? i + size : data.byteLength;
 
     // parse type-specific data


### PR DESCRIPTION
Some MP4 files use a 64 bit length which and the current implementation takes the 64 bit sentinel (size=1) to mean "maximum size". It seems that some devices (I think this includes iPhone) place an `mdat` with a 64 bit length (even though not needed) head of the `moov`. This change allows the parser to find the `moov`. 