### PR TITLE
Avoid unwrapping crash when pmt parsing has returned undefined

### DIFF
--- a/lib/m2ts/m2ts.js
+++ b/lib/m2ts/m2ts.js
@@ -465,7 +465,7 @@ ElementaryStream = function() {
             tracks: []
           };
 
-        programMapTable = data.programMapTable;
+        programMapTable = data.programMapTable || {};
 
         // translate audio and video streams to tracks
         if (programMapTable.video !== null) {

--- a/lib/tools/ts-inspector.js
+++ b/lib/tools/ts-inspector.js
@@ -41,7 +41,7 @@ var parsePsi_ = function(bytes, pmt) {
           pmt.pid = probe.ts.parsePat(packet);
           break;
         case 'pmt':
-          var table = probe.ts.parsePmt(packet);
+          var table = probe.ts.parsePmt(packet) || {};
 
           pmt.table = pmt.table || {};
 


### PR DESCRIPTION
When trying to transmux or inspect the attached ts segment, mux.js crashes because the pmt parsing returns an undefined value that the caller tries to use as a non empty object. This PR adds fallbacks to use empty objects when that happens.

Here is a typescript file that reproduces the problem:
```
import { mp2t } from 'mux.js';
import fs from 'fs';

main(process.argv.slice(2)).catch(err => console.error(err));

async function main(args: string[]) {
  for (const file of args) {
    const buffer = fs.readFileSync(file);
    const tsInfo = mp2t.tools.inspect(buffer);
    console.log(`File ${file}: ${JSON.stringify(tsInfo, null,  2)}`);
  }
}
```

Without the fix, the output is as follows:
```
$ muxProbe ~/Desktop/pmt.ts
TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at parsePsi_2 (..../muxProbe.js:7423:20)
    at inspectTs_2 (..../muxProbe.js:7705:5)
    at Object.inspect2 [as inspect] (..../muxProbe.js:7737:16)
    at main (..../muxProbe.js:7774:42)
    at Object.<anonymous> (..../muxProbe.js:7770:1)
    at Module._compile (node:internal/modules/cjs/loader:1254:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
    at Module.load (node:internal/modules/cjs/loader:1117:32)
    at Module._load (node:internal/modules/cjs/loader:958:12)
```

With the fix, it works as expected:
```
$ muxProbe pmt.ts
File pmt.ts: {
  "video": [
    {
      "pts": 183600,
      "dts": 180000,
      "type": "video",
      "dtsTime": 2,
      "ptsTime": 2.04
    },
    {
      "pts": 500400,
      "dts": 500400,
      "type": "video",
      "dtsTime": 5.56,
      "ptsTime": 5.56
    }
  ],
  "firstKeyFrame": {
    "pts": 183600,
    "dts": 180000,
    "type": "video",
    "dtsTime": 2,
    "ptsTime": 2.04
  },
  "audio": [
    {
      "pts": 180600,
      "dts": 180600,
      "type": "audio",
      "dtsTime": 2.006666666666667,
      "ptsTime": 2.006666666666667
    },
    {
      "pts": 507000,
      "dts": 507000,
      "type": "audio",
      "dtsTime": 5.633333333333334,
      "ptsTime": 5.633333333333334
    }
  ]
}
```
[pmt.ts.zip](https://github.com/videojs/mux.js/files/11905325/pmt.ts.zip)
