### PR TITLE
fix: translation matrix now correct reported as Int32Array[9]

### DIFF
--- a/lib/tools/mp4-inspector.js
+++ b/lib/tools/mp4-inspector.js
@@ -382,7 +382,9 @@ var
       i += 2;
       i += 2;
       i += 2 * 4;
-      result.matrix = new Uint32Array(data.subarray(i, i + (9 * 4)));
+      result.matrix = new Int32Array(9).map(function(v, z) {
+        return view.getInt32(i + z * 4);
+      });
       i += 9 * 4;
       i += 6 * 4;
       result.nextTrackId = view.getUint32(i);
@@ -578,7 +580,9 @@ var
       result.volume = view.getUint8(i) + (view.getUint8(i + 1) / 8);
       i += 2;
       i += 2;
-      result.matrix = new Uint32Array(data.subarray(i, i + (9 * 4)));
+      result.matrix = new Int32Array(9).map(function(v, z) {
+        return view.getInt32(i + z * 4);
+      });
       i += 9 * 4;
       result.width = view.getUint16(i) + (view.getUint16(i + 2) / 65536);
       i += 4;


### PR DESCRIPTION
We are currently returning the 36 byte matrix inside `mvhd` and `tkhd` as a Int32Array[36] where the top 24 bits are always zero. This appears to be in error and it would make more sense to return these 36 octets a Int32Array[9] to properly represent a 3x3 affine transform. 