### PR TITLE
chore: add npm publish in release workflow

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -30,12 +30,17 @@ jobs:
         with:
           node-version: '${{steps.nvm.outputs.NVMRC}}'
           cache: npm
+          # this line is required for the setup-node action to be able to run the npm publish below.
+          registry-url: 'https://registry.npmjs.org'
 
       - name: npm install
         run: npm i --prefer-offline --no-audit
 
-      - name: build
-        run: npm run build-prod || npm run build --if-present
+      # publish runs build for us via a prepublishOnly script
+      - name: npm release
+        run: npm publish --tag next
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Check if this is a pre-release
         run: echo ::set-output name=IS_PRE_RELEASE::$(npx -p not-prerelease is-prerelease && echo "true" || echo "false")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: github-release
+name: release
 on:
   push:
     tags:
@@ -7,7 +7,7 @@ on:
     # match semver pre-releases
     - "v[0-9]+.[0-9]+.[0-9]+-*"
 jobs:
-  github-release:
+  release:
     env:
       # Set this if you want a netlify example
       NETLIFY_BASE: 'muxjs.netlify.app/'
@@ -73,3 +73,4 @@ jobs:
           files: |
             dist/**/*.js
             dist/**/*.css
+          discussion_category_name: Releases

--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -6,4 +6,4 @@
 - Ensure the tests are passing on main
 - You may need to be granted npm publish permissions if this is your first time publishing. Try to get this working first!
 - Version on npm `npm version [patch|minor|major]`
-- Push changes from versioning to main, and the new tag you just created `git push && git push --tags`. You can also push the specific tag with `git push [remote] [tag]`
+- Push changes from versioning to main, and the new tag you just created `git push --follow-tags origin main`.

--- a/COLLABORATOR_GUIDE.md
+++ b/COLLABORATOR_GUIDE.md
@@ -3,11 +3,7 @@
 
 # Releasing
 
-- Ensure the tests are passing on master
+- Ensure the tests are passing on main
 - You may need to be granted npm publish permissions if this is your first time publishing. Try to get this working first!
 - Version on npm `npm version [patch|minor|major]`
-- Push changes from versioning to master, and the new tag you just created `git push && git push --tags`. You can also push the specific tag with `git push [remote] [tag]`
-- Publish on npm `npm publish`
-- Go to https://github.com/videojs/mux.js/releases
-- Click "Draft a new release"
-- Fill out the form with the released version and upload the files in the `/dist` directory
+- Push changes from versioning to main, and the new tag you just created `git push && git push --tags`. You can also push the specific tag with `git push [remote] [tag]`


### PR DESCRIPTION
Note: `NPM_TOKEN` should be added as repo's secrete