### PR TITLE
fix(aac): missing timestamp rollover

### DIFF
--- a/lib/aac/index.js
+++ b/lib/aac/index.js
@@ -11,6 +11,8 @@
 'use strict';
 var Stream = require('../utils/stream.js');
 var aacUtils = require('./utils');
+var handleRollover =
+  require('../m2ts/timestamp-rollover-stream.js').handleRollover;
 
 // Constants
 var AacStream;
@@ -22,7 +24,8 @@ var AacStream;
 AacStream = function() {
   var
     everything = new Uint8Array(),
-    timeStamp = 0;
+    timeStamp = 0,
+    referenceDTS;
 
   AacStream.prototype.init.call(this);
 
@@ -94,11 +97,15 @@ AacStream = function() {
           break;
         }
 
+        if (referenceDTS === undefined) {
+          referenceDTS = timeStamp;
+        }
+
         packet = {
           type: 'audio',
           data: everything.subarray(byteIndex, byteIndex + frameSize),
-          pts: timeStamp,
-          dts: timeStamp
+          pts: handleRollover(timeStamp, referenceDTS),
+          dts: handleRollover(timeStamp, referenceDTS)
         };
         this.trigger('data', packet);
         byteIndex += frameSize;


### PR DESCRIPTION
## Description
This PR fixes the missing timestamp rollover in AAC stream packets.

Refer https://github.com/videojs/http-streaming/issues/1371#issue-1582588141

## Specific Changes proposed

- handle PTS and DTS  timestamp rollover

## Requirements Checklist
- [X] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Change has been verified in an actual browser (Chrome, Firefox, IE)
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
  - [ ] Example created ([starter template on JSBin](https://codepen.io/gkatsev/pen/GwZegv?editors=1000#0))
- [ ] Reviewed by Two Core Contributors
