### PR TITLE
fix: 608 caption out of bound rows

### DIFF
--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -1433,7 +1433,9 @@ var Cea608Stream = function(field, dataChannel) {
         this.setRollUp(packet.pts, row);
       }
 
-      if (row !== this.row_) {
+      // Ensure the row is between 0 and 14, otherwise use the most
+      // recent or default row.
+      if (row !== this.row_ && row >= 0 && row <= 14) {
         // formatting is only persistent for current row
         this.clearFormatting(packet.pts);
         this.row_ = row;


### PR DESCRIPTION
We were seeing some odd results with the following stream, regarding captions failing:
https://solutions.brightcove.com/slevitas/jiras/cisco-bc-64040/capture/m-chunklist.m3u8

This fix ensures that even if for some reason a PAC packet seems to have an invalid row, the player will not fail