### PR TITLE
ID3: add parsing text, link and APIC frames

### DIFF
--- a/lib/m2ts/metadata-stream.js
+++ b/lib/m2ts/metadata-stream.js
@@ -45,119 +45,119 @@ var
             (data[2] << 7) |
             (data[3]);
   },
-  tagParsers = {
-    'APIC': function(tag) {
+  frameParsers = {
+    'APIC': function(frame) {
       var
         i = 1,
         mimeTypeEndIndex,
         descriptionEndIndex,
         LINK_MIME_TYPE = '-->';
 
-      if (tag.data[0] !== textEncodingDescriptionByte.Utf8) {
+      if (frame.data[0] !== textEncodingDescriptionByte.Utf8) {
         // ignore frames with unrecognized character encodings
         return;
       }
 
       // parsing fields [ID3v2.4.0 section 4.14.]
-      mimeTypeEndIndex = tag.data.indexOf(0, i);
+      mimeTypeEndIndex = frame.data.indexOf(0, i);
       if (mimeTypeEndIndex < 0) {
         // malformed frame
         return;
       }
       
       // parsing Mime type field (terminated with \0)
-      tag.mimeType = parseIso88591(tag.data, i, mimeTypeEndIndex);
+      frame.mimeType = parseIso88591(frame.data, i, mimeTypeEndIndex);
       i = mimeTypeEndIndex + 1;
 
       // parsing 1-byte Picture Type field
-      tag.pictureType = tag.data[i];
+      frame.pictureType = frame.data[i];
       i++
 
-      descriptionEndIndex = tag.data.indexOf(0, i);
+      descriptionEndIndex = frame.data.indexOf(0, i);
       if (descriptionEndIndex < 0) {
         // malformed frame
         return;
       }
 
       // parsing Description field (terminated with \0)
-      tag.description = parseUtf8(tag.data, i, descriptionEndIndex);
+      frame.description = parseUtf8(frame.data, i, descriptionEndIndex);
       i = descriptionEndIndex + 1;
 
-      if (tag.mimeType === LINK_MIME_TYPE) {
+      if (frame.mimeType === LINK_MIME_TYPE) {
         // parsing Picture Data field as URL (always represented as ISO-8859-1 [ID3v2.4.0 section 4.])
-        tag.url = parseIso88591(tag.data, i, tag.data.length)
+        frame.url = parseIso88591(frame.data, i, frame.data.length)
       } else {
         // parsing Picture Data field as binary data
-        tag.pictureData = tag.data.subarray(i, tag.data.length);
+        frame.pictureData = frame.data.subarray(i, frame.data.length);
       }
     },
-    'T*': function(tag) {
-      if (tag.data[0] !== textEncodingDescriptionByte.Utf8) {
+    'T*': function(frame) {
+      if (frame.data[0] !== textEncodingDescriptionByte.Utf8) {
         // ignore frames with unrecognized character encodings
         return;
       }
       
-      // parse text field, do not include null terminator in the tag value
+      // parse text field, do not include null terminator in the frame value
       // frames that allow different types of encoding contain terminated text [ID3v2.4.0 section 4.]
-      tag.value = parseUtf8(tag.data, 1, tag.data.length).replace(/\0*$/, '')
+      frame.value = parseUtf8(frame.data, 1, frame.data.length).replace(/\0*$/, '')
       
       // text information frames supports multiple strings, stored as a terminator separated list [ID3v2.4.0 section 4.2.]
-      tag.values = tag.value.split('\0');
+      frame.values = frame.value.split('\0');
     },
-    'TXXX': function(tag) {
+    'TXXX': function(frame) {
       var i;
-      if (tag.data[0] !== textEncodingDescriptionByte.Utf8) {
+      if (frame.data[0] !== textEncodingDescriptionByte.Utf8) {
         // ignore frames with unrecognized character encodings
         return;
       }
 
-      for (i = 1; i < tag.data.length; i++) {
-        if (tag.data[i] === 0) {
+      for (i = 1; i < frame.data.length; i++) {
+        if (frame.data[i] === 0) {
           // parse the text fields
-          tag.description = parseUtf8(tag.data, 1, i);
+          frame.description = parseUtf8(frame.data, 1, i);
           // do not include the null terminator in the tag value
           // frames that allow different types of encoding contain terminated text [ID3v2.4.0 section 4.]
-          tag.value = parseUtf8(tag.data, i + 1, tag.data.length).replace(/\0*$/, '');
+          frame.value = parseUtf8(frame.data, i + 1, frame.data.length).replace(/\0*$/, '');
           break;
         }
       }
-      tag.data = tag.value;
+      frame.data = frame.value;
     },
-    'W*': function(tag) {
+    'W*': function(frame) {
       // parse URL field; URL fields are always represented as ISO-8859-1 [ID3v2.4.0 section 4.]
       // if the value is followed by a string termination all the following information should be ignored [ID3v2.4.0 section 4.3]
-      tag.url = parseIso88591(tag.data, 0, tag.data.length).replace(/\0.*$/, '');
+      frame.url = parseIso88591(frame.data, 0, frame.data.length).replace(/\0.*$/, '');
     },
-    'WXXX': function(tag) {
+    'WXXX': function(frame) {
       var i;
-      if (tag.data[0] !== textEncodingDescriptionByte.Utf8) {
+      if (frame.data[0] !== textEncodingDescriptionByte.Utf8) {
         // ignore frames with unrecognized character encodings
         return;
       }
 
-      for (i = 1; i < tag.data.length; i++) {
-        if (tag.data[i] === 0) {
+      for (i = 1; i < frame.data.length; i++) {
+        if (frame.data[i] === 0) {
           // parse the description and URL fields
-          tag.description = parseUtf8(tag.data, 1, i);
+          frame.description = parseUtf8(frame.data, 1, i);
           // URL fields are always represented as ISO-8859-1 [ID3v2.4.0 section 4.]
           // if the value is followed by a string termination all the following information should be ignored [ID3v2.4.0 section 4.3]
-          tag.url = parseIso88591(tag.data, i + 1, tag.data.length).replace(/\0.*$/, '');
+          frame.url = parseIso88591(frame.data, i + 1, frame.data.length).replace(/\0.*$/, '');
           break;
         }
       }
     },
-    'PRIV': function(tag) {
+    'PRIV': function(frame) {
       var i;
 
-      for (i = 0; i < tag.data.length; i++) {
-        if (tag.data[i] === 0) {
+      for (i = 0; i < frame.data.length; i++) {
+        if (frame.data[i] === 0) {
           // parse the description and URL fields
-          tag.owner = parseIso88591(tag.data, 0, i);
+          frame.owner = parseIso88591(frame.data, 0, i);
           break;
         }
       }
-      tag.privateData = tag.data.subarray(i + 1);
-      tag.data = tag.privateData;
+      frame.privateData = frame.data.subarray(i + 1);
+      frame.data = frame.privateData;
     }
   },
   MetadataStream;
@@ -291,15 +291,15 @@ MetadataStream = function(options) {
       frame.key = frame.id;
 
       // parse frame values
-      if (tagParsers[frame.id]) {
+      if (frameParsers[frame.id]) {
         // use frame specific parser
-        tagParsers[frame.id](frame);
+        frameParsers[frame.id](frame);
       } else if (frame.id[0] === 'T') {
         // use text frame generic parser
-        tagParsers['T*'](frame);
+        frameParsers['T*'](frame);
       } else if (frame.id[0] === 'W') {
         // use URL link frame generic parser
-        tagParsers['W*'](frame);
+        frameParsers['W*'](frame);
       }
 
       // handle the special PRIV frame used to indicate the start

--- a/lib/m2ts/metadata-stream.js
+++ b/lib/m2ts/metadata-stream.js
@@ -99,8 +99,7 @@ var
       
       // parse text field, do not include null terminator in the frame value
       // frames that allow different types of encoding contain terminated text [ID3v2.4.0 section 4.]
-      frame.value = parseUtf8(frame.data, 1, frame.data.length).replace(/\0*$/, '')
-      
+      frame.value = parseUtf8(frame.data, 1, frame.data.length).replace(/\0*$/, '');
       // text information frames supports multiple strings, stored as a terminator separated list [ID3v2.4.0 section 4.2.]
       frame.values = frame.value.split('\0');
     },

--- a/lib/m2ts/metadata-stream.js
+++ b/lib/m2ts/metadata-stream.js
@@ -65,7 +65,7 @@ var
         return;
       }
       
-      // parsing Mime type field (terminataed with \0)
+      // parsing Mime type field (terminated with \0)
       tag.mimeType = parseIso88591(tag.data, i, mimeTypeEndIndex);
       i = mimeTypeEndIndex + 1;
 

--- a/lib/m2ts/metadata-stream.js
+++ b/lib/m2ts/metadata-stream.js
@@ -47,31 +47,48 @@ var
   },
   tagParsers = {
     'APIC': function(tag) {
-      var i, j;
+      var
+        i = 1,
+        mimeTypeEndIndex,
+        descriptionEndIndex,
+        LINK_MIME_TYPE = '-->';
+
       if (tag.data[0] !== textEncodingDescriptionByte.Utf8) {
         // ignore frames with unrecognized character encodings
         return;
       }
 
       // parsing fields [ID3v2.4.0 section 4.14.]
-      i = tag.data.indexOf(0, 1);
-      if (i < 0) {
-        return; // malformed frame
+      mimeTypeEndIndex = tag.data.indexOf(0, i);
+      if (mimeTypeEndIndex < 0) {
+        // malformed frame
+        return;
       }
       
-      tag.mimeType = parseIso88591(tag.data, 1, i++); // MIME type terminated with \0
-      tag.pictureType = tag.data[i++]; // 1-byte Picture Type
+      // parsing Mime type field (terminataed with \0)
+      tag.mimeType = parseIso88591(tag.data, i, mimeTypeEndIndex);
+      i = mimeTypeEndIndex + 1;
 
-      j = tag.data.indexOf(0, i);
-      if (j < 0) {
-        return; // malformed frame
+      // parsing 1-byte Picture Type field
+      tag.pictureType = tag.data[i];
+      i++
+
+      descriptionEndIndex = tag.data.indexOf(0, i);
+      if (descriptionEndIndex < 0) {
+        // malformed frame
+        return;
       }
 
-      tag.description = parseUtf8(tag.data, i, j++); // Description terminated with \0
-      if (tag.mimeType === '-->') {
-        tag.url = parseIso88591(tag.data, j, tag.data.length) // URL (always represented as ISO-8859-1 [ID3v2.4.0 section 4.])
+      // parsing Description field (terminated with \0)
+      tag.description = parseUtf8(tag.data, i, descriptionEndIndex);
+      i = descriptionEndIndex + 1;
+
+      if (tag.mimeType === LINK_MIME_TYPE) {
+        // parsing Picture Data field as URL (always represented as ISO-8859-1 [ID3v2.4.0 section 4.])
+        tag.url = parseIso88591(tag.data, i, tag.data.length)
       } else {
-        tag.pictureData = tag.data.subarray(j, tag.data.length); // Picture data (binary data)
+        // parsing Picture Data field as binary data
+        tag.pictureData = tag.data.subarray(i, tag.data.length);
       }
     },
     'T*': function(tag) {
@@ -276,7 +293,7 @@ MetadataStream = function(options) {
       } else if (frame.id[0] === 'T') {
         // use text frame generic parser
         tagParsers['T*'](frame);
-      } else if (frame.id[0] == 'W') {
+      } else if (frame.id[0] === 'W') {
         // use URL link frame generic parser
         tagParsers['W*'](frame);
       }

--- a/lib/m2ts/metadata-stream.js
+++ b/lib/m2ts/metadata-stream.js
@@ -92,7 +92,6 @@ var
       }
     },
     'T*': function(tag) {
-      var values;
       if (tag.data[0] !== textEncodingDescriptionByte.Utf8) {
         // ignore frames with unrecognized character encodings
         return;
@@ -100,14 +99,10 @@ var
       
       // parse text field, do not include null terminator in the tag value
       // frames that allow different types of encoding contain terminated text [ID3v2.4.0 section 4.]
-      values = parseUtf8(tag.data, 1, tag.data.length).replace(/\0*$/, '').split('\0');
-
+      tag.value = parseUtf8(tag.data, 1, tag.data.length).replace(/\0*$/, '')
+      
       // text information frames supports multiple strings, stored as a terminator separated list [ID3v2.4.0 section 4.2.]
-      if (values.length > 1) {
-        tag.value = values;
-      } else {
-        tag.value = values[0];
-      }
+      tag.values = tag.value.split('\0');
     },
     'TXXX': function(tag) {
       var i;

--- a/lib/m2ts/metadata-stream.js
+++ b/lib/m2ts/metadata-stream.js
@@ -92,13 +92,22 @@ var
       }
     },
     'T*': function(tag) {
+      var values;
       if (tag.data[0] !== textEncodingDescriptionByte.Utf8) {
         // ignore frames with unrecognized character encodings
         return;
       }
+      
       // parse text field, do not include null terminator in the tag value
       // frames that allow different types of encoding contain terminated text [ID3v2.4.0 section 4.]
-      tag.value = parseUtf8(tag.data, 1, tag.data.length).replace(/\0*$/, '');;
+      values = parseUtf8(tag.data, 1, tag.data.length).replace(/\0*$/, '').split('\0');
+
+      // text information frames supports multiple strings, stored as a terminator separated list [ID3v2.4.0 section 4.2.]
+      if (values.length > 1) {
+        tag.value = values;
+      } else {
+        tag.value = values[0];
+      }
     },
     'TXXX': function(tag) {
       var i;

--- a/lib/m2ts/metadata-stream.js
+++ b/lib/m2ts/metadata-stream.js
@@ -12,6 +12,14 @@
 var
   Stream = require('../utils/stream'),
   StreamTypes = require('./stream-types'),
+  // Frames that allow different types of text encoding contain a text
+  // encoding description byte [ID3v2.4.0 section 4.]
+  textEncodingDescriptionByte = {
+    Iso88591: 0x00, // ISO-8859-1, terminated with \0.
+    Utf16:    0x01, // UTF-16 encoded Unicode BOM, terminated with \0\0
+    Utf16be:  0x02, // UTF-16BE encoded Unicode, without BOM, terminated with \0\0
+    Utf8:     0x03  // UTF-8 encoded Unicode, terminated with \0
+  },
   // return a percent-encoded representation of the specified byte range
   // @see http://en.wikipedia.org/wiki/Percent-encoding
   percentEncode = function(bytes, start, end) {
@@ -38,9 +46,46 @@ var
             (data[3]);
   },
   tagParsers = {
-    TXXX: function(tag) {
+    'APIC': function(tag) {
+      var i, j;
+      if (tag.data[0] !== textEncodingDescriptionByte.Utf8) {
+        // ignore frames with unrecognized character encodings
+        return;
+      }
+
+      // parsing fields [ID3v2.4.0 section 4.14.]
+      i = tag.data.indexOf(0, 1);
+      if (i < 0) {
+        return; // malformed frame
+      }
+      
+      tag.mimeType = parseIso88591(tag.data, 1, i++); // MIME type terminated with \0
+      tag.pictureType = tag.data[i++]; // 1-byte Picture Type
+
+      j = tag.data.indexOf(0, i);
+      if (j < 0) {
+        return; // malformed frame
+      }
+
+      tag.description = parseUtf8(tag.data, i, j++); // Description terminated with \0
+      if (tag.mimeType === '-->') {
+        tag.url = parseIso88591(tag.data, j, tag.data.length) // URL (always represented as ISO-8859-1 [ID3v2.4.0 section 4.])
+      } else {
+        tag.pictureData = tag.data.subarray(j, tag.data.length); // Picture data (binary data)
+      }
+    },
+    'T*': function(tag) {
+      if (tag.data[0] !== textEncodingDescriptionByte.Utf8) {
+        // ignore frames with unrecognized character encodings
+        return;
+      }
+      // parse text field, do not include null terminator in the tag value
+      // frames that allow different types of encoding contain terminated text [ID3v2.4.0 section 4.]
+      tag.value = parseUtf8(tag.data, 1, tag.data.length).replace(/\0*$/, '');;
+    },
+    'TXXX': function(tag) {
       var i;
-      if (tag.data[0] !== 3) {
+      if (tag.data[0] !== textEncodingDescriptionByte.Utf8) {
         // ignore frames with unrecognized character encodings
         return;
       }
@@ -50,15 +95,21 @@ var
           // parse the text fields
           tag.description = parseUtf8(tag.data, 1, i);
           // do not include the null terminator in the tag value
+          // frames that allow different types of encoding contain terminated text [ID3v2.4.0 section 4.]
           tag.value = parseUtf8(tag.data, i + 1, tag.data.length).replace(/\0*$/, '');
           break;
         }
       }
       tag.data = tag.value;
     },
-    WXXX: function(tag) {
+    'W*': function(tag) {
+      // parse URL field; URL fields are always represented as ISO-8859-1 [ID3v2.4.0 section 4.]
+      // if the value is followed by a string termination all the following information should be ignored [ID3v2.4.0 section 4.3]
+      tag.url = parseIso88591(tag.data, 0, tag.data.length).replace(/\0.*$/, '');
+    },
+    'WXXX': function(tag) {
       var i;
-      if (tag.data[0] !== 3) {
+      if (tag.data[0] !== textEncodingDescriptionByte.Utf8) {
         // ignore frames with unrecognized character encodings
         return;
       }
@@ -67,12 +118,14 @@ var
         if (tag.data[i] === 0) {
           // parse the description and URL fields
           tag.description = parseUtf8(tag.data, 1, i);
-          tag.url = parseUtf8(tag.data, i + 1, tag.data.length);
+          // URL fields are always represented as ISO-8859-1 [ID3v2.4.0 section 4.]
+          // if the value is followed by a string termination all the following information should be ignored [ID3v2.4.0 section 4.3]
+          tag.url = parseIso88591(tag.data, i + 1, tag.data.length).replace(/\0.*$/, '');
           break;
         }
       }
     },
-    PRIV: function(tag) {
+    'PRIV': function(tag) {
       var i;
 
       for (i = 0; i < tag.data.length; i++) {
@@ -215,34 +268,44 @@ MetadataStream = function(options) {
         data: tag.data.subarray(frameStart + 10, frameStart + frameSize + 10)
       };
       frame.key = frame.id;
+
+      // parse frame values
       if (tagParsers[frame.id]) {
+        // use frame specific parser
         tagParsers[frame.id](frame);
-
-        // handle the special PRIV frame used to indicate the start
-        // time for raw AAC data
-        if (frame.owner === 'com.apple.streaming.transportStreamTimestamp') {
-          var
-            d = frame.data,
-            size = ((d[3] & 0x01)  << 30) |
-                   (d[4]  << 22) |
-                   (d[5] << 14) |
-                   (d[6] << 6) |
-                   (d[7] >>> 2);
-
-          size *= 4;
-          size += d[7] & 0x03;
-          frame.timeStamp = size;
-          // in raw AAC, all subsequent data will be timestamped based
-          // on the value of this frame
-          // we couldn't have known the appropriate pts and dts before
-          // parsing this ID3 tag so set those values now
-          if (tag.pts === undefined && tag.dts === undefined) {
-            tag.pts = frame.timeStamp;
-            tag.dts = frame.timeStamp;
-          }
-          this.trigger('timestamp', frame);
-        }
+      } else if (frame.id[0] === 'T') {
+        // use text frame generic parser
+        tagParsers['T*'](frame);
+      } else if (frame.id[0] == 'W') {
+        // use URL link frame generic parser
+        tagParsers['W*'](frame);
       }
+
+      // handle the special PRIV frame used to indicate the start
+      // time for raw AAC data
+      if (frame.owner === 'com.apple.streaming.transportStreamTimestamp') {
+        var
+          d = frame.data,
+          size = ((d[3] & 0x01)  << 30) |
+                  (d[4]  << 22) |
+                  (d[5] << 14) |
+                  (d[6] << 6) |
+                  (d[7] >>> 2);
+
+        size *= 4;
+        size += d[7] & 0x03;
+        frame.timeStamp = size;
+        // in raw AAC, all subsequent data will be timestamped based
+        // on the value of this frame
+        // we couldn't have known the appropriate pts and dts before
+        // parsing this ID3 tag so set those values now
+        if (tag.pts === undefined && tag.dts === undefined) {
+          tag.pts = frame.timeStamp;
+          tag.dts = frame.timeStamp;
+        }
+        this.trigger('timestamp', frame);
+      }
+
       tag.frames.push(frame);
 
       frameStart += 10; // advance past the frame header

--- a/test/metadata-stream.test.js
+++ b/test/metadata-stream.test.js
@@ -634,8 +634,13 @@ QUnit.test('should parse text frames in web worker', function(assert) {
       done = assert.async();
 
   worker.addEventListener('message', function(e) {
+    assert.equal(e.data.frames.length, 2, 'got 2 frames');
     assert.equal(e.data.frames[0].key, 'TIT2', 'frame key is TIT2');
     assert.equal(e.data.frames[0].value, 'sample song title', 'parsed value')
+    assert.equal(e.data.frames[1].key, 'TIT3', 'frame key is TIT3');
+    assert.equal(e.data.frames[1].value.length, 2, 'parsed value is an array of size 2')
+    assert.equal(e.data.frames[1].value[0], 'sample title 1', 'parsed multiple string value')
+    assert.equal(e.data.frames[1].value[1], 'sample title 2', 'parsed multiple string value')
     worker.terminate();
     done();
   });
@@ -645,7 +650,12 @@ QUnit.test('should parse text frames in web worker', function(assert) {
     data: new Uint8Array(id3Tag(id3Frame('TIT2',
                                           0x03, // utf-8
                                           // frames that allow different types of encoding contain terminated text [ID3v2.4.0 section 4.]
-                                          stringToCString('sample song title'))))
+                                          stringToCString('sample song title')),
+                                id3Frame('TIT3',
+                                          0x03, // utf-8
+                                          // frames that allow different types of encoding contain terminated text [ID3v2.4.0 section 4.]
+                                          // text information frames supports multiple strings, stored as a terminator separated list [ID3v2.4.0 section 4.2.]
+                                          stringToCString('sample title 1'), stringToCString('sample title 2'))))
   });
 });
 

--- a/test/metadata-stream.test.js
+++ b/test/metadata-stream.test.js
@@ -637,10 +637,13 @@ QUnit.test('should parse text frames in web worker', function(assert) {
     assert.equal(e.data.frames.length, 2, 'got 2 frames');
     assert.equal(e.data.frames[0].key, 'TIT2', 'frame key is TIT2');
     assert.equal(e.data.frames[0].value, 'sample song title', 'parsed value')
+    assert.equal(e.data.frames[0].values.length, 1, 'parsed value is an array of size 1')
+    assert.equal(e.data.frames[0].values[0], 'sample song title', 'parsed a non multiple strings value')
     assert.equal(e.data.frames[1].key, 'TIT3', 'frame key is TIT3');
-    assert.equal(e.data.frames[1].value.length, 2, 'parsed value is an array of size 2')
-    assert.equal(e.data.frames[1].value[0], 'sample title 1', 'parsed multiple string value')
-    assert.equal(e.data.frames[1].value[1], 'sample title 2', 'parsed multiple string value')
+    assert.equal(e.data.frames[1].value, 'sample title 1\0sample title 2', 'parsed value')
+    assert.equal(e.data.frames[1].values.length, 2, 'parsed value is an array of size 2')
+    assert.equal(e.data.frames[1].values[0], 'sample title 1', 'parsed 1st multiple strings value')
+    assert.equal(e.data.frames[1].values[1], 'sample title 2', 'parsed 2nd multiple strings value')
     worker.terminate();
     done();
   });

--- a/test/metadata-stream.test.js
+++ b/test/metadata-stream.test.js
@@ -536,7 +536,7 @@ QUnit.test('should skip tag frame parsing on malformed frame, preserving previou
   })
   
   assert.equal(events.length, 1, 'parsed 1 tag')
-  assert.equal(events[0].frames.length, 1, 'parsed one frame');
+  assert.equal(events[0].frames.length, 1, 'parsed 1 frame');
   assert.equal(events[0].frames[0].key, 'TIT2');
 });
 
@@ -545,16 +545,16 @@ QUnit.test('can parse APIC frame in web worker', function(assert) {
       done = assert.async();
 
   worker.addEventListener('message', function(e) {
-    assert.equal(e.data.frames[0].key, 'APIC', 'frame key mismatch');
-    assert.equal(e.data.frames[0].mimeType, 'image/jpeg', 'APIC frame MIME type mismatch');
-    assert.equal(e.data.frames[0].pictureType, 0x03, 'APIC frame Picture type mismatch');
-    assert.equal(e.data.frames[0].description, 'sample description', 'APIC frame description mismatch');
-    assert.deepEqual(e.data.frames[0].pictureData, new Uint8Array(stringToInts("picture binary data")), 'APIC frame Picture data mismatch');
-    assert.equal(e.data.frames[1].key, 'APIC', 'frame key mismatch');
-    assert.equal(e.data.frames[1].mimeType, '-->', 'APIC frame MIME type mismatch');
-    assert.equal(e.data.frames[1].pictureType, 0x04, 'APIC frame Picture type mismatch');
-    assert.equal(e.data.frames[1].description, 'sample description 2', 'APIC frame description mismatch');
-    assert.equal(e.data.frames[1].url, 'http://example.org/cover-back.jpg', 'APIC frame Picture URL mismatch');
+    assert.equal(e.data.frames[0].key, 'APIC', 'frame key is APIC');
+    assert.equal(e.data.frames[0].mimeType, 'image/jpeg', 'parsed MIME type is "image/jpeg"');
+    assert.equal(e.data.frames[0].pictureType, 0x03, 'parsed picture type is 0x03');
+    assert.equal(e.data.frames[0].description, 'sample description', 'parsed description');
+    assert.deepEqual(e.data.frames[0].pictureData, new Uint8Array(stringToInts("picture binary data")), 'parsed picture data');
+    assert.equal(e.data.frames[1].key, 'APIC', 'frame key is APIC');
+    assert.equal(e.data.frames[1].mimeType, '-->', 'parsed MIME type is "-->"');
+    assert.equal(e.data.frames[1].pictureType, 0x04, 'parsed picture type is 0x04');
+    assert.equal(e.data.frames[1].description, 'sample description 2', 'parsed description');
+    assert.equal(e.data.frames[1].url, 'http://example.org/cover-back.jpg', 'parsed picture data');
     worker.terminate();
     done();
   });
@@ -634,8 +634,8 @@ QUnit.test('should parse text frames in web worker', function(assert) {
       done = assert.async();
 
   worker.addEventListener('message', function(e) {
-    assert.equal(e.data.frames[0].key, 'TIT2', 'frame key mismatch');
-    assert.equal(e.data.frames[0].value, 'sample song title', 'TIT2 frame value mismatch')
+    assert.equal(e.data.frames[0].key, 'TIT2', 'frame key is TIT2');
+    assert.equal(e.data.frames[0].value, 'sample song title', 'parsed value')
     worker.terminate();
     done();
   });
@@ -658,8 +658,8 @@ QUnit.test('should parse URL link frames in web worker', function(assert) {
   payloadBytes = stringToInts('http://example.org\0 ignored \0 part')
 
   worker.addEventListener('message', function(e) {
-    assert.equal(e.data.frames[0].key, 'WOAF', 'frame key mismatch');
-    assert.equal(e.data.frames[0].url, 'http://example.org', 'WOAF frame URL mismatch')
+    assert.equal(e.data.frames[0].key, 'WOAF', 'frame key is WOAF');
+    assert.equal(e.data.frames[0].url, 'http://example.org', 'parsed URL')
     worker.terminate();
     done();
   });


### PR DESCRIPTION
This PR adds parsing:
- Text information frames [[ID3v2.4.0](https://id3.org/id3v2.4.0-frames) section 4.2.]
- URL link frames [[ID3v2.4.0](https://id3.org/id3v2.4.0-frames) section 4.3.]
- Attached picture frames (with "-->" MIME type support) [[ID3v2.4.0](https://id3.org/id3v2.4.0-frames) section 4.14.]

Tested in unit tests and by parsing [media-uq37ul2b4_b64000_330729098.ts.zip](https://github.com/videojs/mux.js/files/8785831/media-uq37ul2b4_b64000_330729098.ts.zip)
that results in the following metadata being sent to the client:
![image](https://user-images.githubusercontent.com/13220781/170679783-1fa5b760-3874-4a43-8b90-2a05e31dce50.png)

 