### PR TITLE
fix: correct PAT section_number and last_section_number offsets

### DIFF
--- a/lib/m2ts/m2ts.js
+++ b/lib/m2ts/m2ts.js
@@ -141,8 +141,8 @@ TransportParseStream = function() {
   };
 
   parsePat = function(payload, pat) {
-    pat.section_number = payload[7]; // eslint-disable-line camelcase
-    pat.last_section_number = payload[8]; // eslint-disable-line camelcase
+    pat.section_number = payload[6]; // eslint-disable-line camelcase
+    pat.last_section_number = payload[7]; // eslint-disable-line camelcase
 
     // skip the PSI header and parse the first PMT entry
     self.pmtPid = (payload[10] & 0x1F) << 8 | payload[11];

--- a/test/transmuxer.test.js
+++ b/test/transmuxer.test.js
@@ -283,6 +283,26 @@ QUnit.test('parses the program map table pid from the program association table 
   assert.strictEqual(0x0010, transportParseStream.pmtPid, 'parsed PMT pid');
 });
 
+QUnit.test('parses section_number and last_section_number from the PAT', function(assert) {
+  var packet, pat;
+
+  // Distinctive values: the shared PAT fixture is zero here, which hides
+  // an off-by-one against program_number (ISO/IEC 13818-1 2.4.4.3).
+  pat = PAT.slice();
+  pat[11] = 0x03;
+  pat[12] = 0x05;
+
+  transportParseStream.on('data', function(data) {
+    packet = data;
+  });
+
+  transportParseStream.push(new Uint8Array(pat));
+  assert.ok(packet, 'parsed a packet');
+  assert.strictEqual(packet.section_number, 0x03, 'parsed section_number'); // eslint-disable-line camelcase
+  assert.strictEqual(packet.last_section_number, 0x05, 'parsed last_section_number'); // eslint-disable-line camelcase
+  assert.strictEqual(packet.pmtPid, 0x0010, 'parsed PMT pid');
+});
+
 QUnit.test('does not parse PES packets until after the PES has been parsed', function(assert) {
   var pesCount = 0;
 


### PR DESCRIPTION
## Summary

`TransportParseStream.parsePat` now reads `section_number` and `last_section_number` at `payload[6]` and `payload[7]`. After `parsePsi` skips `pointer_field`, those fields are at `payload[6]` and `payload[7]`, not `[7]` and `[8]`, so the old read was one byte too late (ISO/IEC 13818-1 2.4.4.3). `parsePmt` already uses the same PSI header indexing (`payload[5]` = `current_next_indicator`).

`pmtPid` at `payload[10]`/`[11]` is unchanged. That matches the reporter and the spec; the in-tree PAT fixture already depended on it.

A QUnit case copies the shared PAT fixture and sets distinctive section numbers. The fixture zeros both fields, which hid the off-by-one against `last_section_number` / `program_number`.

Fixes #432.

## Decision

Only the two section-number indexes change. That matches the issue, the spec, and `parsePmt`. Nothing in this repo reads the section fields today (`ElementaryStream`'s PAT handler is empty), but they are still emitted on the PAT `data` event.

The alternative is to skip a leading `program_number == 0` (NIT) when selecting `pmtPid`, or to stop attaching the unused section fields. Can switch to skipping NIT entries or dropping the unused fields.

## Test plan

- [x] `npx qunit test/dist/bundle.js --filter "parses section_number and last_section_number from the PAT"` fails on the old indexes (`actual` 5 and 0) and passes with this change
- [x] `npx qunit test/dist/bundle.js --filter "MP2T TransportParseStream"` (9 tests)
- [x] `npx qunit test/dist/bundle.js` (338 passed, 4 skipped)
- [ ] Existing transmux of a real HLS TS still finds the PMT (PID path unchanged)
