### PR TITLE
chore: Update id3.org reference in comment

### DIFF
--- a/lib/aac/utils.js
+++ b/lib/aac/utils.js
@@ -140,7 +140,7 @@ var parseAacTimestamp = function(packet) {
   }
 
   // parse one or more ID3 frames
-  // http://id3.org/id3v2.3.0#ID3v2_frame_overview
+  // https://web.archive.org/web/20220912050912/https://id3.org/id3v2.3.0#ID3v2_frame_overview
   do {
     // determine the number of bytes in this frame
     frameSize = parseSyncSafeInteger(packet.subarray(frameStart + 4, frameStart + 8));


### PR DESCRIPTION
Update ID3 header overview link to a web archive one since [id3.org looks gone](https://exiftool.org/forum/index.php?topic=14610.0).