### PR TITLE
fix: 708 captions multi-byte char fix

### DIFF
--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -690,9 +690,12 @@ Cea708Stream.prototype.handleText = function(i, service, options) {
 
   // Converts an array of bytes to a unicode hex string.
   function toHexString(byteArray) {
-    return Array.from(byteArray, function(byte) {
-      return ('0' + (byte & 0xFF).toString(16)).slice(-2);
-    }).join('');
+    const newArr = [];
+    byteArray.forEach((byte) => {
+      newArr.push(('0' + (byte & 0xFF).toString(16)).slice(-2));
+    });
+
+    return newArr.join('');
   };
 
   if (isMultiByte) {

--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -688,18 +688,32 @@ Cea708Stream.prototype.handleText = function(i, service, options) {
   var char;
   var charCodeArray;
 
+  // Converts an array of bytes to a unicode hex string.
+  function toHexString(byteArray) {
+    return Array.from(byteArray, function(byte) {
+      return ('0' + (byte & 0xFF).toString(16)).slice(-2);
+    }).join('');
+  };
+
+  if (isMultiByte) {
+    charCodeArray = [currentByte, nextByte];
+    i++;
+  } else {
+    charCodeArray = [currentByte];
+  }
+
   // Use the TextDecoder if one was created for this service
   if (service.textDecoder_ && !isExtended) {
-    if (isMultiByte) {
-      charCodeArray = [currentByte, nextByte];
-      i++;
-    } else {
-     charCodeArray = [currentByte];
-    }
-
     char = service.textDecoder_.decode(new Uint8Array(charCodeArray));
   } else {
-    char = get708CharFromCode(extended | currentByte);
+    // We assume any multi-byte char without a decoder is unicode.
+    if (isMultiByte) {
+      const unicode = toHexString(charCodeArray);
+      // Takes a unicode hex string and creates a single character.
+      char = String.fromCharCode(parseInt(unicode, 16));
+    } else {
+      char = get708CharFromCode(extended | currentByte);
+    }
   }
 
   if (win.pendingNewLine && !win.isEmpty()) {

--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -690,12 +690,9 @@ Cea708Stream.prototype.handleText = function(i, service, options) {
 
   // Converts an array of bytes to a unicode hex string.
   function toHexString(byteArray) {
-    const newArr = [];
-    byteArray.forEach((byte) => {
-      newArr.push(('0' + (byte & 0xFF).toString(16)).slice(-2));
-    });
-
-    return newArr.join('');
+    return byteArray.map((byte) => {
+      return ('0' + (byte & 0xFF).toString(16)).slice(-2);
+    }).join('');
   };
 
   if (isMultiByte) {

--- a/test/caption-stream.test.js
+++ b/test/caption-stream.test.js
@@ -3051,6 +3051,33 @@ QUnit.test('Decodes multibyte characters if valid encoding option is provided an
   }
 });
 
+QUnit.test('Decodes multi-byte characters as unicode if no valid encoding option is provided', function(assert) {
+  var captions = [];
+
+  cea708Stream = new m2ts.Cea708Stream({
+    captionServices: {
+      SERVICE1: {}
+    }
+  });
+
+  cea708Stream.on('data', function(caption) {
+    captions.push(caption);
+  });
+
+  cc708Korean.forEach(cea708Stream.push, cea708Stream);
+
+  cea708Stream.flushDisplayed(4721138662, cea708Stream.services[1]);
+
+  assert.equal(captions.length, 1, 'parsed single caption correctly');
+
+  assert.notOk(cea708Stream.services[1].textDecoder_, 'TextDecoder was not created');
+  assert.equal(
+    captions[0].text,
+    '듏낡 ',
+    'parsed multibyte characters correctly'
+  );
+});
+
 QUnit.test('Creates TextDecoder only if valid encoding value is provided', function(assert) {
   var secondCea708Stream;
 


### PR DESCRIPTION
We were seeing issues with non-latin 708 captions not being displayed correctly. It appears that the issue that we are not always handling multi-byte characters correctly.

This fix proposes that in the case where we see a multi-byte character without a pre-designated decoder, we send the byte array through a function to turn it into a hex string, and then from there decode it into the character.

Example Test Playlist: https://solutions.brightcove.com/wseymour/708-testing/playlist.m3u8

Before: 
<img width="637" alt="Screenshot 2023-10-12 at 10 47 59 AM" src="https://github.com/videojs/mux.js/assets/26021721/0a887c86-db07-4f72-9cfe-00a678951b8f">

After:
<img width="639" alt="Screenshot 2023-10-12 at 10 46 12 AM" src="https://github.com/videojs/mux.js/assets/26021721/00ef4bae-ebd9-4dfb-8793-73baa1565df8">
