### PR TITLE
fix: decode CEA-708 P16 characters outside the G0/G1 range

### DIFF
--- a/lib/m2ts/caption-stream.js
+++ b/lib/m2ts/caption-stream.js
@@ -738,12 +738,19 @@ Cea708Stream.prototype.multiByteCharacter = function (i, service) {
   var firstByte = packetData[i + 1];
   var secondByte = packetData[i + 2];
 
-  if (within708TextBlock(firstByte) && within708TextBlock(secondByte)) {
-    i = this.handleText(++i, service, {isMultiByte: true});
-  } else {
-    // Unknown command
+  if (firstByte === undefined || secondByte === undefined) {
+    return i;
   }
 
+  // G0/G1 ranges match encoded sets such as EUC-KR. Unicode P16 code units
+  // (e.g. 0x01 0x7c = 'ż') sit outside those ranges and must still be decoded
+  // when no TextDecoder is configured.
+  if (service.textDecoder_ &&
+      !(within708TextBlock(firstByte) && within708TextBlock(secondByte))) {
+    return i;
+  }
+
+  i = this.handleText(++i, service, {isMultiByte: true});
   return i;
 };
 

--- a/test/caption-stream.test.js
+++ b/test/caption-stream.test.js
@@ -3078,6 +3078,37 @@ QUnit.test('Decodes multi-byte characters as unicode if no valid encoding option
   );
 });
 
+QUnit.test('Decodes P16 two-byte characters outside the G0/G1 text block', function(assert) {
+  var captions = [];
+
+  cea708Stream.on('data', function(caption) {
+    captions.push(caption);
+  });
+
+  // P16 (0x18) introduces a 16-bit character. Unicode letters such as
+  // ż (U+017C), ł (U+0142), and ć (U+0107) have a first byte below 0x20,
+  // which is outside the G0/G1 ranges used for single-byte 708 text.
+  // ó (U+00F3) is a single G1 byte and should still decode beside them.
+  [
+    { type: 3, pts: 1000, ccData: packetHeader708(0, 8, 1, 14) },
+    { type: 2, pts: 1000, ccData: displayWindows708([0]) },
+    { type: 2, pts: 1000, ccData: 0x8000 }, // CW0
+    { type: 2, pts: 1000, ccData: 0x1801 }, // P16, U+017C
+    { type: 2, pts: 1000, ccData: 0x7cf3 }, // ż then ó (G1)
+    { type: 2, pts: 1000, ccData: 0x1801 }, // P16, U+0142
+    { type: 2, pts: 1000, ccData: 0x4218 }, // ł then P16
+    { type: 2, pts: 1000, ccData: 0x0107 }, // ć U+0107
+
+    { type: 3, pts: 2000, ccData: packetHeader708(1, 2, 1, 2) },
+    { type: 2, pts: 2000, ccData: 0x8aff },
+
+    { type: 3, pts: 3000, ccData: packetHeader708(2, 1, 1, 0) }
+  ].forEach(cea708Stream.push, cea708Stream);
+
+  assert.equal(captions.length, 1, 'parsed 1 caption');
+  assert.equal(captions[0].text, 'żółć', 'parsed P16 unicode characters correctly');
+});
+
 QUnit.test('Creates TextDecoder only if valid encoding value is provided', function(assert) {
   var secondCea708Stream;
 


### PR DESCRIPTION
## Summary

The default (no `TextDecoder`) path now accepts any two P16 bytes as a 16-bit character, matching how `handleText` already treats multi-byte input without an encoding. CEA-708 P16 (`0x18`) was only decoded when both payload bytes sat in the G0/G1 text ranges (`0x20-0x7f`, `0xa0-0xff`), so Unicode letters such as ż (U+017C = `0x01 0x7c`) never appeared in dialect and Cyrillic captions.

The G0/G1 filter remains when `captionServices.SERVICEn.encoding` creates a TextDecoder, so EUC-KR Korean still skips the sample's trailing `P16 0x00 0x20` instead of emitting a NUL.

Fixes https://github.com/videojs/mux.js/issues/446

The same stream and a stricter "always consume two P16 bytes" change landed in shaka-player#7929.

## Decision

Keep the G0/G1 filter only when a TextDecoder is configured. Removing it for every P16 (reporter request; shaka-player#7929) would decode the existing Korean fixture's `P16 0x00 0x20` as `"\u0000 "` under euc-kr and fail that unit test. The reporter noted the check "is only applicable to the Korean language."

Happy to switch to unconditional P16 consume and update the euc-kr expectation if that is preferred.

## Test plan

- [x] New CEA-708 unit test: P16 ż / ł / ć plus G1 ó → `żółć` (fails on main with `"|óB"`, passes here).
- [x] Existing CEA-708 tests, including euc-kr `니가 ` and unicode fallback `듏낡 `.
- [x] Full node QUnit suite (`node scripts/node-test.js`): 338 pass, 4 skip, 0 fail.
- [ ] Optional: play https://mtoczko.github.io/hls-test-streams/test-cea708-p16/playlist.m3u8 and confirm SERVICE1 matches the alphabets on the issue.

Fixes #446
