### PR TITLE
chore(package): bump rollup to ^2.80.0 to fix DOM clobbering vulnerability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
       CI_TEST_TYPE: ${{matrix.test-type}}
     runs-on: ${{matrix.os}}
     steps:
+    - name: Disable apparmor, which breaks chromium headless
+      run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
     - name: checkout code
       uses: actions/checkout@v3
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1110,12 +1110,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.14.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
-      "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
-      "requires": {
-        "regenerator-runtime": "^0.13.4"
-      }
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="
     },
     "@babel/template": {
       "version": "7.14.5",
@@ -3040,7 +3037,7 @@
       "dev": true,
       "requires": {
         "add-stream": "^1.0.0",
-        "conventional-changelog-writer": "^5.0.0",
+        "conventional-changelog-writer": "^4.0.18",
         "conventional-commits-parser": "^3.2.0",
         "dateformat": "^3.0.0",
         "get-pkg-repo": "^1.0.0",
@@ -3052,32 +3049,8 @@
         "q": "^1.5.1",
         "read-pkg": "^3.0.0",
         "read-pkg-up": "^3.0.0",
+        "shelljs": "^0.8.3",
         "through2": "^4.0.0"
-      },
-      "dependencies": {
-        "conventional-changelog-writer": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-5.0.0.tgz",
-          "integrity": "sha512-HnDh9QHLNWfL6E1uHz6krZEQOgm8hN7z/m7tT16xwd802fwgMN0Wqd7AQYVkhpsjDUx/99oo+nGgvKF657XP5g==",
-          "dev": true,
-          "requires": {
-            "conventional-commits-filter": "^2.0.7",
-            "dateformat": "^3.0.0",
-            "handlebars": "^4.7.6",
-            "json-stringify-safe": "^5.0.1",
-            "lodash": "^4.17.15",
-            "meow": "^8.0.0",
-            "semver": "^6.0.0",
-            "split": "^1.0.0",
-            "through2": "^4.0.0"
-          }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        }
       }
     },
     "conventional-changelog-ember": {
@@ -3141,6 +3114,32 @@
         "compare-func": "^2.0.0",
         "github-url-from-git": "^1.4.0",
         "q": "^1.4.1"
+      }
+    },
+    "conventional-changelog-writer": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.1.0.tgz",
+      "integrity": "sha512-WwKcUp7WyXYGQmkLsX4QmU42AZ1lqlvRW9mqoyiQzdD+rJWbTepdWoKJuwXTS+yq79XKnQNa93/roViPQrAQgw==",
+      "dev": true,
+      "requires": {
+        "compare-func": "^2.0.0",
+        "conventional-commits-filter": "^2.0.7",
+        "dateformat": "^3.0.0",
+        "handlebars": "^4.7.6",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.15",
+        "meow": "^8.0.0",
+        "semver": "^6.0.0",
+        "split": "^1.0.0",
+        "through2": "^4.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+          "dev": true
+        }
       }
     },
     "conventional-commits-filter": {
@@ -6162,7 +6161,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true
     },
     "json5": {
@@ -6853,7 +6852,7 @@
     "lodash.ismatch": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.ismatch/-/lodash.ismatch-4.4.0.tgz",
-      "integrity": "sha1-dWy1FQyjum8RCFp4hJZF8Yj4Xzc=",
+      "integrity": "sha512-fPMfXjGQEV9Xsq/8MTSgUf255gawYRbjwMyDbcvDhXgV7enSZA0hynz6vMPnpAb5iONEzBHBPsT+0zes5Z301g==",
       "dev": true
     },
     "lodash.pad": {
@@ -8251,11 +8250,6 @@
         "regenerate": "^1.4.2"
       }
     },
-    "regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
-    },
     "regenerator-transform": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.5.tgz",
@@ -8461,9 +8455,9 @@
       }
     },
     "rollup": {
-      "version": "2.52.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.52.2.tgz",
-      "integrity": "sha512-4RlFC3k2BIHlUsJ9mGd8OO+9Lm2eDF5P7+6DNQOp5sx+7N/1tFM01kELfbxlMX3MxT6owvLB1ln4S3QvvQlbUA==",
+      "version": "2.80.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
+      "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -8477,18 +8471,6 @@
       "requires": {
         "@rollup/pluginutils": "^4.1.0",
         "matched": "^5.0.1"
-      }
-    },
-    "rollup-plugin-external-globals": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-external-globals/-/rollup-plugin-external-globals-0.6.1.tgz",
-      "integrity": "sha512-mlp3KNa5sE4Sp9UUR2rjBrxjG79OyZAh/QC18RHIjM+iYkbBwNXSo8DHRMZWtzJTrH8GxQ+SJvCTN3i14uMXIA==",
-      "dev": true,
-      "requires": {
-        "@rollup/pluginutils": "^4.0.0",
-        "estree-walker": "^2.0.1",
-        "is-reference": "^1.2.1",
-        "magic-string": "^0.25.7"
       }
     },
     "rollup-plugin-istanbul": {
@@ -9395,7 +9377,7 @@
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
+        "strip-ansi": "^6.0.0"
       }
     },
     "string.prototype.padend": {
@@ -9651,7 +9633,7 @@
       "requires": {
         "commander": "^2.20.0",
         "source-map": "~0.7.2",
-        "source-map-support": "~0.5.20"
+        "source-map-support": "~0.5.19"
       },
       "dependencies": {
         "commander": {
@@ -10266,7 +10248,6 @@
         "@rollup/plugin-multi-entry": "^4.0.0",
         "@rollup/plugin-node-resolve": "^9.0.0",
         "@videojs/babel-config": "^0.2.0",
-        "rollup-plugin-external-globals": "^0.6.1",
         "rollup-plugin-istanbul": "^2.0.1",
         "rollup-plugin-terser": "^7.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "@videojs/vhs-utils": "^3.0.0",
     "karma": "^5.0.0",
     "qunit": "^2.16.0",
-    "rollup": "^2.37.1",
+    "rollup": "^2.80.0",
     "rollup-plugin-data-files": "^0.1.0",
     "rollup-plugin-worker-factory": "^0.5.6",
     "sinon": "^8.1.1",


### PR DESCRIPTION
## Description
Fix security vulnerability in npm dependencies.

`rollup` was on a range that included versions `<=2.79.2`, which are affected by a DOM clobbering vulnerability (high severity). Bumped to `^2.80.0`.

## Specific Changes proposed
- Bump `rollup` from `^2.37.1` to `^2.80.0` in `devDependencies`

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] Unit Tests updated or fixed
- [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors