### PR TITLE
chore(ci): run karma on local headless browsers instead of BrowserStack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,6 @@ jobs:
         os: [ubuntu-latest]
         test-type: ['unit']
     env:
-      BROWSER_STACK_USERNAME: ${{secrets.BROWSER_STACK_USERNAME}}
-      BROWSER_STACK_ACCESS_KEY: ${{secrets.BROWSER_STACK_ACCESS_KEY}}
       CI_TEST_TYPE: ${{matrix.test-type}}
     runs-on: ${{matrix.os}}
     steps:

--- a/scripts/karma.conf.js
+++ b/scripts/karma.conf.js
@@ -8,7 +8,7 @@ module.exports = function(config) {
     coverage: false,
     browsers(aboutToRun) {
       return aboutToRun.filter(function(launcherName) {
-        return !(/^Safari/).test(launcherName);
+        return !(/^(Safari|Chromium)/).test(launcherName);
       });
     },
     browserstackLaunchers(defaults) {


### PR DESCRIPTION
## Why

CI has had no green run since October 2025. The `ci (ubuntu-latest, unit)` job hangs in `npm run test` and only ends when it hits the 6 hour GitHub timeout ([example run](https://github.com/videojs/mux.js/actions/runs/31584530096)).

From the logs, the BrowserStack sessions never start, and karma waits for them forever. Why they never start hasn't been diagnosed — whether the account or credentials behind the `BROWSER_STACK_USERNAME` / `BROWSER_STACK_ACCESS_KEY` secrets are still valid isn't visible from the repo side. But the hang is avoidable entirely by skipping BrowserStack: with those env vars removed from the job, `videojs-generate-karma-config` falls back to `karma-detect-browsers` and runs the runner's local browsers.

In our own player stack we've found that testing in real (cloud) browsers really only adds value for Safari-exclusive playback behaviour — native HLS, AirPlay integration and the like — and we've reworked our test stack to use headless browsers everywhere else, which made CI both faster and more stable. In this repo, the BrowserStack setup provides no Safari coverage anyway: `scripts/karma.conf.js` already deletes the Safari BrowserStack launchers and filters `/^Safari/` out of the browser list, so the effective BrowserStack set was only Chrome and Firefox — both preinstalled on `ubuntu-latest`. 

## Change

- Drop the two `BROWSER_STACK_*` env vars from the `ci` job, so `videojs-generate-karma-config` falls back to `karma-detect-browsers` and runs the runner's local (headless) browsers.
- Filter `Chromium` launchers alongside the existing Safari filter in `scripts/karma.conf.js`: `ChromiumHeadless` cannot start on `ubuntu-latest` (AppArmor blocks its sandbox with "No usable sandbox!") and it duplicates the Chrome coverage anyway.

The BrowserStack launcher definitions are deliberately untouched, so anyone with working BrowserStack credentials can still use them locally — and if the repo's secrets are confirmed working again later, restoring the two env vars restores the old behavior.

## Verification

Ran `npm run test:browser` locally with no BrowserStack credentials in the environment: karma detected and launched local Chrome Headless and all 337 tests passed per browser.

This PR's own checks are the real proof — `pull_request` workflows run from the merge ref, so the `ci (ubuntu-latest, unit)` job below is running with this change applied: it passes in about a minute on both Chrome and Firefox (674 assertions total) instead of hanging for 6 hours.

Unblocks #452, which cannot get a green CI run as things stand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
