### PR TITLE
fix(m2ts): PES packets missing timestamp rollover

### DIFF
--- a/lib/m2ts/m2ts.js
+++ b/lib/m2ts/m2ts.js
@@ -12,7 +12,8 @@
 var Stream = require('../utils/stream.js'),
   CaptionStream = require('./caption-stream'),
   StreamTypes = require('./stream-types'),
-  TimestampRolloverStream = require('./timestamp-rollover-stream').TimestampRolloverStream;
+  TimestampRolloverStream = require('./timestamp-rollover-stream').TimestampRolloverStream,
+  handleRollover = require('./timestamp-rollover-stream').handleRollover;
 
 // object types
 var TransportPacketStream, TransportParseStream, ElementaryStream;
@@ -309,6 +310,8 @@ ElementaryStream = function() {
       size: 0
     },
     programMapTable,
+    referenceDTS,
+    referencePTS,
     parsePes = function(payload, pes) {
       var ptsDtsFlags;
       const startPrefix = payload[0] << 16 | payload[1] << 8 | payload[2]
@@ -360,6 +363,18 @@ ElementaryStream = function() {
           pes.dts += (payload[18] & 0x06) >>> 1; // OR by the two LSBs
         }
       }
+
+      if (referencePTS === undefined) {
+        referencePTS = pes.pts;
+      }
+
+      if (referenceDTS === undefined) {
+        referenceDTS = pes.dts;
+      }
+
+      pes.dts = handleRollover(pes.dts, referenceDTS);
+      pes.pts = handleRollover(pes.pts, referencePTS);
+
       // the data section starts immediately after the PES header.
       // pes_header_data_length specifies the number of header bytes
       // that follow the last byte of the field.


### PR DESCRIPTION
## Description

Handles `PTS` and `DTS` titmestamp rollover separately, directly in PES packets.